### PR TITLE
NWK retries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -483,7 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.52.0",
 ]
 
@@ -653,6 +665,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -660,20 +678,19 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "9fbfd9d094a40bf3ae768db9361049ace4c0e04a4fd6b359518bd7b73a73dd97"
 dependencies = [
- "libc",
  "rand_chacha",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_chacha"
-version = "0.3.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core",
@@ -681,11 +698,11 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom",
+ "getrandom 0.3.3",
 ]
 
 [[package]]
@@ -703,7 +720,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
  "libredox",
  "thiserror",
 ]
@@ -991,6 +1008,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1101,6 +1127,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c06928c8748d81b05c9be96aad92e1b6ff01833332f281e8cfca3be4b35fc9ec"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags",
 ]
 
 [[package]]

--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -27,6 +27,7 @@ serde_json = "1.0.140"
 serde = { version = "1.0.219", features = ["derive"] }
 num_enum = "0.7.3"
 thiserror = "2.0.12"
+rand = "0.9.1"
 
 [[bin]]
 name = "ziggurat"
@@ -35,6 +36,3 @@ path = "src/server.rs"
 [[bin]]
 name = "ziggurat-pcap"
 path = "src/tools/dump_pcap.rs"
-
-[dev-dependencies]
-rand = "0.8.5"

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -22,6 +22,7 @@ use zigbee_parts::commands::{
     NwkRouteRequestCommand, NwkRouteRequestManyToOne,
 };
 
+use rand::prelude::*;
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::mem::drop;
@@ -125,7 +126,8 @@ pub enum NwkDeviceType {
 pub struct Nib {
     pub nwk_sequence_number: u8,
     pub nwk_passive_ack_timeout: Duration,
-    pub nwk_max_broadcast_retries: u8,
+    /// The maximum number of retries allowed after a broadcast transmission failure.
+    pub nwkc_max_broadcast_retries: u8,
     pub nwk_max_children: u8,
     pub nwk_max_depth: u8,
     pub nwk_neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
@@ -244,7 +246,7 @@ impl Nib {
         Nib {
             nwk_sequence_number: 0,
             nwk_passive_ack_timeout: Duration::from_millis(500),
-            nwk_max_broadcast_retries: 2,
+            nwkc_max_broadcast_retries: 2,
             nwk_max_children: 32,
             nwk_max_depth: 15,
             nwk_neighbor_table: HashMap::new(),
@@ -388,6 +390,9 @@ pub struct State {
     /// auto-ACK, but this is generally innocuous and won't collide with a second
     /// coordinator running at the same time.
     pub hack_disable_tx: bool,
+    /// Instead of caching route information, always perform route discovery. This is
+    /// much slower but ensures that routing logic is always followed.
+    pub hack_force_route_discovery: bool,
 }
 
 impl State {
@@ -402,6 +407,7 @@ impl State {
 
             hack_ignore_broadcast_startup_wait_period: true,
             hack_disable_tx: false,
+            hack_force_route_discovery: true,
         }
     }
 }
@@ -1756,21 +1762,21 @@ impl ZigbeeStack {
         });
     }
 
-    pub async fn send_nwk_frame(&self, mut nwk_frame: NwkFrame) -> Result<(), String> {
-        // Compute a next-hop address, if necessary. All broadcasts are sent to the
-        // 802.15.4 broadcast address, since the distinction between different types of
-        // devices is at a higher layer.
-        let next_hop_address =
-            if nwk_frame.nwk_header.destination.as_u16() < BROADCAST_LOW_POWER_ROUTERS.as_u16() {
-                self.discover_route(nwk_frame.nwk_header.destination)
-                    .await?
-            } else {
-                Nwk(0xFFFF)
-            };
+    pub async fn send_nwk_frame(&self, nwk_frame: NwkFrame) -> Result<(), String> {
+        if nwk_frame.nwk_header.destination.as_u16() >= BROADCAST_LOW_POWER_ROUTERS.as_u16() {
+            self.send_broadcast_nwk_frame(nwk_frame).await
+        } else {
+            self.send_unicast_nwk_frame(nwk_frame).await
+        }
+    }
 
+    pub async fn send_unicast_nwk_frame(&self, mut nwk_frame: NwkFrame) -> Result<(), String> {
+        // Compute a next-hop address
+        let next_hop_address = self
+            .discover_route(nwk_frame.nwk_header.destination)
+            .await?;
         let mut state = self.state.lock().unwrap();
 
-        // For now, as does the NWK sequence number
         state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
         nwk_frame.nwk_header.sequence_number = state.nib.nwk_sequence_number;
         nwk_frame.aux_header = Some(NwkAuxHeader {
@@ -1791,7 +1797,7 @@ impl ZigbeeStack {
 
         drop(state);
 
-        for attempt in 0..nwkc_unicast_retries {
+        for attempt in 0..=nwkc_unicast_retries {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
@@ -1817,7 +1823,7 @@ impl ZigbeeStack {
                     frame_type: Ieee802154FrameType::Data,
                     security_enabled: false,
                     frame_pending: false,
-                    ack_request: (next_hop_address != Nwk(0xFFFF)),
+                    ack_request: true,
                     pan_id_compression: true,
                     reserved: false,
                     sequence_number_suppression: false,
@@ -1836,36 +1842,32 @@ impl ZigbeeStack {
             };
 
             // When forwarding packets to another node, update the counters for the neighbor
-            if next_hop_address != Nwk(0xFFFF) {
-                // TODO: maybe wrap the send state into some sort of struct to avoid
-                // needing to do this?
-                if let Some(relaying_ieee) =
-                    state.nib.nwk_address_map.iter().find_map(|(&eui64, &nwk)| {
-                        if nwk == next_hop_address {
-                            Some(eui64)
-                        } else {
-                            None
-                        }
-                    })
-                {
-                    if let Some(neighbor_entry) =
-                        state.nib.nwk_neighbor_table.get_mut(&relaying_ieee)
-                    {
-                        // Update the neighbor table counters
-                        neighbor_entry.router_outbound_activity =
-                            neighbor_entry.router_outbound_activity.saturating_add(1);
+            // TODO: maybe wrap the send state into some sort of struct to avoid
+            // needing to do this?
+            if let Some(relaying_ieee) =
+                state.nib.nwk_address_map.iter().find_map(|(&eui64, &nwk)| {
+                    if nwk == next_hop_address {
+                        Some(eui64)
+                    } else {
+                        None
                     }
+                })
+            {
+                if let Some(neighbor_entry) = state.nib.nwk_neighbor_table.get_mut(&relaying_ieee) {
+                    // Update the neighbor table counters
+                    neighbor_entry.router_outbound_activity =
+                        neighbor_entry.router_outbound_activity.saturating_add(1);
                 }
+            }
 
-                // And the routing table counters
-                if let Some(route_entry) = state
-                    .nib
-                    .nwk_route_table
-                    .get_mut(&nwk_frame.nwk_header.destination)
-                {
-                    route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
-                    route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
-                }
+            // And the routing table counters
+            if let Some(route_entry) = state
+                .nib
+                .nwk_route_table
+                .get_mut(&nwk_frame.nwk_header.destination)
+            {
+                route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
+                route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
             }
 
             // Increment counters before sending
@@ -1884,15 +1886,15 @@ impl ZigbeeStack {
                     break;
                 }
                 Err(e) => {
-                    log::warn!("Failed to send frame: {e}");
+                    log::warn!("Failed to send unicast frame: {e}");
 
-                    if attempt + 1 == nwkc_unicast_retries {
-                        log::error!("Failed to send frame after {} attempts", attempt + 1);
+                    if attempt + 1 > nwkc_unicast_retries {
+                        log::error!("Failed to send unicast frame after {} attempts", attempt);
                         return Err(e);
                     }
                     log::debug!(
-                        "Retrying frame send, attempt {} of {}",
-                        attempt + 1,
+                        "Retrying unicast frame send, attempt {} of {}",
+                        attempt,
                         nwkc_unicast_retries
                     );
 
@@ -1904,17 +1906,115 @@ impl ZigbeeStack {
         Ok(())
     }
 
+    pub async fn send_broadcast_nwk_frame(&self, mut nwk_frame: NwkFrame) -> Result<(), String> {
+        let mut state = self.state.lock().unwrap();
+
+        state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
+        nwk_frame.nwk_header.sequence_number = state.nib.nwk_sequence_number;
+        nwk_frame.aux_header = Some(NwkAuxHeader {
+            security_control: NwkSecurityHeaderControlField {
+                security_level: NwkSecurityLevel::NoSecurity,
+                key_id: NwkSecurityHeaderKeyId::NetworkKey,
+                extended_nonce: true,
+                require_verified_frame_counter: false,
+                reserved: 0b0,
+            },
+            frame_counter: 0, // This field is rewritten and is always up-to-date
+            extended_source: Some(state.nib.nwk_ieee_address),
+            key_sequence_number: state.nib.nwk_active_key_seq_number,
+        });
+
+        let nwkc_broadcast_retries = state.nib.nwkc_max_broadcast_retries;
+        let nwkc_max_broadcast_jitter = state.nib.nwkc_max_broadcast_jitter;
+
+        drop(state);
+
+        for attempt in 0..=nwkc_broadcast_retries {
+            state = self.state.lock().unwrap();
+
+            // The encryption frame counter always increments
+            state
+                .nib
+                .nwk_security_material_primary
+                .outgoing_frame_counter = state
+                .nib
+                .nwk_security_material_primary
+                .outgoing_frame_counter
+                .wrapping_add(1);
+
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter = state
+                .nib
+                .nwk_security_material_primary
+                .outgoing_frame_counter;
+
+            let encrypted_nwk_frame =
+                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key)?;
+
+            let ieee802154_frame = Ieee802154Frame {
+                frame_control: Ieee802154FrameControl {
+                    frame_type: Ieee802154FrameType::Data,
+                    security_enabled: false,
+                    frame_pending: false,
+                    ack_request: false,
+                    pan_id_compression: true,
+                    reserved: false,
+                    sequence_number_suppression: false,
+                    information_elements_present: false,
+                    dest_addr_mode: Ieee802154AddressingMode::Short,
+                    frame_version: 0,
+                    src_addr_mode: Ieee802154AddressingMode::Short,
+                },
+                sequence_number: Some(state.ieee802154_sequence_number),
+                dest_pan_id: Some(state.nib.nwk_pan_id),
+                // All broadcasts are sent to the 802.15.4 broadcast address, since the
+                // distinction between Zigbee groups and broadcasts is at a higher layer
+                dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
+                src_pan_id: None,
+                src_address: Some(Ieee802154Address::Nwk(state.nib.nwk_network_address)),
+                payload: encrypted_nwk_frame.to_bytes(),
+                fcs: 0x0000, // It'll be replaced
+            };
+
+            // Increment counters before sending
+            state.nib.nwk_tx_total = state.nib.nwk_tx_total.wrapping_add(1);
+
+            // Handle `nwk_tx_total` wrapping
+            if state.nib.nwk_tx_total == 0x0000 {
+                for (_, neighbor) in state.nib.nwk_neighbor_table.iter_mut() {
+                    neighbor.transmit_failure = 0;
+                }
+            }
+            drop(state);
+
+            // TODO: implement logic to detect when broadcasts have been successfully
+            // sent. This is done by keeping track of which neighbor routers have been
+            // "heard" relaying it. For now, we just retry a few times.
+            let _ = self.send_802154_frame(ieee802154_frame).await;
+
+            let sleep_time = nwkc_max_broadcast_jitter.mul_f32(rand::random::<f32>());
+            log::debug!(
+                "Retrying broadcast frame send, attempt {} of {} in {:?}",
+                attempt,
+                nwkc_broadcast_retries,
+                sleep_time,
+            );
+
+            tokio::time::sleep(sleep_time).await;
+        }
+
+        Ok(())
+    }
+
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, String> {
-        if !self
-            .state
-            .lock()
-            .unwrap()
-            .nib
-            .nwk_route_table
-            .contains_key(&destination)
+        let state = self.state.lock().unwrap();
+
+        if state.hack_force_route_discovery || !state.nib.nwk_route_table.contains_key(&destination)
         {
+            drop(state);
             log::debug!("Starting route discovery for NWK {destination:?}");
             self.send_route_discovery(destination).await;
+        } else {
+            drop(state);
         }
 
         let (route_entry_status, route_entry_next_hop_address) = {

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -22,7 +22,6 @@ use zigbee_parts::commands::{
     NwkRouteRequestCommand, NwkRouteRequestManyToOne,
 };
 
-use rand::prelude::*;
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::mem::drop;

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -1770,16 +1770,6 @@ impl ZigbeeStack {
 
         let mut state = self.state.lock().unwrap();
 
-        // The encryption frame counter always increments
-        state
-            .nib
-            .nwk_security_material_primary
-            .outgoing_frame_counter = state
-            .nib
-            .nwk_security_material_primary
-            .outgoing_frame_counter
-            .wrapping_add(1);
-
         // For now, as does the NWK sequence number
         state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
         nwk_frame.nwk_header.sequence_number = state.nib.nwk_sequence_number;
@@ -1791,83 +1781,127 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
                 reserved: 0b0,
             },
-            frame_counter: state
-                .nib
-                .nwk_security_material_primary
-                .outgoing_frame_counter,
+            frame_counter: 0, // This field is rewritten and is always up-to-date
             extended_source: Some(state.nib.nwk_ieee_address),
             key_sequence_number: state.nib.nwk_active_key_seq_number,
         });
 
-        let encrypted_nwk_frame =
-            nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key)?;
+        let nwkc_unicast_retries = state.nib.nwkc_unicast_retries;
+        let nwkc_unicast_retry_delay = state.nib.nwkc_unicast_retry_delay;
 
-        let ieee802154_frame = Ieee802154Frame {
-            frame_control: Ieee802154FrameControl {
-                frame_type: Ieee802154FrameType::Data,
-                security_enabled: false,
-                frame_pending: false,
-                ack_request: (next_hop_address != Nwk(0xFFFF)),
-                pan_id_compression: true,
-                reserved: false,
-                sequence_number_suppression: false,
-                information_elements_present: false,
-                dest_addr_mode: Ieee802154AddressingMode::Short,
-                frame_version: 0,
-                src_addr_mode: Ieee802154AddressingMode::Short,
-            },
-            sequence_number: Some(state.ieee802154_sequence_number),
-            dest_pan_id: Some(state.nib.nwk_pan_id),
-            dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
-            src_pan_id: None,
-            src_address: Some(Ieee802154Address::Nwk(state.nib.nwk_network_address)),
-            payload: encrypted_nwk_frame.to_bytes(),
-            fcs: 0x0000, // It'll be replaced
-        };
+        drop(state);
 
-        // When forwarding packets to another node, update the counters for the neighbor
-        if next_hop_address != Nwk(0xFFFF) {
-            // TODO: maybe wrap the send state into some sort of struct to avoid
-            // needing to do this?
-            if let Some(relaying_ieee) =
-                state.nib.nwk_address_map.iter().find_map(|(&eui64, &nwk)| {
-                    if nwk == next_hop_address {
-                        Some(eui64)
-                    } else {
-                        None
+        for attempt in 0..nwkc_unicast_retries {
+            state = self.state.lock().unwrap();
+
+            // The encryption frame counter always increments
+            state
+                .nib
+                .nwk_security_material_primary
+                .outgoing_frame_counter = state
+                .nib
+                .nwk_security_material_primary
+                .outgoing_frame_counter
+                .wrapping_add(1);
+
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter = state
+                .nib
+                .nwk_security_material_primary
+                .outgoing_frame_counter;
+
+            let encrypted_nwk_frame =
+                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key)?;
+
+            let ieee802154_frame = Ieee802154Frame {
+                frame_control: Ieee802154FrameControl {
+                    frame_type: Ieee802154FrameType::Data,
+                    security_enabled: false,
+                    frame_pending: false,
+                    ack_request: (next_hop_address != Nwk(0xFFFF)),
+                    pan_id_compression: true,
+                    reserved: false,
+                    sequence_number_suppression: false,
+                    information_elements_present: false,
+                    dest_addr_mode: Ieee802154AddressingMode::Short,
+                    frame_version: 0,
+                    src_addr_mode: Ieee802154AddressingMode::Short,
+                },
+                sequence_number: Some(state.ieee802154_sequence_number),
+                dest_pan_id: Some(state.nib.nwk_pan_id),
+                dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
+                src_pan_id: None,
+                src_address: Some(Ieee802154Address::Nwk(state.nib.nwk_network_address)),
+                payload: encrypted_nwk_frame.to_bytes(),
+                fcs: 0x0000, // It'll be replaced
+            };
+
+            // When forwarding packets to another node, update the counters for the neighbor
+            if next_hop_address != Nwk(0xFFFF) {
+                // TODO: maybe wrap the send state into some sort of struct to avoid
+                // needing to do this?
+                if let Some(relaying_ieee) =
+                    state.nib.nwk_address_map.iter().find_map(|(&eui64, &nwk)| {
+                        if nwk == next_hop_address {
+                            Some(eui64)
+                        } else {
+                            None
+                        }
+                    })
+                {
+                    if let Some(neighbor_entry) =
+                        state.nib.nwk_neighbor_table.get_mut(&relaying_ieee)
+                    {
+                        // Update the neighbor table counters
+                        neighbor_entry.router_outbound_activity =
+                            neighbor_entry.router_outbound_activity.saturating_add(1);
                     }
-                })
-            {
-                if let Some(neighbor_entry) = state.nib.nwk_neighbor_table.get_mut(&relaying_ieee) {
-                    // Update the neighbor table counters
-                    neighbor_entry.router_outbound_activity =
-                        neighbor_entry.router_outbound_activity.saturating_add(1);
+                }
+
+                // And the routing table counters
+                if let Some(route_entry) = state
+                    .nib
+                    .nwk_route_table
+                    .get_mut(&nwk_frame.nwk_header.destination)
+                {
+                    route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
+                    route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
                 }
             }
 
-            // And the routing table counters
-            if let Some(route_entry) = state
-                .nib
-                .nwk_route_table
-                .get_mut(&nwk_frame.nwk_header.destination)
-            {
-                route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
-                route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
+            // Increment counters before sending
+            state.nib.nwk_tx_total = state.nib.nwk_tx_total.wrapping_add(1);
+
+            // Handle `nwk_tx_total` wrapping
+            if state.nib.nwk_tx_total == 0x0000 {
+                for (_, neighbor) in state.nib.nwk_neighbor_table.iter_mut() {
+                    neighbor.transmit_failure = 0;
+                }
+            }
+            drop(state);
+
+            match self.send_802154_frame(ieee802154_frame).await {
+                Ok(_) => {
+                    break;
+                }
+                Err(e) => {
+                    log::warn!("Failed to send frame: {e}");
+
+                    if attempt + 1 == nwkc_unicast_retries {
+                        log::error!("Failed to send frame after {} attempts", attempt + 1);
+                        return Err(e);
+                    }
+                    log::debug!(
+                        "Retrying frame send, attempt {} of {}",
+                        attempt + 1,
+                        nwkc_unicast_retries
+                    );
+
+                    tokio::time::sleep(nwkc_unicast_retry_delay).await;
+                }
             }
         }
 
-        // Increment counters before sending
-        state.nib.nwk_tx_total = state.nib.nwk_tx_total.wrapping_add(1);
-
-        // Handle `nwk_tx_total` wrapping
-        if state.nib.nwk_tx_total == 0x0000 {
-            for (_, neighbor) in state.nib.nwk_neighbor_table.iter_mut() {
-                neighbor.transmit_failure = 0;
-            }
-        }
-        drop(state);
-
-        self.send_802154_frame(ieee802154_frame).await
+        Ok(())
     }
 
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, String> {


### PR DESCRIPTION
This PR implements retries at the NWK level. From experience with other radios, I think it's best to allow the higher-level application to manage further retries.

The network key frame counter needs to be incremented before every send, even for retries, so the state mutex needs to be acquired and dropped a bunch of times in a row to make this possible.