### PR TITLE
Update abstract bits

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "abstract-bits"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57274eff82141f21b4a9707551f540e74471431df9eba816fc8ebf563d93f8cc"
+checksum = "2c265591a83d97ca12d32d679e8e0df1b11ff21b333a1679a52ff1bec2e16add"
 dependencies = [
  "abstract-bits-derive",
  "arbitrary-int",
@@ -16,9 +16,9 @@ dependencies = [
 
 [[package]]
 name = "abstract-bits-derive"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7ed95b24ea1d92a55947dbdc0d08fda020d16690fe5c951e845faa740a5cb71"
+checksum = "00ad589d11a94666dca636f13148a47005575d58034ed0f9d63d24b661c9d622"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",

--- a/crates/zigbee-parts/Cargo.toml
+++ b/crates/zigbee-parts/Cargo.toml
@@ -7,8 +7,7 @@ license.workspace = true
 authors.workspace = true
 
 [dependencies]
-# will be replaced with crates.io dependency later
-abstract-bits = "0.1.0"
+abstract-bits = "0.2.0"
 num_enum = "0.7.3"
 hex = "0.4.3"
 thiserror = "2.0.12"

--- a/crates/zigbee-parts/src/commands.rs
+++ b/crates/zigbee-parts/src/commands.rs
@@ -42,7 +42,7 @@ pub enum NwkRouteRequestManyToOne {
 pub struct NwkRouteRequestCommand {
     reserved: u3,
     pub many_to_one: NwkRouteRequestManyToOne,
-    #[abstract_bits(controls = destination_eui64)]
+    #[abstract_bits(presence_of = destination_eui64)]
     reserved: bool,
     reserved: u2,
     pub route_request_identifier: u8,
@@ -64,9 +64,9 @@ impl Command for NwkRouteRequestCommand {
 #[derive(Debug, Clone, PartialEq)]
 pub struct NwkRouteReplyCommand {
     reserved: u4,
-    #[abstract_bits(controls = originator_eui64)]
+    #[abstract_bits(presence_of = originator_eui64)]
     reserved: bool,
-    #[abstract_bits(controls = responder_eui64)]
+    #[abstract_bits(presence_of = responder_eui64)]
     reserved: bool,
     reserved: u2,
     pub route_request_identifier: u8,


### PR DESCRIPTION
> My only comment is about readability for the control fields: is reserved the only field name prefix the library considers for the control fields? It may be a little more readable to rename them to things like `link_statuses_len` or `has_originator_eui64`?

This is now supported. I have also taken the liberty of setting the tokio_unstable cfg flag in .cargo/config. You no longer need: `RUSTFLAGS="--cfg tokio_unstable"` after merging this. 