### PR TITLE
Implement Zigbee command addressing

### DIFF
--- a/src/server.rs
+++ b/src/server.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 
 use ziggurat::spinel_client::SpinelClient;
 use ziggurat::types::{Eui64, Key, Nwk, PanId};
+use ziggurat::zigbee_aps::ApsDeliveryMode;
 use ziggurat::zigbee_stack::{ZigbeeNotification, ZigbeeStack};
 
 #[derive(Deserialize, Debug)]
@@ -215,25 +216,41 @@ impl ZigguratServer {
                 }
             }
             "send_aps_command" => {
-                let destination_nwk =
-                    Nwk::from_hex(cmd.data.get("destination_nwk").unwrap().as_str().unwrap());
+                let delivery_mode = match cmd.data.get("delivery_mode").unwrap().as_str().unwrap() {
+                    "unicast" => ApsDeliveryMode::Unicast,
+                    "broadcast" => ApsDeliveryMode::Broadcast,
+                    "multicast" => ApsDeliveryMode::Multicast,
+                    _ => {
+                        return CommandResponse {
+                            tid: cmd.tid,
+                            cmd: cmd.cmd,
+                            data: json!({"status": "error", "reason": "invalid_delivery_mode"}),
+                        };
+                    }
+                };
+
+                let destination =
+                    Nwk::from_hex(cmd.data.get("destination").unwrap().as_str().unwrap());
                 let profile_id = cmd.data.get("profile_id").unwrap().as_u64().unwrap() as u16;
                 let cluster_id = cmd.data.get("cluster_id").unwrap().as_u64().unwrap() as u16;
                 let src_ep = cmd.data.get("src_ep").unwrap().as_u64().unwrap() as u8;
                 let dst_ep = cmd.data.get("dst_ep").unwrap().as_u64().unwrap() as u8;
                 let aps_ack = cmd.data.get("aps_ack").unwrap().as_bool().unwrap();
                 let aps_seq = cmd.data.get("aps_seq").unwrap().as_u64().unwrap() as u8;
+                let radius = cmd.data.get("radius").unwrap().as_u64().unwrap() as u8;
                 let data = hex::decode(cmd.data.get("data").unwrap().as_str().unwrap()).unwrap();
 
                 let status = self
                     .zigbee_stack
                     .send_aps_command(
-                        destination_nwk,
+                        delivery_mode,
+                        destination,
                         profile_id,
                         cluster_id,
                         src_ep,
                         dst_ep,
                         aps_ack,
+                        radius,
                         aps_seq,
                         data,
                     )

--- a/src/tools/zigpy_client.py
+++ b/src/tools/zigpy_client.py
@@ -133,9 +133,17 @@ class ZigguratControllerApplication(zigpy.application.ControllerApplication):
             metadata={},
         )
 
+        '''
         node_info = NodeInfo(
             ieee=t.EUI64.convert("bc:02:6e:ff:fe:24:db:90"),
             nwk=t.NWK(0x0000),
+            logical_type=zdo_t.LogicalType.Coordinator,
+        )
+        '''
+
+        node_info = NodeInfo(
+            ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
+            nwk=t.NWK(0xABCD),
             logical_type=zdo_t.LogicalType.Coordinator,
         )
 
@@ -199,8 +207,6 @@ class ZigguratControllerApplication(zigpy.application.ControllerApplication):
             self.packet_received(packet)
 
     async def send_packet(self, packet):
-        assert packet.dst.addr_mode is t.AddrMode.NWK
-
         profile_id = 0x0000
 
         if packet.src_ep != 0 or packet.dst_ep != 0:
@@ -209,13 +215,19 @@ class ZigguratControllerApplication(zigpy.application.ControllerApplication):
         await self._api.send_command(
             "send_aps_command",
             {
-                "destination_nwk": packet.dst.address.serialize()[::-1].hex(),
+                "delivery_mode": {
+                    t.AddrMode.NWK: "unicast",
+                    t.AddrMode.Group: "multicast",
+                    t.AddrMode.Broadcast: "broadcast",
+                }[packet.dst.addr_mode],
+                "destination": packet.dst.address.serialize()[::-1].hex(),
                 # "destination_eui64": "00:0d:6f:ff:fe:a4:f1:0b",
                 "profile_id": profile_id,
                 "cluster_id": packet.cluster_id or 0x0000,
                 "src_ep": packet.src_ep,
-                "dst_ep": packet.dst_ep,
+                "dst_ep": packet.dst_ep or 0,
                 "aps_ack": t.TransmitOptions.ACK in packet.tx_options,
+                "radius": packet.radius,
                 "aps_seq": packet.tsn,
                 "data": packet.data.serialize().hex(),
             },
@@ -237,15 +249,28 @@ async def main(host, port):
     await app.connect()
     await app.start_network()
 
+    for seq in range(1000):
+        await app.send_packet(
+            t.ZigbeePacket(
+                src_ep=123,
+                dst=t.AddrModeAddress(
+                    addr_mode=t.AddrMode.Group, address=seq % 0xFFF0,
+                ),
+                tsn=12,
+                profile_id=0x0104,
+                cluster_id=0x0006,
+                data=t.SerializableBytes(b"\x01" + bytes([seq % 255]) + b"\x00"),
+                radius=1,
+                non_member_radius=3,
+                tx_options=t.TransmitOptions.NONE,
+            )
+        )
+        await asyncio.sleep(0.1)
+
+    '''
     dev = app.add_device(nwk=0x26f4, ieee=t.EUI64.convert("00:0d:6f:ff:fe:a4:f1:0b"))
     await dev.schedule_initialize()
-
-    while True:
-        try:
-            async with asyncio.timeout(1):
-                await dev.endpoints[1].on_off.toggle()
-        except asyncio.TimeoutError:
-            _LOGGER.warning("Timed out...")
+    '''
 
 
 if __name__ == "__main__":

--- a/src/tools/zigpy_client.py
+++ b/src/tools/zigpy_client.py
@@ -133,17 +133,9 @@ class ZigguratControllerApplication(zigpy.application.ControllerApplication):
             metadata={},
         )
 
-        '''
         node_info = NodeInfo(
             ieee=t.EUI64.convert("bc:02:6e:ff:fe:24:db:90"),
             nwk=t.NWK(0x0000),
-            logical_type=zdo_t.LogicalType.Coordinator,
-        )
-        '''
-
-        node_info = NodeInfo(
-            ieee=t.EUI64.convert("aa:bb:cc:dd:11:22:33:44"),
-            nwk=t.NWK(0xABCD),
             logical_type=zdo_t.LogicalType.Coordinator,
         )
 
@@ -267,10 +259,15 @@ async def main(host, port):
         )
         await asyncio.sleep(0.1)
 
-    '''
     dev = app.add_device(nwk=0x26f4, ieee=t.EUI64.convert("00:0d:6f:ff:fe:a4:f1:0b"))
     await dev.schedule_initialize()
-    '''
+
+    while True:
+        try:
+            async with asyncio.timeout(1):
+                await dev.endpoints[1].on_off.toggle()
+        except asyncio.TimeoutError:
+            _LOGGER.warning("Timed out...")
 
 
 if __name__ == "__main__":

--- a/src/zigbee_aps.rs
+++ b/src/zigbee_aps.rs
@@ -204,7 +204,8 @@ impl ApsAckFrame {
 #[derive(Debug, Clone, PartialEq)]
 pub struct ApsDataFrame {
     pub frame_control: ApsFrameControl,
-    pub destination_endpoint: u8,
+    pub group_id: Option<u16>,
+    pub destination_endpoint: Option<u8>,
     pub cluster_id: u16,
     pub profile_id: u16,
     pub source_endpoint: u8,
@@ -219,7 +220,18 @@ impl ApsDataFrame {
         }
 
         let (frame_control, remaining) = ApsFrameControl::deserialize(bytes)?;
-        let destination_endpoint = u8::from_le_bytes([remaining[0]]);
+
+        let mut group_id = None;
+        let mut destination_endpoint = None;
+
+        if frame_control.delivery_mode == ApsDeliveryMode::Multicast {
+            group_id = Some(u16::from_le_bytes([remaining[0], remaining[1]]));
+            destination_endpoint = None;
+        } else {
+            group_id = None;
+            destination_endpoint = Some(u8::from_le_bytes([remaining[0]]));
+        }
+
         let cluster_id = u16::from_le_bytes([remaining[1], remaining[2]]);
         let profile_id = u16::from_le_bytes([remaining[3], remaining[4]]);
         let source_endpoint = u8::from_le_bytes([remaining[5]]);
@@ -228,6 +240,7 @@ impl ApsDataFrame {
 
         Ok(Self {
             frame_control: frame_control,
+            group_id: group_id,
             destination_endpoint: destination_endpoint,
             cluster_id: cluster_id,
             profile_id: profile_id,
@@ -241,7 +254,15 @@ impl ApsDataFrame {
         let mut bytes = Vec::new();
 
         bytes.extend(self.frame_control.to_bytes());
-        bytes.extend(self.destination_endpoint.to_le_bytes());
+
+        if let Some(group_id) = self.group_id {
+            bytes.extend(group_id.to_le_bytes());
+        }
+
+        if let Some(destination_endpoint) = self.destination_endpoint {
+            bytes.extend(destination_endpoint.to_le_bytes());
+        }
+
         bytes.extend(self.cluster_id.to_le_bytes());
         bytes.extend(self.profile_id.to_le_bytes());
         bytes.extend(self.source_endpoint.to_le_bytes());

--- a/src/zigbee_stack.rs
+++ b/src/zigbee_stack.rs
@@ -509,7 +509,7 @@ impl ZigbeeStack {
                         profile_id: aps_frame.profile_id,
                         cluster_id: aps_frame.cluster_id,
                         src_ep: aps_frame.source_endpoint,
-                        dst_ep: aps_frame.destination_endpoint,
+                        dst_ep: aps_frame.destination_endpoint.unwrap_or(0),
                         lqi: packet.lqi,
                         rssi: packet.rssi,
                         data: aps_frame.asdu,
@@ -974,13 +974,13 @@ impl ZigbeeStack {
             destination_endpoint: Some(aps_frame.source_endpoint),
             cluster_id: Some(aps_frame.cluster_id),
             profile_id: Some(aps_frame.profile_id),
-            source_endpoint: Some(aps_frame.destination_endpoint),
+            source_endpoint: aps_frame.destination_endpoint,
             counter: aps_frame.counter,
         };
 
         // Wrap it in a NWK frame
         let destination = nwk_frame.nwk_header.source;
-        let outgoing_nwk_frame = self.wrap_aps_frame(destination, &ApsFrame::Ack(ack_frame));
+        let outgoing_nwk_frame = self.wrap_aps_frame(destination, 30, &ApsFrame::Ack(ack_frame));
         let mut ieee802154_frame = self.wrap_nwk_frame(&outgoing_nwk_frame);
 
         let arc_self = self
@@ -995,44 +995,91 @@ impl ZigbeeStack {
 
     fn prepare_request(
         &self,
+        delivery_mode: ApsDeliveryMode,
         destination: Nwk,
         src_ep: u8,
         dst_ep: u8,
         cluster_id: u16,
         profile_id: u16,
         aps_ack: bool,
+        radius: u8,
         counter: u8,
         asdu: &Vec<u8>,
     ) -> Ieee802154Frame {
-        let aps_frame = ApsDataFrame {
-            frame_control: ApsFrameControl {
-                frame_type: ApsFrameType::Data,
-                delivery_mode: ApsDeliveryMode::Unicast,
-                reserved: 0b0,
-                security: false,
-                ack_request: aps_ack,
-                extended_header: false,
+        let aps_frame = match delivery_mode {
+            ApsDeliveryMode::Unicast => ApsDataFrame {
+                frame_control: ApsFrameControl {
+                    frame_type: ApsFrameType::Data,
+                    delivery_mode: ApsDeliveryMode::Unicast,
+                    reserved: 0b0,
+                    security: false,
+                    ack_request: aps_ack,
+                    extended_header: false,
+                },
+                group_id: None,
+                destination_endpoint: Some(dst_ep),
+                cluster_id: cluster_id,
+                profile_id: profile_id,
+                source_endpoint: src_ep,
+                counter: counter,
+                asdu: asdu.to_vec(),
             },
-            destination_endpoint: dst_ep,
-            cluster_id: cluster_id,
-            profile_id: profile_id,
-            source_endpoint: src_ep,
-            counter: counter,
-            asdu: asdu.to_vec(),
+            ApsDeliveryMode::Broadcast => ApsDataFrame {
+                frame_control: ApsFrameControl {
+                    frame_type: ApsFrameType::Data,
+                    delivery_mode: ApsDeliveryMode::Broadcast,
+                    reserved: 0b0,
+                    security: false,
+                    ack_request: false,
+                    extended_header: false,
+                },
+                group_id: None,
+                destination_endpoint: Some(dst_ep),
+                cluster_id: cluster_id,
+                profile_id: profile_id,
+                source_endpoint: src_ep,
+                counter: counter,
+                asdu: asdu.to_vec(),
+            },
+            ApsDeliveryMode::Multicast => ApsDataFrame {
+                frame_control: ApsFrameControl {
+                    frame_type: ApsFrameType::Data,
+                    delivery_mode: ApsDeliveryMode::Multicast,
+                    reserved: 0b0,
+                    security: false,
+                    ack_request: false,
+                    extended_header: false,
+                },
+                group_id: Some(destination.as_u16()),
+                destination_endpoint: None,
+                cluster_id: cluster_id,
+                profile_id: profile_id,
+                source_endpoint: src_ep,
+                counter: counter,
+                asdu: asdu.to_vec(),
+            },
         };
 
         log::debug!("Prepared APS frame: {:#?}", aps_frame);
 
-        // TODO: routing :)
-        // At this point, we assume the destination device is in range of the coordinator.
-        let nwk_frame = self.wrap_aps_frame(destination, &ApsFrame::Data(aps_frame));
+        let nwk_frame = self.wrap_aps_frame(
+            if aps_frame.frame_control.delivery_mode == ApsDeliveryMode::Unicast {
+                // TODO: routing :)
+                // At this point, we assume the destination device is in range of the coordinator.
+                destination
+            } else {
+                Nwk(0xFFFD)
+            },
+            radius,
+            &ApsFrame::Data(aps_frame),
+        );
         log::debug!("Prepared NWK frame: {:#?}", nwk_frame);
         let ieee802154_frame = self.wrap_nwk_frame(&nwk_frame);
 
         ieee802154_frame
     }
 
-    fn wrap_aps_frame(&self, destination: Nwk, aps_frame: &ApsFrame) -> NwkFrame {
+    fn wrap_aps_frame(&self, destination: Nwk, radius: u8, aps_frame: &ApsFrame) -> NwkFrame {
         // TODO: TX frame counter wrapping is an error condition
         let mut state = self.state.lock().unwrap();
 
@@ -1063,7 +1110,7 @@ impl ZigbeeStack {
                 },
                 destination: destination,
                 source: state.nib.nwk_network_address,
-                radius: 30,
+                radius: radius,
                 sequence_number: state.nib.nwk_sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
@@ -1115,7 +1162,11 @@ impl ZigbeeStack {
                 frame_type: Ieee802154FrameType::Data,
                 security_enabled: false,
                 frame_pending: false,
-                ack_request: true,
+                ack_request: if destination == Ieee802154Address::Nwk(Nwk(0xFFFF)) {
+                    false
+                } else {
+                    true
+                },
                 pan_id_compression: true,
                 reserved: false,
                 sequence_number_suppression: false,
@@ -1170,22 +1221,26 @@ impl ZigbeeStack {
 
     pub async fn send_aps_command(
         &self,
+        delivery_mode: ApsDeliveryMode,
         destination: Nwk,
         profile_id: u16,
         cluster_id: u16,
         src_ep: u8,
         dst_ep: u8,
         aps_ack: bool,
+        radius: u8,
         aps_seq: u8,
         data: Vec<u8>,
     ) -> Result<(), String> {
         let ieee802154_frame = self.prepare_request(
+            delivery_mode,
             destination,
             src_ep,
             dst_ep,
             cluster_id,
             profile_id,
             aps_ack,
+            radius,
             aps_seq,
             &data,
         );


### PR DESCRIPTION
Implement `unicast`, `broadcast`, and `multicast` addressing and the associated changes to APS data frames.

Next up: routing!