### PR TITLE
Clean up error types and migrate error strings to error enums

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,9 +1,15 @@
 repos:
   - repo: local
     hooks:
-      - id: rust-linting
-        name: Rust linting
+      - id: cargo-fmt
+        name: Cargo fmt
         entry: cargo fmt --all
+        language: system
+        pass_filenames: false
+
+      - id: cargo-check
+        name: Cargo check
+        entry: cargo check --workspace
         language: system
         pass_filenames: false
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -341,12 +341,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "84b26c544d002229e640969970a2e74021aadf6e2f96372b9c58eff97de08eb3"
 
 [[package]]
-name = "heck"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,12 +776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
-
-[[package]]
 name = "ryu"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -886,19 +874,6 @@ checksum = "4f5fd57c80058a56cf5c777ab8a126398ece8e442983605d280a44ce79d0edef"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.26.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 2.0.101",
 ]
 
 [[package]]
@@ -1215,7 +1190,6 @@ dependencies = [
  "serial2",
  "serial2-tokio",
  "shellexpand",
- "strum_macros",
  "thiserror",
  "tokio",
  "zigbee-parts",

--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -19,7 +19,6 @@ shellexpand = "3.1.0"
 inline_colorization = "0.1.6"
 derivative = "2.2.0"
 crc_all = "0.2.2"
-strum_macros = "0.26.4"
 serial2-tokio = "0.1.14"
 tokio = { version = "1.43.0", features = ["full"] }
 log = "0.4.26"

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -210,10 +210,18 @@ impl ZigguratServer {
                     )
                     .await;
 
-                CommandResponse {
-                    tid: cmd.tid,
-                    cmd: cmd.cmd,
-                    data: json!({"status": if status.is_ok() { "success" } else { "error" } }),
+                if status.is_ok() {
+                    CommandResponse {
+                        tid: cmd.tid,
+                        cmd: cmd.cmd,
+                        data: json!({"status": "success"}),
+                    }
+                } else {
+                    CommandResponse {
+                        tid: cmd.tid,
+                        cmd: cmd.cmd,
+                        data: json!({"status": "error", "reason": status.err().map(|e| e.to_string())}),
+                    }
                 }
             }
             "send_aps_command" => {

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -4,10 +4,14 @@ use crc_all::CrcAlgo;
 use log;
 use std::collections::HashMap;
 use strum_macros::FromRepr;
+use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
 const CRC_KERMIT: CrcAlgo<u16> = CrcAlgo::<u16>::new(0x1021, 16, 0xFFFF, 0xFFFF, true);
 const U21_MAX: u32 = 1 << 21;
+
+#[derive(Error, Debug)]
+pub enum SpinelSendError {}
 
 #[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
 pub enum SpinelCommandId {
@@ -229,7 +233,17 @@ pub enum SpinelMacPromiscuousMode {
     Full = 2,
 }
 
-pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), &'static str> {
+#[derive(Error, Debug)]
+pub enum SpinelFrameParsingError {
+    #[error("payload is too short, expected at least {expected} bytes, got {got}")]
+    PayloadTooShort { expected: usize, got: usize },
+    #[error("not a spinel frame, expected flag 0b10, got {flag}")]
+    NotSpinelFrame { flag: u8 },
+    #[error("packed uint21 did not terminate")]
+    PackedU21DidNotTerminate,
+}
+
+pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), SpinelFrameParsingError> {
     let mut result = 0u32;
 
     for (index, byte) in bytes.iter().enumerate() {
@@ -244,7 +258,7 @@ pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), &'static 
         }
     }
 
-    return Err("Packed uint21 did not terminate");
+    return Err(SpinelFrameParsingError::PackedU21DidNotTerminate);
 }
 
 pub fn packed_uint21_to_bytes(value: u32) -> Vec<u8> {
@@ -281,11 +295,16 @@ pub enum HdlcSpecial {
     Vendor = 0xF8,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Error, Debug)]
 pub enum HdlcLiteFrameParsingError {
-    BadEscapeByte,
-    InvalidCrc,
-    BadLength,
+    #[error("bad escape byte encountered: {byte}")]
+    BadEscapeByte { byte: u8 },
+    #[error("invalid crc, expected {expected_crc}, got {got_crc}")]
+    InvalidCrc { expected_crc: u16, got_crc: u16 },
+    #[error("frame is too short, expected at least {expected} bytes, got {got}")]
+    FrameTooShort { expected: usize, got: usize },
+    #[error("payload is too short, expected at least {expected} bytes, got {got}")]
+    PayloadTooShort { expected: usize, got: usize },
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -296,7 +315,10 @@ pub struct HdlcLiteFrame {
 impl HdlcLiteFrame {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, HdlcLiteFrameParsingError> {
         if bytes.len() < 2 {
-            return Err(HdlcLiteFrameParsingError::BadLength);
+            return Err(HdlcLiteFrameParsingError::FrameTooShort {
+                expected: 2,
+                got: bytes.len(),
+            });
         }
 
         let mut data = Vec::new();
@@ -315,7 +337,7 @@ impl HdlcLiteFrame {
                     && result_byte != (HdlcSpecial::Xoff as u8)
                     && result_byte != (HdlcSpecial::Vendor as u8)
                 {
-                    return Err(HdlcLiteFrameParsingError::BadEscapeByte);
+                    return Err(HdlcLiteFrameParsingError::BadEscapeByte { byte: result_byte });
                 }
             } else if result_byte == HdlcSpecial::Escape as u8 {
                 unescaping = true;
@@ -328,7 +350,10 @@ impl HdlcLiteFrame {
         }
 
         if data.len() < 2 {
-            return Err(HdlcLiteFrameParsingError::BadLength);
+            return Err(HdlcLiteFrameParsingError::PayloadTooShort {
+                expected: 2,
+                got: data.len(),
+            });
         }
 
         let mut crc = 0x0000u16;
@@ -337,8 +362,13 @@ impl HdlcLiteFrame {
         CRC_KERMIT.finish_crc(&mut crc);
         crc ^= 0xFFFF;
 
-        if crc != u16::from_le_bytes([data[data.len() - 2], data[data.len() - 1]]) {
-            return Err(HdlcLiteFrameParsingError::InvalidCrc);
+        let expected_crc = u16::from_le_bytes([data[data.len() - 2], data[data.len() - 1]]);
+
+        if crc != expected_crc {
+            return Err(HdlcLiteFrameParsingError::InvalidCrc {
+                expected_crc: expected_crc,
+                got_crc: crc,
+            });
         }
 
         Ok(Self {
@@ -393,9 +423,12 @@ pub struct SpinelHeader {
 }
 
 impl SpinelHeader {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SpinelFrameParsingError> {
         if bytes.len() < 1 {
-            return Err("Not enough data to parse SpinelHeader");
+            return Err(SpinelFrameParsingError::PayloadTooShort {
+                expected: 1,
+                got: bytes.len(),
+            });
         }
 
         let byte = bytes[0];
@@ -413,12 +446,6 @@ impl SpinelHeader {
     }
 }
 
-#[derive(Debug, Clone)]
-pub enum SpinelFrameParsingError {
-    PayloadTooShort,
-    NotSpinelFrame,
-}
-
 #[derive(Debug, PartialEq, Clone)]
 pub struct SpinelFrame {
     pub header: SpinelHeader,
@@ -429,13 +456,16 @@ pub struct SpinelFrame {
 impl SpinelFrame {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, SpinelFrameParsingError> {
         if bytes.len() < 3 {
-            return Err(SpinelFrameParsingError::PayloadTooShort);
+            return Err(SpinelFrameParsingError::PayloadTooShort {
+                expected: 3,
+                got: bytes.len(),
+            });
         }
 
-        let header = SpinelHeader::from_bytes(&bytes[..1]).unwrap();
+        let header = SpinelHeader::from_bytes(&bytes[..1])?;
 
         if header.flag != 0b10 {
-            return Err(SpinelFrameParsingError::NotSpinelFrame);
+            return Err(SpinelFrameParsingError::NotSpinelFrame { flag: header.flag });
         }
 
         let command_id = bytes[1];
@@ -466,7 +496,7 @@ pub struct SpinelFramePropValueIs {
 }
 
 impl SpinelFramePropValueIs {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SpinelFrameParsingError> {
         match packed_uint21_deserialize(bytes) {
             Ok((property_id, remaining)) => Ok(Self {
                 property_id,
@@ -545,12 +575,14 @@ impl SpinelProtocol {
             // Ignore consecutive flags
             if index.unwrap() > 0 {
                 match HdlcLiteFrame::from_bytes(&self.buffer[0..index.unwrap()]) {
-                    Err(HdlcLiteFrameParsingError::BadEscapeByte)
-                    | Err(HdlcLiteFrameParsingError::InvalidCrc)
-                    | Err(HdlcLiteFrameParsingError::BadLength) => {}
+                    Err(HdlcLiteFrameParsingError::BadEscapeByte { .. })
+                    | Err(HdlcLiteFrameParsingError::InvalidCrc { .. })
+                    | Err(HdlcLiteFrameParsingError::FrameTooShort { .. })
+                    | Err(HdlcLiteFrameParsingError::PayloadTooShort { .. }) => {}
                     Ok(frame) => match SpinelFrame::from_bytes(&frame.data) {
-                        Err(SpinelFrameParsingError::PayloadTooShort)
-                        | Err(SpinelFrameParsingError::NotSpinelFrame) => {}
+                        Err(SpinelFrameParsingError::PayloadTooShort { .. })
+                        | Err(SpinelFrameParsingError::PackedU21DidNotTerminate { .. })
+                        | Err(SpinelFrameParsingError::NotSpinelFrame { .. }) => {}
                         Ok(parsed_frame) => {
                             into.push(parsed_frame);
                             num_parsed_frames += 1;

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crc_all::CrcAlgo;
 use log;
 use num_enum::TryFromPrimitive;

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -2,8 +2,8 @@
 
 use crc_all::CrcAlgo;
 use log;
+use num_enum::TryFromPrimitive;
 use std::collections::HashMap;
-use strum_macros::FromRepr;
 use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 
@@ -13,7 +13,8 @@ const U21_MAX: u32 = 1 << 21;
 #[derive(Error, Debug)]
 pub enum SpinelSendError {}
 
-#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[repr(u8)]
 pub enum SpinelCommandId {
     Noop = 0,
     Reset = 1,
@@ -41,7 +42,8 @@ pub enum SpinelCommandId {
     HboDropped = 17,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive, Hash, Eq)]
+#[repr(u32)]
 pub enum SpinelPropertyId {
     // Core Properties
     LastStatus = 0,
@@ -178,14 +180,16 @@ pub enum SpinelPropertyId {
     NestStreamMfg = 0x3BC0,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[repr(u8)]
 pub enum SpinelResetReason {
     Platform = 1,
     Stack = 2,
     Bootloader = 3,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[repr(u8)]
 pub enum SpinelStatus {
     Ok = 0,
     Failure = 1,
@@ -223,7 +227,8 @@ pub enum SpinelStatus {
     ResetWatchdog = 120,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[repr(u8)]
 pub enum SpinelMacPromiscuousMode {
     //  Normal MAC filtering is in place.
     Off = 0,
@@ -241,6 +246,10 @@ pub enum SpinelFrameParsingError {
     NotSpinelFrame { flag: u8 },
     #[error("packed uint21 did not terminate")]
     PackedU21DidNotTerminate,
+    #[error("invalid property id: {property_id}")]
+    InvalidPropertyId { property_id: u32 },
+    #[error("invalid command id: {command_id}")]
+    InvalidCommandId { command_id: u8 },
 }
 
 pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), SpinelFrameParsingError> {
@@ -286,7 +295,8 @@ pub fn packed_uint21_to_bytes(value: u32) -> Vec<u8> {
     chunks
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, FromRepr)]
+#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[repr(u8)]
 pub enum HdlcSpecial {
     Flag = 0x7E,
     Escape = 0x7D,
@@ -449,7 +459,7 @@ impl SpinelHeader {
 #[derive(Debug, PartialEq, Clone)]
 pub struct SpinelFrame {
     pub header: SpinelHeader,
-    pub command_id: u8,
+    pub command_id: SpinelCommandId,
     pub payload: Vec<u8>,
 }
 
@@ -473,7 +483,8 @@ impl SpinelFrame {
 
         Ok(Self {
             header,
-            command_id,
+            command_id: SpinelCommandId::try_from(command_id)
+                .map_err(|_| SpinelFrameParsingError::InvalidCommandId { command_id })?,
             payload,
         })
     }
@@ -482,7 +493,7 @@ impl SpinelFrame {
         let mut result = Vec::new();
 
         result.extend(&self.header.to_bytes());
-        result.push(self.command_id);
+        result.push(self.command_id as u8);
         result.extend(self.payload.iter());
 
         result
@@ -491,7 +502,7 @@ impl SpinelFrame {
 
 #[derive(Debug, Clone)]
 pub struct SpinelFramePropValueIs {
-    pub property_id: u32,
+    pub property_id: SpinelPropertyId,
     pub value: Vec<u8>,
 }
 
@@ -499,7 +510,8 @@ impl SpinelFramePropValueIs {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, SpinelFrameParsingError> {
         match packed_uint21_deserialize(bytes) {
             Ok((property_id, remaining)) => Ok(Self {
-                property_id,
+                property_id: SpinelPropertyId::try_from(property_id)
+                    .map_err(|_| SpinelFrameParsingError::InvalidPropertyId { property_id })?,
                 value: remaining.to_vec(),
             }),
             Err(err) => Err(err),
@@ -507,7 +519,7 @@ impl SpinelFramePropValueIs {
     }
 
     pub fn to_bytes(&self) -> Vec<u8> {
-        let mut result = packed_uint21_to_bytes(self.property_id);
+        let mut result = packed_uint21_to_bytes(self.property_id as u32);
         result.extend(self.value.iter());
 
         result
@@ -521,7 +533,7 @@ pub struct SpinelProtocol {
     pub next_tid: u8,
     pub pending_frames: HashMap<u8, oneshot::Sender<SpinelFrame>>,
     pub unsolicited_frame_receiver: Option<mpsc::Sender<SpinelFrame>>,
-    pub property_update_receivers: HashMap<u32, mpsc::Sender<SpinelFramePropValueIs>>,
+    pub property_update_receivers: HashMap<SpinelPropertyId, mpsc::Sender<SpinelFramePropValueIs>>,
 }
 
 impl SpinelProtocol {
@@ -542,7 +554,7 @@ impl SpinelProtocol {
 
     pub fn set_property_update_receiver(
         &mut self,
-        property_id: u32,
+        property_id: SpinelPropertyId,
         tx: mpsc::Sender<SpinelFramePropValueIs>,
     ) {
         self.property_update_receivers.insert(property_id, tx);
@@ -583,6 +595,10 @@ impl SpinelProtocol {
                         Err(SpinelFrameParsingError::PayloadTooShort { .. })
                         | Err(SpinelFrameParsingError::PackedU21DidNotTerminate { .. })
                         | Err(SpinelFrameParsingError::NotSpinelFrame { .. }) => {}
+                        Err(SpinelFrameParsingError::InvalidPropertyId { .. }) => { /* This cannot happen */
+                        }
+                        Err(SpinelFrameParsingError::InvalidCommandId { .. }) => { /* This cannot happen */
+                        }
                         Ok(parsed_frame) => {
                             into.push(parsed_frame);
                             num_parsed_frames += 1;
@@ -617,7 +633,7 @@ impl SpinelProtocol {
         let tid = frame.header.transaction_id;
 
         if tid == 0 {
-            if frame.command_id == SpinelCommandId::PropValueIs as u8 {
+            if frame.command_id == SpinelCommandId::PropValueIs {
                 match SpinelFramePropValueIs::from_bytes(&frame.payload) {
                     Ok(prop_value_is) => {
                         match self
@@ -648,7 +664,7 @@ impl SpinelProtocol {
 
     pub fn prepare_request(
         &mut self,
-        command_id: u8,
+        command_id: SpinelCommandId,
         payload: Vec<u8>,
     ) -> (SpinelFrame, oneshot::Receiver<SpinelFrame>) {
         // Cycle TIDs from 1..7
@@ -802,7 +818,7 @@ mod test {
                         network_link_id: 0,
                         transaction_id: 1
                     },
-                    command_id: 2,
+                    command_id: SpinelCommandId::PropValueGet,
                     payload: vec![2]
                 },
                 SpinelFrame {
@@ -811,7 +827,7 @@ mod test {
                         network_link_id: 0,
                         transaction_id: 1
                     },
-                    command_id: 2,
+                    command_id: SpinelCommandId::PropValueGet,
                     payload: vec![2]
                 },
                 SpinelFrame {
@@ -820,7 +836,7 @@ mod test {
                         network_link_id: 0,
                         transaction_id: 1
                     },
-                    command_id: 2,
+                    command_id: SpinelCommandId::PropValueGet,
                     payload: vec![2]
                 }
             ]
@@ -847,7 +863,7 @@ mod test {
                         network_link_id: 0,
                         transaction_id: 1
                     },
-                    command_id: 2,
+                    command_id: SpinelCommandId::PropValueGet,
                     payload: vec![2]
                 },
                 SpinelFrame {
@@ -856,7 +872,7 @@ mod test {
                         network_link_id: 0,
                         transaction_id: 1
                     },
-                    command_id: 2,
+                    command_id: SpinelCommandId::PropValueGet,
                     payload: vec![2]
                 },
                 SpinelFrame {
@@ -865,7 +881,7 @@ mod test {
                         network_link_id: 0,
                         transaction_id: 1
                     },
-                    command_id: 2,
+                    command_id: SpinelCommandId::PropValueGet,
                     payload: vec![2]
                 }
             ]
@@ -881,7 +897,7 @@ mod test {
         protocol.next_tid = 3;
 
         let (request, mut rx) = protocol.prepare_request(
-            SpinelCommandId::PropValueGet as u8,
+            SpinelCommandId::PropValueGet,
             packed_uint21_to_bytes(SpinelPropertyId::NcpVersion as u32),
         );
         assert_eq!(
@@ -892,7 +908,7 @@ mod test {
                     network_link_id: 0,
                     transaction_id: 3,
                 },
-                command_id: SpinelCommandId::PropValueGet as u8,
+                command_id: SpinelCommandId::PropValueGet,
                 payload: packed_uint21_to_bytes(SpinelPropertyId::NcpVersion as u32)
             }
         );
@@ -912,7 +928,7 @@ mod test {
                     network_link_id: 0,
                     transaction_id: 3,
                 },
-                command_id: SpinelCommandId::PropValueIs as u8,
+                command_id: SpinelCommandId::PropValueIs,
                 payload:
                     b"\x02SL-OPENTHREAD/2.4.4.0_GitHub-7074a43e4; EFR32; Oct 21 2024 14:40:57\x00"
                         .to_vec()

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -10,9 +10,6 @@ use tokio::sync::{mpsc, oneshot};
 const CRC_KERMIT: CrcAlgo<u16> = CrcAlgo::<u16>::new(0x1021, 16, 0xFFFF, 0xFFFF, true);
 const U21_MAX: u32 = 1 << 21;
 
-#[derive(Error, Debug)]
-pub enum SpinelSendError {}
-
 #[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SpinelCommandId {

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -315,25 +315,24 @@ impl SpinelClient {
             .await?;
 
         let response_payload = response.payload;
-        let (rsp_property_id, payload) =
+        let (rsp_property_id_int, payload) =
             packed_uint21_deserialize(&response_payload).map_err(SpinelError::U21ParsingError)?;
 
+        let rsp_property_id = SpinelPropertyId::try_from(rsp_property_id_int).map_err(|_| {
+            SpinelError::InvalidResponseError {
+                reason: "Invalid property ID in response".to_string(),
+            }
+        })?;
+
         log::info!(
-            "Setting property {:?}={:02X?}, result {}={:02X?}",
+            "Setting property {:?}={:02X?}, result {:?}={:02X?}",
             property_id,
             value,
             rsp_property_id,
             payload
         );
 
-        Ok((
-            SpinelPropertyId::try_from(rsp_property_id).map_err(|_| {
-                SpinelError::InvalidResponseError {
-                    reason: "Invalid property ID in response".to_string(),
-                }
-            })?,
-            payload.to_vec(),
-        ))
+        Ok((rsp_property_id, payload.to_vec()))
     }
 
     // Convenience method wrapping broad functionality are below

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -287,15 +287,10 @@ impl SpinelClient {
             .await?;
 
         let response_payload = response.payload;
-        let (_rsp_property_id, payload) = match packed_uint21_deserialize(&response_payload) {
-            Ok((property_id, payload)) => (property_id, payload),
-            Err(e) => {
-                return Err(SpinelSendError::IoError(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    e,
-                )));
-            }
-        };
+        let (_rsp_property_id, payload) =
+            packed_uint21_deserialize(&response_payload).map_err(|e| {
+                SpinelSendError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            })?;
 
         Ok(payload.to_vec())
     }
@@ -317,15 +312,10 @@ impl SpinelClient {
             .await?;
 
         let response_payload = response.payload;
-        let (rsp_property_id, payload) = match packed_uint21_deserialize(&response_payload) {
-            Ok((property_id, payload)) => (property_id, payload),
-            Err(e) => {
-                return Err(SpinelSendError::IoError(std::io::Error::new(
-                    std::io::ErrorKind::InvalidData,
-                    e,
-                )));
-            }
-        };
+        let (rsp_property_id, payload) =
+            packed_uint21_deserialize(&response_payload).map_err(|e| {
+                SpinelSendError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            })?;
 
         log::info!(
             "Setting property {}={:02X?}, result {}={:02X?}",

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -1,6 +1,7 @@
 use crate::spinel::{
     HdlcLiteFrame, SpinelCommandId, SpinelFrame, SpinelFrameParsingError, SpinelFramePropValueIs,
-    SpinelPropertyId, SpinelProtocol, packed_uint21_deserialize, packed_uint21_to_bytes,
+    SpinelPropertyId, SpinelProtocol, SpinelStatus, packed_uint21_deserialize,
+    packed_uint21_to_bytes,
 };
 use serial2_tokio::SerialPort;
 use std::string::String;
@@ -198,7 +199,7 @@ impl SpinelClient {
 
     pub fn set_property_update_receiver(
         &self,
-        property_id: u32,
+        property_id: SpinelPropertyId,
         tx: mpsc::Sender<SpinelFramePropValueIs>,
     ) {
         self.protocol
@@ -237,7 +238,7 @@ impl SpinelClient {
 
     pub async fn send_command(
         &self,
-        command_id: u8,
+        command_id: SpinelCommandId,
         payload: Vec<u8>,
     ) -> Result<SpinelFrame, SpinelError> {
         let (frame, rx) = {
@@ -279,11 +280,14 @@ impl SpinelClient {
         }
     }
 
-    pub async fn prop_value_get(&self, property_id: u32) -> Result<Vec<u8>, SpinelError> {
+    pub async fn prop_value_get(
+        &self,
+        property_id: SpinelPropertyId,
+    ) -> Result<Vec<u8>, SpinelError> {
         let response = self
             .send_command(
-                SpinelCommandId::PropValueGet as u8,
-                packed_uint21_to_bytes(property_id),
+                SpinelCommandId::PropValueGet,
+                packed_uint21_to_bytes(property_id as u32),
             )
             .await?;
 
@@ -296,13 +300,13 @@ impl SpinelClient {
 
     pub async fn prop_value_set(
         &self,
-        property_id: u32,
+        property_id: SpinelPropertyId,
         value: Vec<u8>,
-    ) -> Result<(u32, Vec<u8>), SpinelError> {
+    ) -> Result<(SpinelPropertyId, Vec<u8>), SpinelError> {
         let response = self
             .send_command(
-                SpinelCommandId::PropValueSet as u8,
-                packed_uint21_to_bytes(property_id)
+                SpinelCommandId::PropValueSet,
+                packed_uint21_to_bytes(property_id as u32)
                     .iter()
                     .chain(value.iter())
                     .cloned()
@@ -315,20 +319,27 @@ impl SpinelClient {
             packed_uint21_deserialize(&response_payload).map_err(SpinelError::U21ParsingError)?;
 
         log::info!(
-            "Setting property {}={:02X?}, result {}={:02X?}",
+            "Setting property {:?}={:02X?}, result {}={:02X?}",
             property_id,
             value,
             rsp_property_id,
             payload
         );
 
-        Ok((rsp_property_id, payload.to_vec()))
+        Ok((
+            SpinelPropertyId::try_from(rsp_property_id).map_err(|_| {
+                SpinelError::InvalidResponseError {
+                    reason: "Invalid property ID in response".to_string(),
+                }
+            })?,
+            payload.to_vec(),
+        ))
     }
 
     // Convenience method wrapping broad functionality are below
     pub async fn get_ncp_version(&self) -> Result<String, SpinelError> {
         let ncp_version_rsp = self
-            .prop_value_get(SpinelPropertyId::NcpVersion as u32)
+            .prop_value_get(SpinelPropertyId::NcpVersion)
             .await
             .unwrap();
 
@@ -340,15 +351,18 @@ impl SpinelClient {
             .to_string())
     }
 
-    pub async fn transmit_frame(&self, tx_frame: &SpinelTxFrame) -> Result<u8, SpinelError> {
+    pub async fn transmit_frame(
+        &self,
+        tx_frame: &SpinelTxFrame,
+    ) -> Result<SpinelStatus, SpinelError> {
         let _send_lock = self.send_lock.lock().await;
 
         let (rsp_prop_id, rsp) = self
-            .prop_value_set(SpinelPropertyId::StreamRaw as u32, tx_frame.to_bytes())
+            .prop_value_set(SpinelPropertyId::StreamRaw, tx_frame.to_bytes())
             .await
             .unwrap();
 
-        if rsp_prop_id != SpinelPropertyId::LastStatus as u32 {
+        if rsp_prop_id != SpinelPropertyId::LastStatus {
             return Err(SpinelError::InvalidResponseError {
                 reason: "Unexpected response property ID".to_string(),
             });
@@ -360,7 +374,8 @@ impl SpinelClient {
             });
         }
 
-        let status = rsp[0];
-        Ok(status)
+        SpinelStatus::try_from(rsp[0]).map_err(|_| SpinelError::InvalidResponseError {
+            reason: "Invalid Spinel status".to_string(),
+        })
     }
 }

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -1,6 +1,6 @@
 use crate::spinel::{
-    HdlcLiteFrame, SpinelCommandId, SpinelFrame, SpinelFramePropValueIs, SpinelPropertyId,
-    SpinelProtocol, packed_uint21_deserialize, packed_uint21_to_bytes,
+    HdlcLiteFrame, SpinelCommandId, SpinelFrame, SpinelFrameParsingError, SpinelFramePropValueIs,
+    SpinelPropertyId, SpinelProtocol, packed_uint21_deserialize, packed_uint21_to_bytes,
 };
 use serial2_tokio::SerialPort;
 use std::string::String;
@@ -165,13 +165,17 @@ impl SpinelRxFrame {
 }
 
 #[derive(Error, Debug)]
-pub enum SpinelSendError {
+pub enum SpinelError {
     #[error("io error")]
     IoError(#[from] std::io::Error),
     #[error("client has disconnected")]
     ChannelClosed,
     #[error("timeout")]
     Timeout,
+    #[error("spinel U21 parsing error")]
+    U21ParsingError(#[from] SpinelFrameParsingError),
+    #[error("spinel parsing error: {reason}")]
+    InvalidResponseError { reason: String },
 }
 
 #[derive(Debug)]
@@ -235,7 +239,7 @@ impl SpinelClient {
         &self,
         command_id: u8,
         payload: Vec<u8>,
-    ) -> Result<SpinelFrame, SpinelSendError> {
+    ) -> Result<SpinelFrame, SpinelError> {
         let (frame, rx) = {
             self.protocol
                 .lock()
@@ -252,33 +256,30 @@ impl SpinelClient {
         let data = hdlc_frame.to_bytes_with_flags();
 
         log::debug!("Writing {:02X?}", data);
-        self.port
-            .write(&data)
-            .await
-            .map_err(SpinelSendError::IoError)?;
+        self.port.write(&data).await.map_err(SpinelError::IoError)?;
 
         match timeout(TIMEOUT, rx).await {
             Ok(Ok(response_frame)) => Ok(response_frame),
-            Ok(Err(_recv_closed)) => {
+            Ok(Err(_)) => {
                 self.protocol
                     .lock()
                     .expect("Failed to lock Spinel")
                     .cancel_request(frame.header.transaction_id);
 
-                Err(SpinelSendError::ChannelClosed)
+                Err(SpinelError::ChannelClosed)
             }
-            Err(_elapsed) => {
+            Err(_) => {
                 self.protocol
                     .lock()
                     .expect("Failed to lock Spinel")
                     .cancel_request(frame.header.transaction_id);
 
-                Err(SpinelSendError::Timeout)
+                Err(SpinelError::Timeout)
             }
         }
     }
 
-    pub async fn prop_value_get(&self, property_id: u32) -> Result<Vec<u8>, SpinelSendError> {
+    pub async fn prop_value_get(&self, property_id: u32) -> Result<Vec<u8>, SpinelError> {
         let response = self
             .send_command(
                 SpinelCommandId::PropValueGet as u8,
@@ -288,9 +289,7 @@ impl SpinelClient {
 
         let response_payload = response.payload;
         let (_rsp_property_id, payload) =
-            packed_uint21_deserialize(&response_payload).map_err(|e| {
-                SpinelSendError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-            })?;
+            packed_uint21_deserialize(&response_payload).map_err(SpinelError::U21ParsingError)?;
 
         Ok(payload.to_vec())
     }
@@ -299,7 +298,7 @@ impl SpinelClient {
         &self,
         property_id: u32,
         value: Vec<u8>,
-    ) -> Result<(u32, Vec<u8>), SpinelSendError> {
+    ) -> Result<(u32, Vec<u8>), SpinelError> {
         let response = self
             .send_command(
                 SpinelCommandId::PropValueSet as u8,
@@ -313,9 +312,7 @@ impl SpinelClient {
 
         let response_payload = response.payload;
         let (rsp_property_id, payload) =
-            packed_uint21_deserialize(&response_payload).map_err(|e| {
-                SpinelSendError::IoError(std::io::Error::new(std::io::ErrorKind::InvalidData, e))
-            })?;
+            packed_uint21_deserialize(&response_payload).map_err(SpinelError::U21ParsingError)?;
 
         log::info!(
             "Setting property {}={:02X?}, result {}={:02X?}",
@@ -329,7 +326,7 @@ impl SpinelClient {
     }
 
     // Convenience method wrapping broad functionality are below
-    pub async fn get_ncp_version(&self) -> Result<String, SpinelSendError> {
+    pub async fn get_ncp_version(&self) -> Result<String, SpinelError> {
         let ncp_version_rsp = self
             .prop_value_get(SpinelPropertyId::NcpVersion as u32)
             .await
@@ -343,7 +340,7 @@ impl SpinelClient {
             .to_string())
     }
 
-    pub async fn transmit_frame(&self, tx_frame: &SpinelTxFrame) -> Result<u8, SpinelSendError> {
+    pub async fn transmit_frame(&self, tx_frame: &SpinelTxFrame) -> Result<u8, SpinelError> {
         let _send_lock = self.send_lock.lock().await;
 
         let (rsp_prop_id, rsp) = self
@@ -352,17 +349,15 @@ impl SpinelClient {
             .unwrap();
 
         if rsp_prop_id != SpinelPropertyId::LastStatus as u32 {
-            return Err(SpinelSendError::IoError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Unexpected response property ID",
-            )));
+            return Err(SpinelError::InvalidResponseError {
+                reason: "Unexpected response property ID".to_string(),
+            });
         }
 
         if rsp.len() < 1 {
-            return Err(SpinelSendError::IoError(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
-                "Unexpected response length",
-            )));
+            return Err(SpinelError::InvalidResponseError {
+                reason: "Unexpected response length".to_string(),
+            });
         }
 
         let status = rsp[0];

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -4,6 +4,7 @@ use crate::spinel::{
 };
 use serial2_tokio::SerialPort;
 use std::string::String;
+use thiserror::Error;
 
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -163,10 +164,13 @@ impl SpinelRxFrame {
     }
 }
 
-#[derive(Debug)]
+#[derive(Error, Debug)]
 pub enum SpinelSendError {
-    IoError(std::io::Error),
+    #[error("io error")]
+    IoError(#[from] std::io::Error),
+    #[error("client has disconnected")]
     ChannelClosed,
+    #[error("timeout")]
     Timeout,
 }
 

--- a/crates/stack/src/zigbee_aps.rs
+++ b/crates/stack/src/zigbee_aps.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use abstract_bits::{AbstractBits, abstract_bits};
 use num_enum::TryFromPrimitive;
 

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -15,11 +15,18 @@ use constant_time_eq::constant_time_eq;
 use num_enum::TryFromPrimitive;
 
 use derivative::Derivative;
+use thiserror::Error;
 
 pub const BROADCAST_ALL_DEVICES: Nwk = Nwk(0xFFFF);
 pub const BROADCAST_RX_ON_WHEN_IDLE: Nwk = Nwk(0xFFFD);
 pub const BROADCAST_ALL_ROUTERS_AND_COORDINATOR: Nwk = Nwk(0xFFFC);
 pub const BROADCAST_LOW_POWER_ROUTERS: Nwk = Nwk(0xFFFB);
+
+#[derive(Error, Debug)]
+pub enum NwkDecryptionError {
+    #[error("Invalid MAC tag")]
+    InvalidMacTag,
+}
 
 #[abstract_bits(bits = 2)]
 #[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
@@ -391,52 +398,23 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
 
 #[derive(Derivative)]
 #[derivative(Debug, Clone, PartialEq)]
-pub struct NwkFrame {
+pub struct EncryptedNwkFrame {
     pub nwk_header: NwkHeader,
     pub aux_header: Option<NwkAuxHeader>,
     #[derivative(Debug(format_with = "format_hex"))]
-    pub payload: Vec<u8>,
-    pub encrypted: bool,
+    pub ciphertext: Vec<u8>,
 }
 
-impl NwkFrame {
-    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
-        let mut remaining;
-        let nwk_header;
-        (nwk_header, remaining) = NwkHeader::deserialize(bytes)?;
+#[derive(Derivative)]
+#[derivative(Debug, Clone, PartialEq)]
+pub struct DecryptedNwkFrame {
+    pub nwk_header: NwkHeader,
+    pub aux_header: Option<NwkAuxHeader>,
+    #[derivative(Debug(format_with = "format_hex"))]
+    pub plaintext: Vec<u8>,
+}
 
-        let mut aux_header = None;
-
-        if nwk_header.frame_control.security {
-            let unwrapped_aux_header;
-            (unwrapped_aux_header, remaining) = NwkAuxHeader::deserialize(remaining)?;
-            aux_header = Some(unwrapped_aux_header);
-        }
-
-        let encrypted = nwk_header.frame_control.security;
-
-        Ok(Self {
-            nwk_header: nwk_header,
-            aux_header: aux_header,
-            payload: remaining.to_vec(),
-            encrypted: encrypted,
-        })
-    }
-
-    pub fn to_bytes(&self) -> Vec<u8> {
-        let mut bytes = Vec::new();
-
-        bytes.extend(self.nwk_header.to_bytes());
-
-        if let Some(aux_header) = &self.aux_header {
-            bytes.extend(aux_header.to_bytes());
-        }
-
-        bytes.extend(self.payload.clone());
-
-        bytes
-    }
-
+impl EncryptedNwkFrame {
     pub fn get_modified_aux_header(&self, nib_security_level: NwkSecurityLevel) -> NwkAuxHeader {
         if self.aux_header.is_none() {
             panic!("Auxiliary header is missing");
@@ -474,56 +452,119 @@ impl NwkFrame {
         NwkCrypto::<2, 4>
     }
 
-    pub fn decrypt(&self, key: &Key) -> Result<Self, &'static str> {
-        if !self.encrypted {
-            return Err("Cannot decrypt unencrypted frame");
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
+        let mut remaining;
+        let nwk_header;
+        (nwk_header, remaining) = NwkHeader::deserialize(bytes)?;
+
+        let mut aux_header = None;
+
+        if nwk_header.frame_control.security {
+            let unwrapped_aux_header;
+            (unwrapped_aux_header, remaining) = NwkAuxHeader::deserialize(remaining)?;
+            aux_header = Some(unwrapped_aux_header);
         }
 
+        Ok(Self {
+            nwk_header: nwk_header,
+            aux_header: aux_header,
+            ciphertext: remaining.to_vec(),
+        })
+    }
+
+    pub fn to_bytes(&self) -> Vec<u8> {
+        let mut bytes = Vec::new();
+
+        bytes.extend(self.nwk_header.to_bytes());
+
+        if let Some(aux_header) = &self.aux_header {
+            bytes.extend(aux_header.to_bytes());
+        }
+
+        bytes.extend(self.ciphertext.clone());
+
+        bytes
+    }
+
+    pub fn decrypt(&self, key: &Key) -> Result<DecryptedNwkFrame, NwkDecryptionError> {
         let crypto = self.get_crypto();
 
         let aux_header = self.get_modified_aux_header(NwkSecurityLevel::EncMic32);
         let nonce = self.get_nonce(&aux_header);
-        let (ciphertext, encrypted_mac_tag) = crypto.split_mac_tag(&self.payload);
+        let (ciphertext, encrypted_mac_tag) = crypto.split_mac_tag(&self.ciphertext);
         let (provided_mac_tag, plaintext) =
             crypto.encrypt_decrypt(key, &nonce, &encrypted_mac_tag, &ciphertext);
         let mac_tag = crypto.compute_mac(&self, key, &plaintext, &aux_header, &nonce);
 
         if !constant_time_eq(&provided_mac_tag, &mac_tag) {
-            return Err("Decryption failed, invalid MAC tag");
+            return Err(NwkDecryptionError::InvalidMacTag);
         }
 
-        Ok(Self {
+        Ok(DecryptedNwkFrame {
             nwk_header: self.nwk_header.clone(),
             aux_header: self.aux_header.clone(),
-            payload: plaintext,
-            encrypted: false,
+            plaintext: plaintext,
         })
     }
+}
 
-    pub fn encrypt(&self, key: &Key) -> Result<Self, &'static str> {
-        if self.encrypted {
-            return Err("Cannot encrypt already encrypted frame");
+impl DecryptedNwkFrame {
+    pub fn get_modified_aux_header(&self, nib_security_level: NwkSecurityLevel) -> NwkAuxHeader {
+        if self.aux_header.is_none() {
+            panic!("Auxiliary header is missing");
         }
 
+        let mut aux_header = self.aux_header.clone().unwrap();
+        aux_header.security_control.security_level = nib_security_level;
+
+        aux_header
+    }
+
+    pub fn get_nonce(&self, aux_header: &NwkAuxHeader) -> [u8; 13] {
+        let source;
+
+        if !aux_header.extended_source.is_none() {
+            source = aux_header.extended_source.unwrap();
+        } else if !self.nwk_header.source_ieee.is_none() {
+            source = self.nwk_header.source_ieee.unwrap();
+        } else {
+            // XXX: this can't happen
+            panic!("Cannot compute nonce with no source address");
+        }
+
+        let mut nonce = [0; 13];
+        nonce[..8].copy_from_slice(&source.to_bytes());
+        nonce[8..12].copy_from_slice(&aux_header.frame_counter.to_le_bytes());
+        nonce[12..13].copy_from_slice(&aux_header.security_control.to_abstract_bits().unwrap());
+
+        nonce
+    }
+
+    pub fn get_crypto(&self) -> NwkCrypto<2, 4> {
+        // Only a single configuration is supported but to keep the cryptography code
+        // readable, it's useful to be generic here
+        NwkCrypto::<2, 4>
+    }
+
+    pub fn encrypt(&self, key: &Key) -> EncryptedNwkFrame {
         let crypto = self.get_crypto();
 
         let aux_header = self.get_modified_aux_header(NwkSecurityLevel::EncMic32);
         let nonce = self.get_nonce(&aux_header);
-        let plaintext = &self.payload;
+        let plaintext = &self.plaintext;
 
         let mac_tag = crypto.compute_mac(&self, key, &plaintext, &aux_header, &nonce);
         let (encrypted_mac_tag, ciphertext) =
             crypto.encrypt_decrypt(key, &nonce, &mac_tag, &plaintext);
 
-        let mut payload = ciphertext;
-        payload.extend(encrypted_mac_tag);
+        let mut ciphertext_with_tag = ciphertext;
+        ciphertext_with_tag.extend(encrypted_mac_tag);
 
-        Ok(Self {
+        EncryptedNwkFrame {
             nwk_header: self.nwk_header.clone(),
             aux_header: self.aux_header.clone(),
-            payload: payload,
-            encrypted: true,
-        })
+            ciphertext: ciphertext_with_tag,
+        }
     }
 }
 
@@ -536,10 +577,9 @@ mod test {
     fn test_nwk_decryption_unicast() {
         let bytes =
             hex!("0802426b00000f2e287a0a0000a8ef171e004b120000f7a7e37b47adb47593c8a375c98ba6");
-        let nwk_frame = NwkFrame::from_bytes(&bytes).unwrap();
+        let nwk_frame = EncryptedNwkFrame::from_bytes(&bytes).unwrap();
 
-        let expected_nwk_frame = NwkFrame {
-            encrypted: true,
+        let expected_nwk_frame = EncryptedNwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
@@ -572,7 +612,7 @@ mod test {
                 extended_source: Some(Eui64::from_hex("00:12:4b:00:1e:17:ef:a8")),
                 key_sequence_number: 0,
             }),
-            payload: hex!("f7a7e37b47adb47593c8a375c98ba6").to_vec(),
+            ciphertext: hex!("f7a7e37b47adb47593c8a375c98ba6").to_vec(),
         };
 
         assert_eq!(nwk_frame, expected_nwk_frame);
@@ -580,17 +620,16 @@ mod test {
         let key = Key::from_hex("e8785a1ed5996b3ef715cb3fbdd69187");
         let decrypted_nwk_frame = nwk_frame.decrypt(&key).unwrap();
 
-        let expected_decrypted_nwk_frame = NwkFrame {
-            encrypted: false,
+        let expected_decrypted_nwk_frame = DecryptedNwkFrame {
             nwk_header: expected_nwk_frame.nwk_header,
             aux_header: expected_nwk_frame.aux_header,
-            payload: hex!("00010600040101a9015701").to_vec(),
+            plaintext: hex!("00010600040101a9015701").to_vec(),
         };
 
         assert_eq!(decrypted_nwk_frame, expected_decrypted_nwk_frame);
 
         // Make sure encryption is round trip
-        let re_encrypted_nwk_frame = decrypted_nwk_frame.encrypt(&key).unwrap();
+        let re_encrypted_nwk_frame = decrypted_nwk_frame.encrypt(&key);
         assert_eq!(nwk_frame.to_bytes(), bytes);
         assert_eq!(re_encrypted_nwk_frame, nwk_frame);
         assert_eq!(re_encrypted_nwk_frame.to_bytes(), bytes);
@@ -600,10 +639,9 @@ mod test {
     fn test_source_route() {
         let bytes =
             hex!("0806e73c375f1dcc010039f9287ea30000023c710c01881700000b73db5468c7cbc47caf8705");
-        let nwk_frame = NwkFrame::from_bytes(&bytes).unwrap();
+        let nwk_frame = EncryptedNwkFrame::from_bytes(&bytes).unwrap();
 
-        let expected_nwk_frame = NwkFrame {
-            encrypted: true,
+        let expected_nwk_frame = EncryptedNwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
@@ -639,7 +677,7 @@ mod test {
                 extended_source: Some(Eui64::from_hex("00:17:88:01:0c:71:3c:02")),
                 key_sequence_number: 0,
             }),
-            payload: hex!("0b73db5468c7cbc47caf8705").to_vec(),
+            ciphertext: hex!("0b73db5468c7cbc47caf8705").to_vec(),
         };
 
         assert_eq!(nwk_frame, expected_nwk_frame);
@@ -647,17 +685,16 @@ mod test {
         let key = Key::from_hex("31908c7c51c2f01552bc90cc16e5443d");
         let decrypted_nwk_frame = nwk_frame.decrypt(&key).unwrap();
 
-        let expected_decrypted_nwk_frame = NwkFrame {
-            encrypted: false,
+        let expected_decrypted_nwk_frame = DecryptedNwkFrame {
             nwk_header: expected_nwk_frame.nwk_header,
             aux_header: expected_nwk_frame.aux_header,
-            payload: hex!("020106000401405b").to_vec(),
+            plaintext: hex!("020106000401405b").to_vec(),
         };
 
         assert_eq!(decrypted_nwk_frame, expected_decrypted_nwk_frame);
 
         // Make sure encryption is round trip
-        let re_encrypted_nwk_frame = decrypted_nwk_frame.encrypt(&key).unwrap();
+        let re_encrypted_nwk_frame = decrypted_nwk_frame.encrypt(&key);
         assert_eq!(nwk_frame.to_bytes(), bytes);
         assert_eq!(re_encrypted_nwk_frame, nwk_frame);
         assert_eq!(re_encrypted_nwk_frame.to_bytes(), bytes);

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -411,7 +411,7 @@ pub struct NwkFrame {
     pub nwk_header: NwkHeader,
     pub aux_header: Option<NwkAuxHeader>,
     #[derivative(Debug(format_with = "format_hex"))]
-    pub plaintext: Vec<u8>,
+    pub payload: Vec<u8>,
 }
 
 impl EncryptedNwkFrame {
@@ -503,7 +503,7 @@ impl EncryptedNwkFrame {
         Ok(NwkFrame {
             nwk_header: self.nwk_header.clone(),
             aux_header: self.aux_header.clone(),
-            plaintext: plaintext,
+            payload: plaintext,
         })
     }
 }
@@ -623,7 +623,7 @@ mod test {
         let expected_decrypted_nwk_frame = NwkFrame {
             nwk_header: expected_nwk_frame.nwk_header,
             aux_header: expected_nwk_frame.aux_header,
-            plaintext: hex!("00010600040101a9015701").to_vec(),
+            payload: hex!("00010600040101a9015701").to_vec(),
         };
 
         assert_eq!(decrypted_nwk_frame, expected_decrypted_nwk_frame);
@@ -688,7 +688,7 @@ mod test {
         let expected_decrypted_nwk_frame = NwkFrame {
             nwk_header: expected_nwk_frame.nwk_header,
             aux_header: expected_nwk_frame.aux_header,
-            plaintext: hex!("020106000401405b").to_vec(),
+            payload: hex!("020106000401405b").to_vec(),
         };
 
         assert_eq!(decrypted_nwk_frame, expected_decrypted_nwk_frame);

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use abstract_bits::AbstractBits;
 use abstract_bits::abstract_bits;
 use ieee_802154::types::{Eui64, Key, Nwk, format_hex};

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -317,14 +317,14 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
 
     pub fn compute_mac(
         &self,
-        frame: &NwkFrame,
+        nwk_header: &NwkHeader,
         key: &Key,
         plaintext: &[u8],
         aux_header: &NwkAuxHeader,
         nonce: &[u8; 13],
     ) -> [u8; M] {
         let mut auth_data = Vec::new();
-        auth_data.extend(frame.nwk_header.to_bytes());
+        auth_data.extend(nwk_header.to_bytes());
         auth_data.extend(aux_header.to_bytes());
 
         let encoded_auth_data_len = auth_data.len().to_be_bytes();
@@ -494,7 +494,7 @@ impl EncryptedNwkFrame {
         let (ciphertext, encrypted_mac_tag) = crypto.split_mac_tag(&self.ciphertext);
         let (provided_mac_tag, plaintext) =
             crypto.encrypt_decrypt(key, &nonce, &encrypted_mac_tag, &ciphertext);
-        let mac_tag = crypto.compute_mac(&self, key, &plaintext, &aux_header, &nonce);
+        let mac_tag = crypto.compute_mac(&self.nwk_header, key, &plaintext, &aux_header, &nonce);
 
         if !constant_time_eq(&provided_mac_tag, &mac_tag) {
             return Err(NwkDecryptionError::InvalidMacTag);
@@ -551,9 +551,9 @@ impl NwkFrame {
 
         let aux_header = self.get_modified_aux_header(NwkSecurityLevel::EncMic32);
         let nonce = self.get_nonce(&aux_header);
-        let plaintext = &self.plaintext;
+        let plaintext = &self.payload;
 
-        let mac_tag = crypto.compute_mac(&self, key, &plaintext, &aux_header, &nonce);
+        let mac_tag = crypto.compute_mac(&self.nwk_header, key, &plaintext, &aux_header, &nonce);
         let (encrypted_mac_tag, ciphertext) =
             crypto.encrypt_decrypt(key, &nonce, &mac_tag, &plaintext);
 

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -407,7 +407,7 @@ pub struct EncryptedNwkFrame {
 
 #[derive(Derivative)]
 #[derivative(Debug, Clone, PartialEq)]
-pub struct DecryptedNwkFrame {
+pub struct NwkFrame {
     pub nwk_header: NwkHeader,
     pub aux_header: Option<NwkAuxHeader>,
     #[derivative(Debug(format_with = "format_hex"))]
@@ -486,7 +486,7 @@ impl EncryptedNwkFrame {
         bytes
     }
 
-    pub fn decrypt(&self, key: &Key) -> Result<DecryptedNwkFrame, NwkDecryptionError> {
+    pub fn decrypt(&self, key: &Key) -> Result<NwkFrame, NwkDecryptionError> {
         let crypto = self.get_crypto();
 
         let aux_header = self.get_modified_aux_header(NwkSecurityLevel::EncMic32);
@@ -500,7 +500,7 @@ impl EncryptedNwkFrame {
             return Err(NwkDecryptionError::InvalidMacTag);
         }
 
-        Ok(DecryptedNwkFrame {
+        Ok(NwkFrame {
             nwk_header: self.nwk_header.clone(),
             aux_header: self.aux_header.clone(),
             plaintext: plaintext,
@@ -508,7 +508,7 @@ impl EncryptedNwkFrame {
     }
 }
 
-impl DecryptedNwkFrame {
+impl NwkFrame {
     pub fn get_modified_aux_header(&self, nib_security_level: NwkSecurityLevel) -> NwkAuxHeader {
         if self.aux_header.is_none() {
             panic!("Auxiliary header is missing");
@@ -620,7 +620,7 @@ mod test {
         let key = Key::from_hex("e8785a1ed5996b3ef715cb3fbdd69187");
         let decrypted_nwk_frame = nwk_frame.decrypt(&key).unwrap();
 
-        let expected_decrypted_nwk_frame = DecryptedNwkFrame {
+        let expected_decrypted_nwk_frame = NwkFrame {
             nwk_header: expected_nwk_frame.nwk_header,
             aux_header: expected_nwk_frame.aux_header,
             plaintext: hex!("00010600040101a9015701").to_vec(),
@@ -685,7 +685,7 @@ mod test {
         let key = Key::from_hex("31908c7c51c2f01552bc90cc16e5443d");
         let decrypted_nwk_frame = nwk_frame.decrypt(&key).unwrap();
 
-        let expected_decrypted_nwk_frame = DecryptedNwkFrame {
+        let expected_decrypted_nwk_frame = NwkFrame {
             nwk_header: expected_nwk_frame.nwk_header,
             aux_header: expected_nwk_frame.aux_header,
             plaintext: hex!("020106000401405b").to_vec(),

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -3,7 +3,7 @@ use crate::ieee_802154::{
     Ieee802154FrameType,
 };
 use crate::spinel::{SpinelFramePropValueIs, SpinelPropertyId, SpinelStatus};
-use crate::spinel_client::{SpinelClient, SpinelRxFrame, SpinelTxFrame};
+use crate::spinel_client::{SpinelClient, SpinelError, SpinelRxFrame, SpinelTxFrame};
 use crate::zigbee_aps::{
     ApsAckFrame, ApsAckFrameControl, ApsDataFrame, ApsDeliveryMode, ApsFrame, ApsFrameControl,
     ApsFrameType, parse_aps_frame,
@@ -15,6 +15,8 @@ use crate::zigbee_nwk::{
 };
 use ieee_802154::types::{Eui64, Key, Nwk, PanId};
 
+use thiserror::Error;
+use tokio::time::error::Elapsed;
 use tokio::time::timeout;
 use zigbee_parts::Command;
 use zigbee_parts::commands::{
@@ -33,6 +35,8 @@ use tokio::time::{Duration, Instant};
 mod neighbor;
 mod route;
 
+const APS_ACK_TIMEOUT: Duration = Duration::from_millis(5000);
+
 // The number of the most recent samples taken into consideration SHOULD be n = 3, which
 // eliminates single outliers maintains a fast response to real changes in link quality,
 // and keeps memory requirements to a minimum.
@@ -50,6 +54,24 @@ fn lqi_to_link_cost(lqi: u8) -> u8 {
         193..=255 => 1,
         // 0 corresponds to "unknown LQI"
     }
+}
+
+#[derive(Error, Debug)]
+pub enum ZigbeeStackError {
+    #[error("route discovery timed out")]
+    RouteDiscoveryTimeout(#[from] Elapsed),
+    #[error("route discovery unexpectedly failed: {0}")]
+    RouteDiscoveryFailure(String),
+    #[error("next hop {next_hop:?} did not ACK")]
+    NwkNoAck { next_hop: Nwk },
+    #[error("transmit rejected due to CCA failure")]
+    CcaFailure,
+    #[error("unexpected transmit failure: {0:?}")]
+    SpinelTransmitFailure(SpinelStatus),
+    #[error("aps ack timeout")]
+    ApsAckTimeout,
+    #[error("spinel error: {0}")]
+    SpinelError(#[from] SpinelError),
 }
 
 #[derive(Debug)]
@@ -557,7 +579,7 @@ impl ZigbeeStack {
         key: Key,
         key_seq_number: u8,
         outgoing_frame_counter: u32,
-    ) -> Result<(), String> {
+    ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
         state.channel = nwk_channel;
         state.nib.nwk_update_id = nwk_update_id;
@@ -576,17 +598,17 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(SpinelPropertyId::PhyEnabled, vec![true as u8])
             .await
-            .expect("Failed to enable the PHY");
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
             .prop_value_set(SpinelPropertyId::PhyChan, vec![nwk_channel])
             .await
-            .map_err(|e| format!("Failed to set PHY channel: {:?}", e))?;
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
             .prop_value_set(SpinelPropertyId::PhyTxPower, vec![8])
             .await
-            .map_err(|e| format!("Failed to set PHY TX power: {:?}", e))?;
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         /*
         self.spinel
@@ -595,7 +617,7 @@ impl ZigbeeStack {
                 vec![SpinelMacPromiscuousMode::Full as u8],
             )
             .await
-            .expect("Failed to set the MAC promiscuous mode");
+            .map_err(ZigbeeStackError::SpinelError)?;
         */
 
         self.spinel
@@ -604,7 +626,7 @@ impl ZigbeeStack {
                 state.nib.nwk_ieee_address.to_bytes().to_vec(),
             )
             .await
-            .map_err(|e| format!("Failed to set MAC IEEE address: {:?}", e))?;
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
             .prop_value_set(
@@ -612,7 +634,7 @@ impl ZigbeeStack {
                 state.nib.nwk_network_address.to_bytes().to_vec(),
             )
             .await
-            .map_err(|e| format!("Failed to set MAC NWK address: {:?}", e))?;
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
             .prop_value_set(
@@ -620,17 +642,17 @@ impl ZigbeeStack {
                 state.nib.nwk_pan_id.to_bytes().to_vec(),
             )
             .await
-            .map_err(|e| format!("Failed to set MAC PAN ID: {:?}", e))?;
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
             .prop_value_set(SpinelPropertyId::MacRxOnWhenIdleMode, vec![true as u8])
             .await
-            .expect("Failed to set RX on when idle");
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
             .prop_value_set(SpinelPropertyId::MacRawStreamEnabled, vec![true as u8])
             .await
-            .expect("Failed to enable the RAW stream");
+            .map_err(ZigbeeStackError::SpinelError)?;
 
         // This is treated as the start time of the stack
         state.start_time = Some(Instant::now());
@@ -1673,7 +1695,7 @@ impl ZigbeeStack {
         self.background_send_nwk_frame(state, aps_ack_frame);
     }
 
-    async fn send_802154_frame(&self, mut frame: Ieee802154Frame) -> Result<(), String> {
+    async fn send_802154_frame(&self, mut frame: Ieee802154Frame) -> Result<(), ZigbeeStackError> {
         // Briefly grab the channel when sending, we don't want to hold the lock while
         // waiting for an ACK
         let mut state = self.state.lock().unwrap();
@@ -1719,11 +1741,17 @@ impl ZigbeeStack {
         if status == SpinelStatus::Ok {
             return Ok(());
         } else if status == SpinelStatus::NoAck {
-            return Err("No ACK".to_string());
+            let next_hop = match frame.dest_address.unwrap() {
+                Ieee802154Address::Nwk(nwk) => Some(nwk),
+                _ => None,
+            }
+            .expect("Next 802.15.4. hop must have NWK addressing");
+
+            return Err(ZigbeeStackError::NwkNoAck { next_hop: next_hop });
         } else if status == SpinelStatus::CcaFailure {
-            return Err("CCA failure".to_string());
+            return Err(ZigbeeStackError::CcaFailure);
         } else {
-            return Err("Unknown failure: {status:#?}".to_string());
+            return Err(ZigbeeStackError::SpinelTransmitFailure(status));
         }
     }
 
@@ -1937,7 +1965,7 @@ impl ZigbeeStack {
                 .outgoing_frame_counter;
 
             let encrypted_nwk_frame =
-                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key)?;
+                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -2068,7 +2096,9 @@ impl ZigbeeStack {
                     Some(entry) => entry,
                     None => {
                         log::warn!("No route discovery entry found for {destination:?}");
-                        return Err("No route discovery entry found".to_string());
+                        return Err(ZigbeeStackError::RouteDiscoveryFailure(
+                            "No discovery entry found".to_string(),
+                        ));
                     }
                 };
 
@@ -2080,22 +2110,15 @@ impl ZigbeeStack {
         );
 
         match timeout(discovery_timeout, rx.recv()).await {
-            Ok(Ok(_)) => {
+            Ok(_) => {
                 log::debug!("Route discovery completed for NWK {destination:#?}");
             }
-            Ok(Err(_)) => {
+            Err(err) => {
                 log::debug!("Route discovery timed out");
                 let mut state = self.state.lock().unwrap();
                 let entry = state.nib.nwk_route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
-                return Err("Route discovery timed out".to_string());
-            }
-            Err(_) => {
-                log::debug!("Route discovery timed out");
-                let mut state = self.state.lock().unwrap();
-                let entry = state.nib.nwk_route_table.get_mut(&destination).unwrap();
-                entry.status = route::Status::DiscoveryFailed;
-                return Err("Route discovery timed out".to_string());
+                return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
             }
         };
 
@@ -2239,7 +2262,7 @@ impl ZigbeeStack {
         radius: u8,
         aps_seq: u8,
         data: Vec<u8>,
-    ) -> Result<(), String> {
+    ) -> Result<(), ZigbeeStackError> {
         let aps_frame = match delivery_mode {
             ApsDeliveryMode::Unicast => ApsDataFrame {
                 frame_control: ApsFrameControl {
@@ -2325,40 +2348,39 @@ impl ZigbeeStack {
 
         log::debug!("Prepared NWK frame: {:#?}", nwk_frame);
 
-        let mut maybe_ack_rx = None;
-
-        if aps_ack {
-            let ack_data = ApsAckData {
-                src: destination,
-                destination_endpoint: Some(src_ep), // These are swapped
-                cluster_id: Some(cluster_id),
-                profile_id: Some(profile_id),
-                source_endpoint: Some(dst_ep), // These are swapped
-                counter: aps_seq,
-            };
-
-            let (tx, rx) = oneshot::channel();
-            maybe_ack_rx = Some(rx);
-
-            log::debug!("APS ACK requested, waiting for {:?}", ack_data);
-            state.pending_aps_acks.insert(ack_data, tx);
+        if !aps_ack {
+            self.background_send_nwk_frame(state, nwk_frame);
+            return Ok(());
         }
+
+        let ack_data = ApsAckData {
+            src: destination,
+            destination_endpoint: Some(src_ep), // These are swapped
+            cluster_id: Some(cluster_id),
+            profile_id: Some(profile_id),
+            source_endpoint: Some(dst_ep), // These are swapped
+            counter: aps_seq,
+        };
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+
+        log::debug!("APS ACK requested, waiting for {:?}", ack_data);
+        state.pending_aps_acks.insert(ack_data, ack_tx);
 
         self.background_send_nwk_frame(state, nwk_frame);
 
-        if let Some(ack_rx) = maybe_ack_rx {
-            // With a 5s timeout
-            let aps_ack_timeout = Duration::from_secs(5);
-            match tokio::time::timeout(aps_ack_timeout, ack_rx).await {
-                Ok(Ok(())) => {
-                    log::info!("APS ACK received");
-                }
-                Ok(Err(e)) => {
-                    log::warn!("APS ACK channel hung up: {:?}", e);
-                }
-                Err(_) => {
-                    log::warn!("APS ACK timed out");
-                }
+        // With a 5s timeout
+        match tokio::time::timeout(APS_ACK_TIMEOUT, ack_rx).await {
+            Ok(Ok(())) => {
+                log::info!("APS ACK received");
+            }
+            Ok(Err(e)) => {
+                log::warn!("APS ACK channel hung up: {:?}", e);
+                return Err(ZigbeeStackError::ApsAckTimeout);
+            }
+            Err(_) => {
+                log::warn!("APS ACK timed out");
+                return Err(ZigbeeStackError::ApsAckTimeout);
             }
         }
 

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -9,8 +9,8 @@ use crate::zigbee_aps::{
     ApsFrameType, parse_aps_frame,
 };
 use crate::zigbee_nwk::{
-    BROADCAST_ALL_ROUTERS_AND_COORDINATOR, BROADCAST_LOW_POWER_ROUTERS, DecryptedNwkFrame,
-    EncryptedNwkFrame, NwkAuxHeader, NwkFrameControl, NwkFrameType, NwkHeader, NwkRouteDiscovery,
+    BROADCAST_ALL_ROUTERS_AND_COORDINATOR, BROADCAST_LOW_POWER_ROUTERS, EncryptedNwkFrame,
+    NwkAuxHeader, NwkFrame, NwkFrameControl, NwkFrameType, NwkHeader, NwkRouteDiscovery,
     NwkSecurityHeaderControlField, NwkSecurityHeaderKeyId, NwkSecurityLevel,
 };
 use ieee_802154::types::{Eui64, Key, Nwk, PanId};
@@ -659,7 +659,7 @@ impl ZigbeeStack {
         frame: &Ieee802154Frame,
         lqi: u8,
         rssi: i8,
-    ) -> Option<DecryptedNwkFrame> {
+    ) -> Option<NwkFrame> {
         let state = self.state.lock().unwrap();
 
         // 802.15.4 encrypted frames can't be Zigbee NWK
@@ -827,7 +827,7 @@ impl ZigbeeStack {
     }
 
     /// Filter broadcast frames based on the NWK broadcast transaction table
-    pub fn filter_broadcast(&self, nwk_frame: &DecryptedNwkFrame) -> bool {
+    pub fn filter_broadcast(&self, nwk_frame: &NwkFrame) -> bool {
         let now = Instant::now();
         let mut state = self.state.lock().unwrap();
         let broadcast_delivery_time = state.nib.nwkc_broadcast_delivery_time;
@@ -866,13 +866,7 @@ impl ZigbeeStack {
         return false;
     }
 
-    pub fn handle_decrypted_frame(
-        &self,
-        nwk_frame: &DecryptedNwkFrame,
-        sender_nwk: Nwk,
-        lqi: u8,
-        rssi: i8,
-    ) {
+    pub fn handle_decrypted_frame(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk, lqi: u8, rssi: i8) {
         // Update the frame counter for the relaying device
         if let Some(aux_header) = &nwk_frame.aux_header {
             match aux_header.extended_source {
@@ -955,13 +949,7 @@ impl ZigbeeStack {
         }
     }
 
-    fn maybe_recompute_lqa(
-        &self,
-        state: &mut State,
-        nwk_frame: &DecryptedNwkFrame,
-        lqi: u8,
-        _rssi: i8,
-    ) {
+    fn maybe_recompute_lqa(&self, state: &mut State, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
         // Find the source node via its EUI64 address (preferred) or its NWK address
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             state
@@ -1006,7 +994,7 @@ impl ZigbeeStack {
         }
     }
 
-    fn handle_link_status(&self, nwk_frame: &DecryptedNwkFrame) {
+    fn handle_link_status(&self, nwk_frame: &NwkFrame) {
         let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.plaintext) {
             Ok(cmd) => cmd,
             Err(e) => {
@@ -1130,7 +1118,7 @@ impl ZigbeeStack {
         let _ = tx.send(());
     }
 
-    fn handle_route_reply(&self, nwk_frame: &DecryptedNwkFrame) {
+    fn handle_route_reply(&self, nwk_frame: &NwkFrame) {
         let route_reply_cmd = match NwkRouteReplyCommand::deserialize(&nwk_frame.plaintext) {
             Ok(cmd) => cmd,
             Err(e) => {
@@ -1318,7 +1306,7 @@ impl ZigbeeStack {
             return;
         };
 
-        let relayed_route_reply_frame = DecryptedNwkFrame {
+        let relayed_route_reply_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
@@ -1382,7 +1370,7 @@ impl ZigbeeStack {
         });
     }
 
-    fn handle_route_request(&self, nwk_frame: &DecryptedNwkFrame, sender_nwk: Nwk) {
+    fn handle_route_request(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk) {
         let route_request_cmd = match NwkRouteRequestCommand::deserialize(&nwk_frame.plaintext) {
             Ok(cmd) => cmd,
             Err(e) => {
@@ -1561,7 +1549,7 @@ impl ZigbeeStack {
                 return;
             }
 
-            let relayed_route_request_cmd = DecryptedNwkFrame {
+            let relayed_route_request_cmd = NwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
@@ -1597,7 +1585,7 @@ impl ZigbeeStack {
 
             self.background_send_nwk_frame(state, relayed_route_request_cmd);
         } else {
-            let route_reply_frame = DecryptedNwkFrame {
+            let route_reply_frame = NwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
@@ -1636,11 +1624,11 @@ impl ZigbeeStack {
         }
     }
 
-    fn handle_aps_ack_request(&self, aps_frame: &ApsDataFrame, nwk_frame: &DecryptedNwkFrame) {
+    fn handle_aps_ack_request(&self, aps_frame: &ApsDataFrame, nwk_frame: &NwkFrame) {
         log::debug!("Sending back an APS ACK");
 
         let state = self.state.lock().unwrap();
-        let aps_ack_frame = DecryptedNwkFrame {
+        let aps_ack_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
@@ -1759,10 +1747,7 @@ impl ZigbeeStack {
         });
     }
 
-    pub async fn send_nwk_frame(
-        &self,
-        nwk_frame: DecryptedNwkFrame,
-    ) -> Result<(), ZigbeeStackError> {
+    pub async fn send_nwk_frame(&self, nwk_frame: NwkFrame) -> Result<(), ZigbeeStackError> {
         if nwk_frame.nwk_header.destination.as_u16() >= BROADCAST_LOW_POWER_ROUTERS.as_u16() {
             self.send_broadcast_nwk_frame(nwk_frame).await
         } else {
@@ -1772,7 +1757,7 @@ impl ZigbeeStack {
 
     pub async fn send_unicast_nwk_frame(
         &self,
-        mut nwk_frame: DecryptedNwkFrame,
+        mut nwk_frame: NwkFrame,
     ) -> Result<(), ZigbeeStackError> {
         // Compute a next-hop address
         let next_hop_address = self
@@ -1910,7 +1895,7 @@ impl ZigbeeStack {
 
     pub async fn send_broadcast_nwk_frame(
         &self,
-        mut nwk_frame: DecryptedNwkFrame,
+        mut nwk_frame: NwkFrame,
     ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
 
@@ -2205,7 +2190,7 @@ impl ZigbeeStack {
             }
         });
 
-        let route_request_frame = DecryptedNwkFrame {
+        let route_request_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
@@ -2312,7 +2297,7 @@ impl ZigbeeStack {
         log::debug!("Prepared APS frame: {:#?}", aps_frame);
 
         let mut state = self.state.lock().unwrap();
-        let nwk_frame = DecryptedNwkFrame {
+        let nwk_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
@@ -2439,7 +2424,7 @@ impl ZigbeeStack {
 
             state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
 
-            let link_status_frame = DecryptedNwkFrame {
+            let link_status_frame = NwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -9,9 +9,9 @@ use crate::zigbee_aps::{
     ApsFrameType, parse_aps_frame,
 };
 use crate::zigbee_nwk::{
-    BROADCAST_ALL_ROUTERS_AND_COORDINATOR, BROADCAST_LOW_POWER_ROUTERS, NwkAuxHeader, NwkFrame,
-    NwkFrameControl, NwkFrameType, NwkHeader, NwkRouteDiscovery, NwkSecurityHeaderControlField,
-    NwkSecurityHeaderKeyId, NwkSecurityLevel,
+    BROADCAST_ALL_ROUTERS_AND_COORDINATOR, BROADCAST_LOW_POWER_ROUTERS, DecryptedNwkFrame,
+    EncryptedNwkFrame, NwkAuxHeader, NwkFrameControl, NwkFrameType, NwkHeader, NwkRouteDiscovery,
+    NwkSecurityHeaderControlField, NwkSecurityHeaderKeyId, NwkSecurityLevel,
 };
 use ieee_802154::types::{Eui64, Key, Nwk, PanId};
 
@@ -462,7 +462,7 @@ impl ZigbeeStack {
                         continue;
                     }
 
-                    let aps_frame = match parse_aps_frame(&nwk_frame.payload) {
+                    let aps_frame = match parse_aps_frame(&nwk_frame.plaintext) {
                         Ok(ApsFrame::Data(data)) => data,
                         Ok(ApsFrame::Ack(ack)) => {
                             let ack_data =
@@ -659,7 +659,7 @@ impl ZigbeeStack {
         frame: &Ieee802154Frame,
         lqi: u8,
         rssi: i8,
-    ) -> Option<NwkFrame> {
+    ) -> Option<DecryptedNwkFrame> {
         let state = self.state.lock().unwrap();
 
         // 802.15.4 encrypted frames can't be Zigbee NWK
@@ -698,7 +698,7 @@ impl ZigbeeStack {
         }
 
         // Next, try to parse the NWK frame
-        let nwk_frame = match NwkFrame::from_bytes(&frame.payload) {
+        let nwk_frame = match EncryptedNwkFrame::from_bytes(&frame.payload) {
             Ok(nwk_frame) => nwk_frame,
             Err(_) => {
                 log::debug!("Ignoring frame, not a NWK frame");
@@ -716,7 +716,7 @@ impl ZigbeeStack {
         }
 
         // Ignore unencrypted frames
-        if !nwk_frame.encrypted {
+        if !nwk_frame.nwk_header.frame_control.security {
             log::debug!("Ignoring frame, it is not encrypted");
             return None;
         }
@@ -827,7 +827,7 @@ impl ZigbeeStack {
     }
 
     /// Filter broadcast frames based on the NWK broadcast transaction table
-    pub fn filter_broadcast(&self, nwk_frame: &NwkFrame) -> bool {
+    pub fn filter_broadcast(&self, nwk_frame: &DecryptedNwkFrame) -> bool {
         let now = Instant::now();
         let mut state = self.state.lock().unwrap();
         let broadcast_delivery_time = state.nib.nwkc_broadcast_delivery_time;
@@ -866,7 +866,13 @@ impl ZigbeeStack {
         return false;
     }
 
-    pub fn handle_decrypted_frame(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk, lqi: u8, rssi: i8) {
+    pub fn handle_decrypted_frame(
+        &self,
+        nwk_frame: &DecryptedNwkFrame,
+        sender_nwk: Nwk,
+        lqi: u8,
+        rssi: i8,
+    ) {
         // Update the frame counter for the relaying device
         if let Some(aux_header) = &nwk_frame.aux_header {
             match aux_header.extended_source {
@@ -910,7 +916,7 @@ impl ZigbeeStack {
 
         // Handle NWK commands
         if nwk_frame.nwk_header.frame_control.frame_type == NwkFrameType::Command {
-            match NwkCommandId::try_from(nwk_frame.payload[0]) {
+            match NwkCommandId::try_from(nwk_frame.plaintext[0]) {
                 Ok(NwkCommandId::LinkStatus) => {
                     // TODO: Error handling for decoding?
                     log::info!("Link status command frame received");
@@ -924,7 +930,7 @@ impl ZigbeeStack {
                 Ok(NwkCommandId::RouteRecord) => {
                     // TODO: Error handling for decoding?
                     let route_record_cmd =
-                        NwkRouteRecordCommand::deserialize(&nwk_frame.payload).unwrap();
+                        NwkRouteRecordCommand::deserialize(&nwk_frame.plaintext).unwrap();
                     log::info!(
                         "Route record command frame received: {:#?}",
                         route_record_cmd
@@ -940,16 +946,22 @@ impl ZigbeeStack {
                     self.handle_route_request(nwk_frame, sender_nwk);
                 }
                 Err(_) => {
-                    log::warn!("Unknown NWK command: {}", nwk_frame.payload[0]);
+                    log::warn!("Unknown NWK command: {}", nwk_frame.plaintext[0]);
                 }
                 _ => {
-                    log::warn!("Unhandled NWK command: {:?}", nwk_frame.payload[0]);
+                    log::warn!("Unhandled NWK command: {:?}", nwk_frame.plaintext[0]);
                 }
             }
         }
     }
 
-    fn maybe_recompute_lqa(&self, state: &mut State, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
+    fn maybe_recompute_lqa(
+        &self,
+        state: &mut State,
+        nwk_frame: &DecryptedNwkFrame,
+        lqi: u8,
+        _rssi: i8,
+    ) {
         // Find the source node via its EUI64 address (preferred) or its NWK address
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             state
@@ -994,8 +1006,8 @@ impl ZigbeeStack {
         }
     }
 
-    fn handle_link_status(&self, nwk_frame: &NwkFrame) {
-        let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.payload) {
+    fn handle_link_status(&self, nwk_frame: &DecryptedNwkFrame) {
+        let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.plaintext) {
             Ok(cmd) => cmd,
             Err(e) => {
                 log::warn!("Error parsing link status command: {e:?}");
@@ -1118,8 +1130,8 @@ impl ZigbeeStack {
         let _ = tx.send(());
     }
 
-    fn handle_route_reply(&self, nwk_frame: &NwkFrame) {
-        let route_reply_cmd = match NwkRouteReplyCommand::deserialize(&nwk_frame.payload) {
+    fn handle_route_reply(&self, nwk_frame: &DecryptedNwkFrame) {
+        let route_reply_cmd = match NwkRouteReplyCommand::deserialize(&nwk_frame.plaintext) {
             Ok(cmd) => cmd,
             Err(e) => {
                 log::warn!("Error parsing route reply command: {e:?}");
@@ -1306,8 +1318,7 @@ impl ZigbeeStack {
             return;
         };
 
-        let relayed_route_reply_frame = NwkFrame {
-            encrypted: false,
+        let relayed_route_reply_frame = DecryptedNwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
@@ -1371,8 +1382,8 @@ impl ZigbeeStack {
         });
     }
 
-    fn handle_route_request(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk) {
-        let route_request_cmd = match NwkRouteRequestCommand::deserialize(&nwk_frame.payload) {
+    fn handle_route_request(&self, nwk_frame: &DecryptedNwkFrame, sender_nwk: Nwk) {
+        let route_request_cmd = match NwkRouteRequestCommand::deserialize(&nwk_frame.plaintext) {
             Ok(cmd) => cmd,
             Err(e) => {
                 log::warn!("Error parsing route request command: {e:?}");
@@ -1550,8 +1561,7 @@ impl ZigbeeStack {
                 return;
             }
 
-            let relayed_route_request_cmd = NwkFrame {
-                encrypted: false,
+            let relayed_route_request_cmd = DecryptedNwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
@@ -1587,8 +1597,7 @@ impl ZigbeeStack {
 
             self.background_send_nwk_frame(state, relayed_route_request_cmd);
         } else {
-            let route_reply_frame = NwkFrame {
-                encrypted: false,
+            let route_reply_frame = DecryptedNwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
@@ -1627,12 +1636,11 @@ impl ZigbeeStack {
         }
     }
 
-    fn handle_aps_ack_request(&self, aps_frame: &ApsDataFrame, nwk_frame: &NwkFrame) {
+    fn handle_aps_ack_request(&self, aps_frame: &ApsDataFrame, nwk_frame: &DecryptedNwkFrame) {
         log::debug!("Sending back an APS ACK");
 
         let state = self.state.lock().unwrap();
-        let aps_ack_frame = NwkFrame {
-            encrypted: false,
+        let aps_ack_frame = DecryptedNwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
@@ -1751,7 +1759,10 @@ impl ZigbeeStack {
         });
     }
 
-    pub async fn send_nwk_frame(&self, nwk_frame: NwkFrame) -> Result<(), String> {
+    pub async fn send_nwk_frame(
+        &self,
+        nwk_frame: DecryptedNwkFrame,
+    ) -> Result<(), ZigbeeStackError> {
         if nwk_frame.nwk_header.destination.as_u16() >= BROADCAST_LOW_POWER_ROUTERS.as_u16() {
             self.send_broadcast_nwk_frame(nwk_frame).await
         } else {
@@ -1759,7 +1770,10 @@ impl ZigbeeStack {
         }
     }
 
-    pub async fn send_unicast_nwk_frame(&self, mut nwk_frame: NwkFrame) -> Result<(), String> {
+    pub async fn send_unicast_nwk_frame(
+        &self,
+        mut nwk_frame: DecryptedNwkFrame,
+    ) -> Result<(), ZigbeeStackError> {
         // Compute a next-hop address
         let next_hop_address = self
             .discover_route(nwk_frame.nwk_header.destination)
@@ -1804,7 +1818,7 @@ impl ZigbeeStack {
                 .outgoing_frame_counter;
 
             let encrypted_nwk_frame =
-                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key)?;
+                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1894,7 +1908,10 @@ impl ZigbeeStack {
         Ok(())
     }
 
-    pub async fn send_broadcast_nwk_frame(&self, mut nwk_frame: NwkFrame) -> Result<(), String> {
+    pub async fn send_broadcast_nwk_frame(
+        &self,
+        mut nwk_frame: DecryptedNwkFrame,
+    ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
 
         state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
@@ -1992,7 +2009,7 @@ impl ZigbeeStack {
         Ok(())
     }
 
-    pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, String> {
+    pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, ZigbeeStackError> {
         let state = self.state.lock().unwrap();
 
         if state.hack_force_route_discovery || !state.nib.nwk_route_table.contains_key(&destination)
@@ -2188,8 +2205,7 @@ impl ZigbeeStack {
             }
         });
 
-        let route_request_frame = NwkFrame {
-            encrypted: false,
+        let route_request_frame = DecryptedNwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
@@ -2296,8 +2312,7 @@ impl ZigbeeStack {
         log::debug!("Prepared APS frame: {:#?}", aps_frame);
 
         let mut state = self.state.lock().unwrap();
-        let nwk_frame = NwkFrame {
-            encrypted: false,
+        let nwk_frame = DecryptedNwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
@@ -2424,8 +2439,7 @@ impl ZigbeeStack {
 
             state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
 
-            let link_status_frame = NwkFrame {
-                encrypted: false,
+            let link_status_frame = DecryptedNwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -462,7 +462,7 @@ impl ZigbeeStack {
                         continue;
                     }
 
-                    let aps_frame = match parse_aps_frame(&nwk_frame.plaintext) {
+                    let aps_frame = match parse_aps_frame(&nwk_frame.payload) {
                         Ok(ApsFrame::Data(data)) => data,
                         Ok(ApsFrame::Ack(ack)) => {
                             let ack_data =
@@ -910,7 +910,7 @@ impl ZigbeeStack {
 
         // Handle NWK commands
         if nwk_frame.nwk_header.frame_control.frame_type == NwkFrameType::Command {
-            match NwkCommandId::try_from(nwk_frame.plaintext[0]) {
+            match NwkCommandId::try_from(nwk_frame.payload[0]) {
                 Ok(NwkCommandId::LinkStatus) => {
                     // TODO: Error handling for decoding?
                     log::info!("Link status command frame received");
@@ -924,7 +924,7 @@ impl ZigbeeStack {
                 Ok(NwkCommandId::RouteRecord) => {
                     // TODO: Error handling for decoding?
                     let route_record_cmd =
-                        NwkRouteRecordCommand::deserialize(&nwk_frame.plaintext).unwrap();
+                        NwkRouteRecordCommand::deserialize(&nwk_frame.payload).unwrap();
                     log::info!(
                         "Route record command frame received: {:#?}",
                         route_record_cmd
@@ -940,10 +940,10 @@ impl ZigbeeStack {
                     self.handle_route_request(nwk_frame, sender_nwk);
                 }
                 Err(_) => {
-                    log::warn!("Unknown NWK command: {}", nwk_frame.plaintext[0]);
+                    log::warn!("Unknown NWK command: {}", nwk_frame.payload[0]);
                 }
                 _ => {
-                    log::warn!("Unhandled NWK command: {:?}", nwk_frame.plaintext[0]);
+                    log::warn!("Unhandled NWK command: {:?}", nwk_frame.payload[0]);
                 }
             }
         }
@@ -995,7 +995,7 @@ impl ZigbeeStack {
     }
 
     fn handle_link_status(&self, nwk_frame: &NwkFrame) {
-        let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.plaintext) {
+        let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
             Err(e) => {
                 log::warn!("Error parsing link status command: {e:?}");
@@ -1119,7 +1119,7 @@ impl ZigbeeStack {
     }
 
     fn handle_route_reply(&self, nwk_frame: &NwkFrame) {
-        let route_reply_cmd = match NwkRouteReplyCommand::deserialize(&nwk_frame.plaintext) {
+        let route_reply_cmd = match NwkRouteReplyCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
             Err(e) => {
                 log::warn!("Error parsing route reply command: {e:?}");
@@ -1371,7 +1371,7 @@ impl ZigbeeStack {
     }
 
     fn handle_route_request(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk) {
-        let route_request_cmd = match NwkRouteRequestCommand::deserialize(&nwk_frame.plaintext) {
+        let route_request_cmd = match NwkRouteRequestCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
             Err(e) => {
                 log::warn!("Error parsing route request command: {e:?}");

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -439,7 +439,7 @@ impl ZigbeeStack {
     pub fn new(spinel: SpinelClient) -> (Arc<Self>, broadcast::Receiver<ZigbeeNotification>) {
         let (notification_tx, notification_rx) = broadcast::channel::<ZigbeeNotification>(32);
         let (raw_frame_tx, raw_frame_rx) = mpsc::channel::<SpinelFramePropValueIs>(32);
-        spinel.set_property_update_receiver(SpinelPropertyId::StreamRaw as u32, raw_frame_tx);
+        spinel.set_property_update_receiver(SpinelPropertyId::StreamRaw, raw_frame_tx);
 
         let arc_stack = Arc::new_cyclic(|weak_self| ZigbeeStack {
             self_weak: weak_self.clone(),
@@ -574,24 +574,24 @@ impl ZigbeeStack {
 
         // Update the hardware with new settings.
         self.spinel
-            .prop_value_set(SpinelPropertyId::PhyEnabled as u32, vec![true as u8])
+            .prop_value_set(SpinelPropertyId::PhyEnabled, vec![true as u8])
             .await
             .expect("Failed to enable the PHY");
 
         self.spinel
-            .prop_value_set(SpinelPropertyId::PhyChan as u32, vec![nwk_channel])
+            .prop_value_set(SpinelPropertyId::PhyChan, vec![nwk_channel])
             .await
             .map_err(|e| format!("Failed to set PHY channel: {:?}", e))?;
 
         self.spinel
-            .prop_value_set(SpinelPropertyId::PhyTxPower as u32, vec![8])
+            .prop_value_set(SpinelPropertyId::PhyTxPower, vec![8])
             .await
             .map_err(|e| format!("Failed to set PHY TX power: {:?}", e))?;
 
         /*
         self.spinel
             .prop_value_set(
-                SpinelPropertyId::MacPromiscuousMode as u32,
+                SpinelPropertyId::MacPromiscuousMode,
                 vec![SpinelMacPromiscuousMode::Full as u8],
             )
             .await
@@ -600,7 +600,7 @@ impl ZigbeeStack {
 
         self.spinel
             .prop_value_set(
-                SpinelPropertyId::Mac154Laddr as u32,
+                SpinelPropertyId::Mac154Laddr,
                 state.nib.nwk_ieee_address.to_bytes().to_vec(),
             )
             .await
@@ -608,7 +608,7 @@ impl ZigbeeStack {
 
         self.spinel
             .prop_value_set(
-                SpinelPropertyId::Mac154Saddr as u32,
+                SpinelPropertyId::Mac154Saddr,
                 state.nib.nwk_network_address.to_bytes().to_vec(),
             )
             .await
@@ -616,25 +616,19 @@ impl ZigbeeStack {
 
         self.spinel
             .prop_value_set(
-                SpinelPropertyId::Mac154Panid as u32,
+                SpinelPropertyId::Mac154Panid,
                 state.nib.nwk_pan_id.to_bytes().to_vec(),
             )
             .await
             .map_err(|e| format!("Failed to set MAC PAN ID: {:?}", e))?;
 
         self.spinel
-            .prop_value_set(
-                SpinelPropertyId::MacRxOnWhenIdleMode as u32,
-                vec![true as u8],
-            )
+            .prop_value_set(SpinelPropertyId::MacRxOnWhenIdleMode, vec![true as u8])
             .await
             .expect("Failed to set RX on when idle");
 
         self.spinel
-            .prop_value_set(
-                SpinelPropertyId::MacRawStreamEnabled as u32,
-                vec![true as u8],
-            )
+            .prop_value_set(SpinelPropertyId::MacRawStreamEnabled, vec![true as u8])
             .await
             .expect("Failed to enable the RAW stream");
 
@@ -1726,11 +1720,11 @@ impl ZigbeeStack {
             .await
             .expect("Failed to transmit frame");
 
-        if status == SpinelStatus::Ok as u8 {
+        if status == SpinelStatus::Ok {
             return Ok(());
-        } else if status == SpinelStatus::NoAck as u8 {
+        } else if status == SpinelStatus::NoAck {
             return Err("No ACK".to_string());
-        } else if status == SpinelStatus::CcaFailure as u8 {
+        } else if status == SpinelStatus::CcaFailure {
             return Err("CCA failure".to_string());
         } else {
             return Err("Unknown failure: {status:#?}".to_string());

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -372,26 +372,6 @@ impl ApsAckData {
 }
 
 #[derive(Debug)]
-pub enum NwkFrameSequenceNumberOption {
-    Keep,
-    Increment,
-    FixedValue(u8),
-}
-
-#[derive(Debug)]
-pub struct NwkFrameSendOptions {
-    pub sequence_number: NwkFrameSequenceNumberOption,
-}
-
-impl NwkFrameSendOptions {
-    pub fn default() -> Self {
-        NwkFrameSendOptions {
-            sequence_number: NwkFrameSequenceNumberOption::Increment,
-        }
-    }
-}
-
-#[derive(Debug)]
 pub struct State {
     pub channel: u8,
     pub ieee802154_sequence_number: u8,


### PR DESCRIPTION
This PR migrates to explicit error enums via the `thiserror` crate and simplifies error handling as a whole.