### PR TITLE
Replace `Arc` and `Mutex` with channels

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -5,16 +5,16 @@ use serial2::Settings;
 use serial2_tokio::SerialPort;
 use std::env;
 use std::net::SocketAddr;
-use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio::sync::mpsc;
+use tokio::sync::{broadcast, oneshot};
 
 use ziggurat::ieee_802154::Ieee802154Frame;
 use ziggurat::spinel::SpinelPropertyId;
 use ziggurat::spinel_client::{SpinelClient, SpinelRxFrame};
 use ziggurat::types::{Eui64, Key, Nwk, PanId};
-use ziggurat::zigbee_stack::ZigbeeStack;
+use ziggurat::zigbee_stack::{ZigbeeCommand, ZigbeeNotification, ZigbeeStack, ZigbeeStackActor};
 
 #[derive(Deserialize, Debug)]
 struct CommandRequest {
@@ -32,8 +32,11 @@ struct CommandResponse {
 }
 
 pub struct ZigguratServer {
-    zigbee_stack: Arc<Mutex<ZigbeeStack>>,
-    notify_tx: broadcast::Sender<serde_json::Value>,
+    // Outgoing Zigbee stack commands
+    zigbee_tx: mpsc::Sender<ZigbeeCommand>,
+
+    // Incoming Zigbee stack notification
+    notification_rx: broadcast::Receiver<ZigbeeNotification>,
 }
 
 impl ZigguratServer {
@@ -45,35 +48,17 @@ impl ZigguratServer {
             Ok(settings)
         })?;
 
-        // Connect the Spinel client to the port
         let spinel = SpinelClient::new(port);
         spinel.spawn_reader();
 
-        // Start the radio via the stack
-        let zigbee_stack = Arc::new(Mutex::new(ZigbeeStack::new(spinel)));
+        let stack = ZigbeeStack::new(spinel);
+        let (actor, zigbee_tx, notification_rx) = ZigbeeStackActor::new(stack).await;
+        tokio::spawn(actor.run());
 
-        {
-            let mut stack = zigbee_stack.lock().await;
-            stack.start_radio().await;
-        }
-
-        // Spawn the receiver loop in the background
-        {
-            let stack = Arc::clone(&zigbee_stack);
-            tokio::spawn(async move {
-                ZigbeeStack::run_802154_receiver(stack).await;
-            });
-        }
-
-        // Create a channel for notification events
-        let (notify_tx, _notify_rx) = broadcast::channel::<serde_json::Value>(100);
-
-        let server = ZigguratServer {
-            zigbee_stack: zigbee_stack,
-            notify_tx: notify_tx,
-        };
-
-        Ok(server)
+        Ok(ZigguratServer {
+            zigbee_tx: zigbee_tx,
+            notification_rx: notification_rx,
+        })
     }
 
     pub async fn run_tcp_server(&self, listen_addr: &str) -> std::io::Result<()> {
@@ -84,12 +69,10 @@ impl ZigguratServer {
             let (socket, addr) = listener.accept().await?;
             log::debug!("New TCP client from {}", addr);
 
-            let notify_rx = self.notify_tx.subscribe();
-
             let server = self.clone();
 
             tokio::spawn(async move {
-                if let Err(e) = server.handle_client(socket, addr, notify_rx).await {
+                if let Err(e) = server.handle_client(socket, addr).await {
                     log::warn!("Error handling client {}: {:?}", addr, e);
                 } else {
                     log::debug!("Client {} disconnected", addr);
@@ -102,12 +85,12 @@ impl ZigguratServer {
         self,
         mut stream: TcpStream,
         addr: SocketAddr,
-        mut notify_rx: broadcast::Receiver<serde_json::Value>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (reader, mut writer) = stream.split();
         let mut reader = BufReader::new(reader);
-
         let mut line = String::new();
+
+        let mut notification_rx = self.notification_rx.resubscribe();
 
         loop {
             line.clear();
@@ -115,8 +98,7 @@ impl ZigguratServer {
                 read_result = reader.read_line(&mut line) => {
                     let n = read_result?;
                     if n == 0 {
-                        // EOF
-                        break;
+                        break; // EOF reached
                     }
                     match serde_json::from_str::<CommandRequest>(line.trim()) {
                         Ok(cmd) => {
@@ -142,12 +124,33 @@ impl ZigguratServer {
                         }
                     }
                 }
-
-                broadcast_event = notify_rx.recv() => {
-                    match broadcast_event {
-                        Ok(event) => {
-                            let event_str = event.to_string();
-                            writer.write_all(event_str.as_bytes()).await?;
+                notify_event = notification_rx.recv() => {
+                    match notify_event {
+                        Ok(ZigbeeNotification::ReceivedApsCommand {
+                            source,
+                            profile_id,
+                            cluster_id,
+                            src_ep,
+                            dst_ep,
+                            lqi,
+                            rssi,
+                            data,
+                        }) => {
+                            let event = json!({
+                                "tid": 0,
+                                "cmd": "received_aps_command",
+                                "data": {
+                                    "source": hex::encode(source.to_bytes()),
+                                    "profile_id": profile_id,
+                                    "cluster_id": cluster_id,
+                                    "src_ep": src_ep,
+                                    "dst_ep": dst_ep,
+                                    "lqi": lqi,
+                                    "rssi": rssi,
+                                    "data": hex::encode(data),
+                                }
+                            });
+                            writer.write_all(event.to_string().as_bytes()).await?;
                             writer.write_all(b"\n").await?;
                         },
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
@@ -162,127 +165,89 @@ impl ZigguratServer {
                 }
             }
         }
-
         Ok(())
     }
 
     async fn process_command(&self, cmd: CommandRequest) -> CommandResponse {
         match cmd.cmd.as_str() {
             "set_network_settings" => {
-                let channel = cmd.data.get("channel").map(|v| v.as_u64().unwrap() as u8);
-                let nwk_update_id = cmd
-                    .data
-                    .get("nwk_update_id")
-                    .map(|v| v.as_u64().unwrap() as u8);
-                let pan_id = cmd
-                    .data
-                    .get("pan_id")
-                    .map(|v| PanId::from_hex(v.as_str().unwrap()));
-                let extended_pan_id = cmd
-                    .data
-                    .get("extended_pan_id")
-                    .map(|v| Eui64::from_hex(v.as_str().unwrap()));
-                let nwk_address = cmd
-                    .data
-                    .get("nwk_address")
-                    .map(|v| Nwk::from_hex(v.as_str().unwrap()));
-                let ieee_address = cmd
-                    .data
-                    .get("ieee_address")
-                    .map(|v| Eui64::from_hex(v.as_str().unwrap()));
-                let network_key = cmd
-                    .data
-                    .get("network_key")
-                    .map(|v| Key::from_hex(v.as_str().unwrap()));
-                let network_key_seq = cmd
-                    .data
-                    .get("network_key_seq")
-                    .map(|v| v.as_u64().unwrap() as u8);
+                // Build the oneshot channel
+                let (resp_tx, resp_rx) = oneshot::channel();
+                // Extract parameters from the data
+                let channel = cmd.data.get("channel").unwrap().as_u64().unwrap() as u8;
+                let nwk_update_id = cmd.data.get("nwk_update_id").unwrap().as_u64().unwrap() as u8;
+                let pan_id = PanId::from_hex(cmd.data.get("pan_id").unwrap().as_str().unwrap());
+                let extended_pan_id =
+                    Eui64::from_hex(cmd.data.get("extended_pan_id").unwrap().as_str().unwrap());
+                let nwk_address =
+                    Nwk::from_hex(cmd.data.get("nwk_address").unwrap().as_str().unwrap());
+                let ieee_address =
+                    Eui64::from_hex(cmd.data.get("ieee_address").unwrap().as_str().unwrap());
+                let network_key =
+                    Key::from_hex(cmd.data.get("network_key").unwrap().as_str().unwrap());
+                let network_key_seq =
+                    cmd.data.get("network_key_seq").unwrap().as_u64().unwrap() as u8;
                 let network_key_tx_counter = cmd
                     .data
                     .get("network_key_tx_counter")
-                    .map(|v| v.as_u64().unwrap() as u32);
+                    .unwrap()
+                    .as_u64()
+                    .unwrap() as u32;
 
-                {
-                    log::info!("Acquiring Zigbee stack lock...");
-                    let stack = Arc::clone(&self.zigbee_stack);
-                    let mut zigbee = stack.lock().await;
-                    log::info!("Setting network settings...");
-                    zigbee
-                        .set_network_settings(
-                            channel.unwrap(),
-                            nwk_update_id.unwrap(),
-                            pan_id.unwrap(),
-                            extended_pan_id.unwrap(),
-                            nwk_address.unwrap(),
-                            ieee_address.unwrap(),
-                            network_key.unwrap(),
-                            network_key_seq.unwrap(),
-                            network_key_tx_counter.unwrap(),
-                        )
-                        .await;
-                    log::info!("Done!");
-                }
+                // Send the command to the Zigbee actor
+                let command = ZigbeeCommand::SetNetworkSettings {
+                    nwk_channel: channel,
+                    nwk_update_id,
+                    nwk_pan_id: pan_id,
+                    nwk_extended_pan_id: extended_pan_id,
+                    nwk_network_address: nwk_address,
+                    nwk_ieee_address: ieee_address,
+                    key: network_key,
+                    key_seq_number: network_key_seq,
+                    outgoing_frame_counter: network_key_tx_counter,
+                    resp: resp_tx,
+                };
+                let _ = self.zigbee_tx.send(command).await;
+                let status = resp_rx.await.unwrap_or(Err("Unknown error".to_string()));
 
                 CommandResponse {
                     tid: cmd.tid,
                     cmd: cmd.cmd,
-                    data: json!({"status": "success"}),
+                    data: json!({"status": if status.is_ok() { "success" } else { "error" } }),
                 }
             }
-
             "send_aps_command" => {
-                let destination_nwk = cmd
-                    .data
-                    .get("destination_nwk")
-                    .map(|v| Nwk::from_hex(v.as_str().unwrap()));
-                let profile_id = cmd
-                    .data
-                    .get("profile_id")
-                    .map(|v| v.as_u64().unwrap() as u16);
-                let cluster_id = cmd
-                    .data
-                    .get("cluster_id")
-                    .map(|v| v.as_u64().unwrap() as u16);
-                let src_ep = cmd.data.get("src_ep").map(|v| v.as_u64().unwrap() as u8);
-                let dst_ep = cmd.data.get("dst_ep").map(|v| v.as_u64().unwrap() as u8);
-                let data = cmd
-                    .data
-                    .get("data")
-                    .map(|v| hex::decode(v.as_str().unwrap()).unwrap());
+                let (resp_tx, resp_rx) = oneshot::channel();
+                let destination_nwk =
+                    Nwk::from_hex(cmd.data.get("destination_nwk").unwrap().as_str().unwrap());
+                let profile_id = cmd.data.get("profile_id").unwrap().as_u64().unwrap() as u16;
+                let cluster_id = cmd.data.get("cluster_id").unwrap().as_u64().unwrap() as u16;
+                let src_ep = cmd.data.get("src_ep").unwrap().as_u64().unwrap() as u8;
+                let dst_ep = cmd.data.get("dst_ep").unwrap().as_u64().unwrap() as u8;
+                let data = hex::decode(cmd.data.get("data").unwrap().as_str().unwrap()).unwrap();
 
-                {
-                    log::info!("Acquiring Zigbee stack lock...");
-                    let stack = Arc::clone(&self.zigbee_stack);
-                    let mut zigbee = stack.lock().await;
-                    log::info!("Sending APS command...");
-                    zigbee
-                        .send_aps_command(
-                            destination_nwk.unwrap(),
-                            profile_id.unwrap(),
-                            cluster_id.unwrap(),
-                            src_ep.unwrap(),
-                            dst_ep.unwrap(),
-                            data.unwrap(),
-                        )
-                        .await;
-                    log::info!("Done!");
-                }
+                let command = ZigbeeCommand::SendApsCommand {
+                    destination: destination_nwk,
+                    profile_id,
+                    cluster_id,
+                    src_ep,
+                    dst_ep,
+                    data,
+                    resp: resp_tx,
+                };
+                let _ = self.zigbee_tx.send(command).await;
+                let status = resp_rx.await.unwrap_or(Err("Unknown error".to_string()));
 
                 CommandResponse {
                     tid: cmd.tid,
                     cmd: cmd.cmd,
-                    data: json!({"status": "success"}),
+                    data: json!({"status": if status.is_ok() { "success" } else { "error" } }),
                 }
             }
-
             _ => CommandResponse {
                 tid: cmd.tid,
                 cmd: cmd.cmd,
-                data: json!({
-                    "status": "error",
-                    "reason": "unknown_command",
-                }),
+                data: json!({ "status": "error", "reason": "unknown_command" }),
             },
         }
     }
@@ -291,8 +256,8 @@ impl ZigguratServer {
 impl Clone for ZigguratServer {
     fn clone(&self) -> Self {
         ZigguratServer {
-            zigbee_stack: Arc::clone(&self.zigbee_stack),
-            notify_tx: self.notify_tx.clone(),
+            zigbee_tx: self.zigbee_tx.clone(),
+            notification_rx: self.notification_rx.resubscribe(),
         }
     }
 }
@@ -302,27 +267,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::builder()
         .format_timestamp_micros()
         .filter(None, LevelFilter::Debug)
-        //.filter_module("ziggurat::spinel", LevelFilter::Info)
+        //.filter_module("ziggurat::spinel", LevelFilter::Info
         .init();
 
-    // Grab arguments
     let args: Vec<String> = env::args().collect();
     if args.len() < 2 {
         eprintln!("Usage: {} <serial_path> [tcp_listen_addr]", args[0]);
         return Ok(());
     }
-
     let serial_path = &args[1];
     let tcp_listen_addr = args
         .get(2)
         .cloned()
         .unwrap_or_else(|| "0.0.0.0:9999".to_string());
-
-    // Create and configure our Zigbee server
     let server = ZigguratServer::new(serial_path).await?;
-
-    // Now run our async TCP server
     server.run_tcp_server(&tcp_listen_addr).await?;
-
     Ok(())
 }

--- a/src/spinel.rs
+++ b/src/spinel.rs
@@ -216,6 +216,16 @@ pub enum SpinelStatus {
     ResetWatchdog = 120,
 }
 
+#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+pub enum SpinelMacPromiscuousMode {
+    //  Normal MAC filtering is in place.
+    Off = 0,
+    // All MAC packets matching network are passed up the stack.
+    Network = 1,
+    // All decoded MAC packets are passed up the stack.
+    Full = 2,
+}
+
 pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), &'static str> {
     let mut result = 0u32;
 

--- a/src/zigbee_stack.rs
+++ b/src/zigbee_stack.rs
@@ -2,18 +2,7 @@ use crate::ieee_802154::{
     Ieee802154Address, Ieee802154AddressingMode, Ieee802154Frame, Ieee802154FrameControl,
     Ieee802154FrameType,
 };
-use log::LevelFilter;
-use serde::{Deserialize, Serialize};
-use serde_json::json;
-use serial2::Settings;
-use serial2_tokio::SerialPort;
-use std::env;
-use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
-use tokio::net::{TcpListener, TcpStream};
-
-use crate::spinel::SpinelPropertyId;
+use crate::spinel::{SpinelFramePropValueIs, SpinelMacPromiscuousMode, SpinelPropertyId};
 use crate::spinel_client::{SpinelClient, SpinelRxFrame, SpinelTxFrame};
 use crate::types::{Eui64, Key, Nwk, PanId};
 use crate::zigbee_aps::{ApsDeliveryMode, ApsFrame, ApsFrameControl, ApsFrameType};
@@ -24,8 +13,10 @@ use crate::zigbee_nwk::{
 use crate::zigbee_nwk_commands::{
     NwkCommandId, NwkLinkStatusCommand, NwkRouteRecordCommand, NwkRouteReplyCommand,
 };
+use log::{debug, info, warn};
+use serde_json::json;
 use std::collections::HashMap;
-use tokio::sync::{Mutex, broadcast, mpsc};
+use tokio::sync::{broadcast, mpsc, oneshot};
 
 #[derive(Debug)]
 pub enum NwkCapabilityInformationDeviceType {
@@ -345,27 +336,27 @@ pub struct ZigbeeStack {
 }
 
 impl ZigbeeStack {
-    pub fn new(spinel: SpinelClient) -> ZigbeeStack {
+    pub fn new(spinel: SpinelClient) -> Self {
         ZigbeeStack {
             channel: 0,
             ieee802154_sequence_number: 0,
             nib: Nib::new(),
-            spinel: spinel,
+            spinel,
         }
     }
 
     pub async fn start_radio(&self) {
-        // Enable the PHY and set up the radio, save for the channel
         self.spinel
             .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![true as u8])
             .await
             .expect("Failed to enable the PHY");
-
         self.spinel
-            .prop_value_set(SpinelPropertyId::MacPromiscuousMode as u32, vec![2])
+            .prop_value_set(
+                SpinelPropertyId::MacPromiscuousMode as u32,
+                vec![SpinelMacPromiscuousMode::Full as u8],
+            )
             .await
             .expect("Failed to set the MAC promiscuous mode");
-
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::MacRawStreamEnabled as u32,
@@ -373,56 +364,6 @@ impl ZigbeeStack {
             )
             .await
             .expect("Failed to enable the RAW stream");
-    }
-
-    pub async fn run_802154_receiver(self_mutex: Arc<Mutex<ZigbeeStack>>) {
-        let (stream_raw_tx, mut stream_raw_rx) = mpsc::channel(32);
-
-        {
-            // Lock the protocol and set the property update receiver for StreamRaw
-            let stack = self_mutex.lock().await;
-            let mut spinel = stack.spinel.protocol.lock().await;
-
-            spinel.set_property_update_receiver(
-                SpinelPropertyId::StreamRaw as u32,
-                stream_raw_tx.clone(),
-            );
-        }
-
-        // Spawn a new task
-        log::debug!("Spawning Zigbee/Spinel receive loop...");
-
-        while let Some(raw_frame) = stream_raw_rx.recv().await {
-            let packet = match SpinelRxFrame::from_bytes(&raw_frame.value) {
-                Ok(p) => p,
-                Err(e) => {
-                    log::warn!("Error parsing spinel frame: {:?}", e);
-                    continue;
-                }
-            };
-
-            if packet.psdu.len() < 2 {
-                log::warn!("Packet too short to contain FCS");
-                continue;
-            }
-            let frame_data = &packet.psdu[..packet.psdu.len() - 2];
-
-            let ieee802154_frame = match Ieee802154Frame::from_bytes_without_fcs(frame_data) {
-                Ok(f) => f,
-                Err(e) => {
-                    log::warn!("Error parsing IEEE 802.15.4 frame: {:?}", e);
-                    continue;
-                }
-            };
-
-            log::debug!("Received 802.15.4 frame: {:?}", ieee802154_frame);
-            {
-                self_mutex
-                    .lock()
-                    .await
-                    .receive_802154_frame(&ieee802154_frame);
-            }
-        }
     }
 
     pub async fn set_network_settings(
@@ -436,7 +377,7 @@ impl ZigbeeStack {
         key: Key,
         key_seq_number: u8,
         outgoing_frame_counter: u32,
-    ) {
+    ) -> Result<(), String> {
         self.channel = nwk_channel;
         self.nib.nwk_update_id = nwk_update_id;
         self.nib.nwk_pan_id = nwk_pan_id;
@@ -448,36 +389,33 @@ impl ZigbeeStack {
         self.nib
             .nwk_security_material_primary
             .outgoing_frame_counter = outgoing_frame_counter;
-
-        // Update the MAC layer with the new network settings to enable auto-ACK
+        // Update the hardware with new settings.
         self.spinel
             .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![nwk_channel])
             .await
-            .expect("Failed to set the PHY channel");
-
+            .map_err(|e| format!("Failed to set PHY channel: {:?}", e))?;
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Laddr as u32,
                 self.nib.nwk_ieee_address.to_bytes().to_vec(),
             )
             .await
-            .expect("Failed to set the MAC IEEE address");
-
+            .map_err(|e| format!("Failed to set MAC IEEE address: {:?}", e))?;
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Saddr as u32,
                 self.nib.nwk_network_address.to_bytes().to_vec(),
             )
             .await
-            .expect("Failed to set the MAC NWK address");
-
+            .map_err(|e| format!("Failed to set MAC NWK address: {:?}", e))?;
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Panid as u32,
                 self.nib.nwk_pan_id.to_bytes().to_vec(),
             )
             .await
-            .expect("Failed to set the MAC PAN ID");
+            .map_err(|e| format!("Failed to set MAC PAN ID: {:?}", e))?;
+        Ok(())
     }
 
     pub fn receive_802154_frame(&mut self, frame: &Ieee802154Frame) -> Option<NwkFrame> {
@@ -859,7 +797,7 @@ impl ZigbeeStack {
         src_ep: u8,
         dst_ep: u8,
         data: Vec<u8>,
-    ) {
+    ) -> Result<(), String> {
         let ieee802154_frame = self.prepare_request(
             destination,
             src_ep,
@@ -869,7 +807,212 @@ impl ZigbeeStack {
             0,
             &data,
         );
-
         self.send_802154_frame(ieee802154_frame).await;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum ZigbeeCommand {
+    SetNetworkSettings {
+        nwk_channel: u8,
+        nwk_update_id: u8,
+        nwk_pan_id: PanId,
+        nwk_extended_pan_id: Eui64,
+        nwk_network_address: Nwk,
+        nwk_ieee_address: Eui64,
+        key: Key,
+        key_seq_number: u8,
+        outgoing_frame_counter: u32,
+        resp: oneshot::Sender<Result<(), String>>,
+    },
+    SendApsCommand {
+        destination: Nwk,
+        profile_id: u16,
+        cluster_id: u16,
+        src_ep: u8,
+        dst_ep: u8,
+        data: Vec<u8>,
+        resp: oneshot::Sender<Result<(), String>>,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum ZigbeeNotification {
+    ReceivedApsCommand {
+        source: Nwk,
+        profile_id: u16,
+        cluster_id: u16,
+        src_ep: u8,
+        dst_ep: u8,
+        lqi: u8,
+        rssi: i8,
+        data: Vec<u8>,
+    },
+}
+
+/// The actor that processes all Zigbee commands.
+pub struct ZigbeeStackActor {
+    pub stack: ZigbeeStack,
+    pub command_rx: mpsc::Receiver<ZigbeeCommand>,
+    pub notification_tx: broadcast::Sender<ZigbeeNotification>,
+    pub raw_frame_rx: mpsc::Receiver<SpinelFramePropValueIs>,
+}
+
+impl ZigbeeStackActor {
+    pub async fn new(
+        stack: ZigbeeStack,
+    ) -> (
+        Self,
+        mpsc::Sender<ZigbeeCommand>,
+        broadcast::Receiver<ZigbeeNotification>,
+    ) {
+        let (command_tx, command_rx) = mpsc::channel::<ZigbeeCommand>(32);
+        let (notification_tx, notification_rx) = broadcast::channel::<ZigbeeNotification>(32);
+        let (raw_frame_tx, raw_frame_rx) = mpsc::channel::<SpinelFramePropValueIs>(32);
+
+        {
+            let mut spinel_protocol = stack.spinel.protocol.lock().await;
+            spinel_protocol
+                .set_property_update_receiver(SpinelPropertyId::StreamRaw as u32, raw_frame_tx);
+        }
+
+        (
+            ZigbeeStackActor {
+                stack,
+                command_rx,
+                notification_tx,
+                raw_frame_rx,
+            },
+            command_tx,
+            notification_rx,
+        )
+    }
+
+    pub async fn run(mut self) {
+        // Start radio once at the beginning.
+        self.stack.start_radio().await;
+
+        loop {
+            tokio::select! {
+                // Handle incoming Zigbee commands from the mpsc channel.
+                maybe_cmd = self.command_rx.recv() => {
+                    match maybe_cmd {
+                        Some(cmd) => {
+                            match cmd {
+                                ZigbeeCommand::SetNetworkSettings {
+                                    nwk_channel,
+                                    nwk_update_id,
+                                    nwk_pan_id,
+                                    nwk_extended_pan_id,
+                                    nwk_network_address,
+                                    nwk_ieee_address,
+                                    key,
+                                    key_seq_number,
+                                    outgoing_frame_counter,
+                                    resp,
+                                } => {
+                                    let res = self.stack
+                                        .set_network_settings(
+                                            nwk_channel,
+                                            nwk_update_id,
+                                            nwk_pan_id,
+                                            nwk_extended_pan_id,
+                                            nwk_network_address,
+                                            nwk_ieee_address,
+                                            key,
+                                            key_seq_number,
+                                            outgoing_frame_counter
+                                        )
+                                        .await;
+                                    let _ = resp.send(res);
+                                },
+                                ZigbeeCommand::SendApsCommand {
+                                    destination,
+                                    profile_id,
+                                    cluster_id,
+                                    src_ep,
+                                    dst_ep,
+                                    data,
+                                    resp,
+                                } => {
+                                    let res = self.stack
+                                        .send_aps_command(
+                                            destination,
+                                            profile_id,
+                                            cluster_id,
+                                            src_ep,
+                                            dst_ep,
+                                            data
+                                        )
+                                        .await;
+                                    let _ = resp.send(res);
+                                }
+                            }
+                        }
+                        None => {
+                            // mpsc channel closed; nothing more to do.
+                            break;
+                        }
+                    }
+                }
+
+                // Parse incoming 802.15.4 frames from Spinel
+                Some(spinel_frame) = self.raw_frame_rx.recv() => {
+                    let packet = match SpinelRxFrame::from_bytes(&spinel_frame.value) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            log::warn!("Error parsing spinel frame: {:?}", e);
+                            continue;
+                        }
+                    };
+
+                    if packet.psdu.len() < 2 {
+                        log::warn!("Packet too short to contain FCS");
+                        continue;
+                    }
+                    let frame_data = &packet.psdu[..packet.psdu.len() - 2];
+
+                    let ieee802154_frame = match Ieee802154Frame::from_bytes_without_fcs(frame_data) {
+                        Ok(f) => f,
+                        Err(e) => {
+                            log::warn!("Error parsing IEEE 802.15.4 frame: {:?}", e);
+                            continue;
+                        }
+                    };
+
+                    log::debug!("Received 802.15.4 frame: {:?}", ieee802154_frame);
+
+                    match self.stack.receive_802154_frame(&ieee802154_frame) {
+                        Some(nwk_frame) => {
+                            if nwk_frame.nwk_header.frame_control.frame_type != NwkFrameType::Data {
+                                continue;
+                            }
+
+                            let aps_frame = match ApsFrame::from_bytes(&nwk_frame.payload) {
+                                Ok(f) => f,
+                                Err(e) => {
+                                    log::warn!("Error parsing APS frame: {:?}", e);
+                                    continue;
+                                }
+                            };
+
+                            let notification = ZigbeeNotification::ReceivedApsCommand {
+                                source: nwk_frame.nwk_header.source,
+                                profile_id: aps_frame.profile_id,
+                                cluster_id: aps_frame.cluster_id,
+                                src_ep: aps_frame.source_endpoint,
+                                dst_ep: aps_frame.destination_endpoint,
+                                lqi: packet.lqi,
+                                rssi: packet.rssi,
+                                data: aps_frame.asdu,
+                            };
+                            let _ = self.notification_tx.send(notification);
+                        }
+                        None => {}
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
The MPV iteration of the server was functional but suffered from a few architectural issues, namely with concurrency. A simple way to avoid concurrency issues at the time was to use locking but this is not very ergonomic, nor does it scale well for long-running tasks. To work around this problem, a new structure is introduced: `ZigbeeStackActor`. It drives the various asynchronous objects (Spinel and the stack) and coordinates message passing with the server. This sort of solves the architectural problem that forced the MVP to not include any sort of frame RX handler, which is now implemented via `tokio::sync::broadcast`.

I'm sure there are much, much better ways to organize things but this is still an initial pass.