### PR TITLE
Split NIB struct for more granular locking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -459,9 +459,9 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "96936507f153605bddfcda068dd804796c84324ed2510809e5b2a624c81da765"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -559,9 +559,9 @@ checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "70d58bf43669b5795d1576d0641cfb6fbb2057bf629506267a92807158584a13"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "bc838d2a56b5b1a6c25f55575dfc605fabb63bb2365f6c2353ef9159aa69e4a5"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1183,6 +1183,7 @@ dependencies = [
  "inline_colorization",
  "log",
  "num_enum",
+ "parking_lot",
  "pcap-parser",
  "rand",
  "serde",

--- a/crates/stack/Cargo.toml
+++ b/crates/stack/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0.219", features = ["derive"] }
 num_enum = "0.7.3"
 thiserror = "2.0.12"
 rand = "0.9.1"
+parking_lot = "0.12.4"
 
 [[bin]]
 name = "ziggurat"

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -5,12 +5,12 @@ use serial2::Settings;
 use serial2_tokio::SerialPort;
 use std::env;
 use std::net::SocketAddr;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::LocalRuntime;
-use tokio::sync::{Mutex, broadcast}; // Use tokio's async-aware Mutex
+use tokio::sync::broadcast;
 use tokio::task::spawn_local;
 
 use ziggurat::ieee_802154::types::{Eui64, Key, Nwk, PanId};
@@ -66,7 +66,7 @@ impl ZigguratServer {
             let (socket, addr) = listener.accept().await?;
 
             // Enforce the single-client rule using the async mutex
-            let mut is_connected_guard = self.is_client_connected.lock().await;
+            let mut is_connected_guard = self.is_client_connected.lock().unwrap();
             if *is_connected_guard {
                 log::warn!(
                     "Rejecting connection from {}: another client is already connected.",
@@ -94,8 +94,8 @@ impl ZigguratServer {
         }
 
         log::info!("Client {} disconnected.", addr);
-        *self.is_client_connected.lock().await = false;
-        *self.server_state.lock().await = None;
+        *self.is_client_connected.lock().unwrap() = false;
+        *self.server_state.lock().unwrap() = None;
         log::info!("Zigbee stack has been reset.");
     }
 
@@ -146,7 +146,7 @@ impl ZigguratServer {
             }
         }
 
-        let state_guard = self.server_state.lock().await;
+        let state_guard = self.server_state.lock().unwrap();
         let notification_rx = state_guard.as_ref().unwrap().notification_rx.resubscribe();
         drop(state_guard);
 
@@ -226,7 +226,7 @@ impl ZigguratServer {
     async fn process_command(&self, cmd: CommandRequest) -> CommandResponse {
         match cmd.cmd.as_str() {
             "set_network_settings" => {
-                let mut state_guard = self.server_state.lock().await;
+                let mut state_guard = self.server_state.lock().unwrap();
                 if state_guard.is_some() {
                     return CommandResponse {
                         tid: cmd.tid,
@@ -305,7 +305,7 @@ impl ZigguratServer {
                 }
             }
             "send_aps_command" => {
-                let state_guard = self.server_state.lock().await;
+                let state_guard = self.server_state.lock().unwrap();
                 if let Some(server_state) = &*state_guard {
                     // ... (parsing logic remains the same)
                     let delivery_mode = match cmd

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -4,13 +4,13 @@ use serde_json::json;
 use serial2::Settings;
 use serial2_tokio::SerialPort;
 use std::env;
-use std::future;
 use std::net::SocketAddr;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::LocalRuntime;
-use tokio::sync::broadcast;
+use tokio::sync::{Mutex, broadcast}; // Use tokio's async-aware Mutex
 use tokio::task::spawn_local;
 
 use ziggurat::ieee_802154::types::{Eui64, Key, Nwk, PanId};
@@ -41,6 +41,7 @@ struct ServerState {
 
 pub struct ZigguratServer {
     serial_path: String,
+    // Use tokio::sync::Mutex for async-aware locking
     server_state: Mutex<Option<ServerState>>,
     is_client_connected: Mutex<bool>,
 }
@@ -64,20 +65,21 @@ impl ZigguratServer {
         loop {
             let (socket, addr) = listener.accept().await?;
 
-            // Enforce the single-client rule.
-            if *self.is_client_connected.lock().unwrap() {
+            // Enforce the single-client rule using the async mutex
+            let mut is_connected_guard = self.is_client_connected.lock().await;
+            if *is_connected_guard {
                 log::warn!(
                     "Rejecting connection from {}: another client is already connected.",
                     addr
                 );
                 drop(socket);
-                continue;
+                continue; // The lock guard is dropped here
             }
 
             log::info!("Accepted new TCP client from {}", addr);
-            *self.is_client_connected.lock().unwrap() = true;
+            *is_connected_guard = true;
+            drop(is_connected_guard); // Release the lock before spawning the task
 
-            // Clone the Arc to move it into the client handling task.
             let server_clone = self.clone();
             spawn_local(async move {
                 server_clone.handle_client(socket, addr).await;
@@ -86,22 +88,19 @@ impl ZigguratServer {
     }
 
     /// Manages the entire lifecycle of a single client connection.
-    /// This is a wrapper function that ensures the connection flag is reset
-    /// regardless of how the client handler exits.
     async fn handle_client(self: Arc<Self>, stream: TcpStream, addr: SocketAddr) {
         if let Err(e) = self.handle_client_loop(stream, addr).await {
             log::warn!("Error handling client {}: {:?}", addr, e);
         }
 
         log::info!("Client {} disconnected.", addr);
-        *self.is_client_connected.lock().unwrap() = false;
-        // When a client disconnects, we also tear down the Zigbee stack.
-        // A new client will have to re-initialize it.
-        *self.server_state.lock().unwrap() = None;
+        *self.is_client_connected.lock().await = false;
+        *self.server_state.lock().await = None;
         log::info!("Zigbee stack has been reset.");
     }
 
-    /// The core logic loop for handling client messages and Zigbee notifications.
+    /// The core logic loop for handling client messages. This function now correctly
+    /// separates the uninitialized and initialized states.
     async fn handle_client_loop(
         &self,
         stream: TcpStream,
@@ -111,28 +110,69 @@ impl ZigguratServer {
         let mut reader = BufReader::new(reader);
         let mut line = String::new();
 
-        // The notification receiver might not exist yet. We will acquire it
-        // after the stack is initialized by the client.
-        let mut maybe_notification_rx: Option<broadcast::Receiver<ZigbeeNotification>> = None;
+        log::info!(
+            "Client {} connected. Waiting for 'set_network_settings'...",
+            addr
+        );
+        loop {
+            line.clear();
+            match reader.read_line(&mut line).await {
+                Ok(0) => return Ok(()), // Client disconnected
+                Ok(_) => {
+                    let cmd = match serde_json::from_str::<CommandRequest>(line.trim()) {
+                        Ok(cmd) => cmd,
+                        Err(e) => {
+                            log::warn!("JSON parse error from {}: {}", addr, e);
+                            let resp = json!({"tid": 0, "cmd": "error", "data": {"reason": "invalid_json", "details": e.to_string()}});
+                            writer.write_all(resp.to_string().as_bytes()).await?;
+                            writer.write_all(b"\n").await?;
+                            continue;
+                        }
+                    };
+
+                    log::debug!("Received command from {}: {:?}", addr, cmd);
+                    let resp = self.process_command(cmd).await;
+                    let resp_str = serde_json::to_string(&resp)?;
+                    writer.write_all(resp_str.as_bytes()).await?;
+                    writer.write_all(b"\n").await?;
+
+                    if resp.cmd == "set_network_settings"
+                        && resp.data.get("status").and_then(|v| v.as_str()) == Some("success")
+                    {
+                        break;
+                    }
+                }
+                Err(e) => return Err(e.into()),
+            }
+        }
+
+        let state_guard = self.server_state.lock().await;
+        let notification_rx = state_guard.as_ref().unwrap().notification_rx.resubscribe();
+        drop(state_guard);
+
+        log::info!("Stack initialized. Now listening for commands and notifications.");
+
+        self.run_initialized_loop(reader, writer, notification_rx, addr)
+            .await
+    }
+
+    /// Runs the main operational loop after the Zigbee stack has been initialized.
+    async fn run_initialized_loop(
+        &self,
+        reader: BufReader<OwnedReadHalf>,
+        mut writer: OwnedWriteHalf,
+        mut notification_rx: broadcast::Receiver<ZigbeeNotification>,
+        addr: SocketAddr,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut reader = reader;
+        let mut line = String::new();
 
         loop {
-            // If the stack was initialized in a previous loop iteration,
-            // we subscribe to the notification channel here.
-            if maybe_notification_rx.is_none() {
-                if let Some(state) = self.server_state.lock().unwrap().as_ref() {
-                    maybe_notification_rx = Some(state.notification_rx.resubscribe());
-                }
-            }
-
             line.clear();
-
             tokio::select! {
-                // Handle incoming TCP commands from the client.
                 read_result = reader.read_line(&mut line) => {
                     let n = read_result?;
-                    if n == 0 {
-                        break; // EOF reached, client disconnected.
-                    }
+                    if n == 0 { break; }
 
                     match serde_json::from_str::<CommandRequest>(line.trim()) {
                         Ok(cmd) => {
@@ -151,18 +191,7 @@ impl ZigguratServer {
                         }
                     }
                 },
-
-                // Handle notifications from the Zigbee stack.
-                // This branch effectively does nothing until `maybe_notification_rx` is `Some`.
-                // `future::pending()` creates a future that never resolves, which is perfect
-                // for disabling a select branch until it's ready.
-                notify_event = async {
-                    if let Some(ref mut rx) = maybe_notification_rx {
-                        rx.recv().await
-                    } else {
-                        future::pending().await
-                    }
-                } => {
+                notify_event = notification_rx.recv() => {
                      match notify_event {
                         Ok(ZigbeeNotification::ReceivedApsCommand {
                             source, profile_id, cluster_id, src_ep, dst_ep, lqi, rssi, data,
@@ -181,7 +210,6 @@ impl ZigguratServer {
                         },
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
                             log::warn!("Client {} lagged {} messages, skipping...", addr, count);
-                            continue;
                         },
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
                             log::warn!("Broadcast channel closed, ending client connection for {}", addr);
@@ -198,8 +226,8 @@ impl ZigguratServer {
     async fn process_command(&self, cmd: CommandRequest) -> CommandResponse {
         match cmd.cmd.as_str() {
             "set_network_settings" => {
-                // This command is special: it creates the ZigbeeStack.
-                if self.server_state.lock().unwrap().is_some() {
+                let mut state_guard = self.server_state.lock().await;
+                if state_guard.is_some() {
                     return CommandResponse {
                         tid: cmd.tid,
                         cmd: cmd.cmd,
@@ -207,8 +235,6 @@ impl ZigguratServer {
                     };
                 }
 
-                // NOTE: The extensive use of `unwrap()` here matches the original code's style.
-                // A production implementation should handle parsing errors gracefully.
                 let channel = cmd.data.get("channel").unwrap().as_u64().unwrap() as u8;
                 let nwk_update_id = cmd.data.get("nwk_update_id").unwrap().as_u64().unwrap() as u8;
                 let pan_id = PanId::from_hex(cmd.data.get("pan_id").unwrap().as_str().unwrap());
@@ -229,7 +255,6 @@ impl ZigguratServer {
                     .as_u64()
                     .unwrap() as u32;
 
-                // --- Begin Initialization ---
                 log::info!("Initializing Zigbee stack with new settings...");
                 let port = match SerialPort::open(&self.serial_path, |mut settings: Settings| {
                     settings.set_raw();
@@ -262,14 +287,12 @@ impl ZigguratServer {
                     network_key_tx_counter,
                 );
 
-                // Spawn the main stack runner task.
                 let stack_clone = zigbee_stack.clone();
                 spawn_local(async move {
                     stack_clone.run().await;
                 });
 
-                // Store the initialized stack and notifier in our state.
-                *self.server_state.lock().unwrap() = Some(ServerState {
+                *state_guard = Some(ServerState {
                     zigbee_stack,
                     notification_rx,
                 });
@@ -281,11 +304,10 @@ impl ZigguratServer {
                     data: json!({"status": "success"}),
                 }
             }
-
             "send_aps_command" => {
-                // This command depends on the stack being initialized first.
-                let state = self.server_state.lock().unwrap();
-                if let Some(server_state) = &*state {
+                let state_guard = self.server_state.lock().await;
+                if let Some(server_state) = &*state_guard {
+                    // ... (parsing logic remains the same)
                     let delivery_mode = match cmd
                         .data
                         .get("delivery_mode")
@@ -316,6 +338,7 @@ impl ZigguratServer {
                     let data =
                         hex::decode(cmd.data.get("data").unwrap().as_str().unwrap()).unwrap();
 
+                    // The lock is held across this await, which is now safe.
                     let status = server_state
                         .zigbee_stack
                         .send_aps_command(
@@ -338,7 +361,6 @@ impl ZigguratServer {
                         data: json!({"status": if status.is_ok() { "success" } else { "error" }, "reason": status.err().map(|e| e.to_string())}),
                     }
                 } else {
-                    // Return error if stack is not yet initialized.
                     CommandResponse {
                         tid: cmd.tid,
                         cmd: cmd.cmd,
@@ -346,7 +368,6 @@ impl ZigguratServer {
                     }
                 }
             }
-
             _ => CommandResponse {
                 tid: cmd.tid,
                 cmd: cmd.cmd,

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -4,14 +4,14 @@ use serde_json::json;
 use serial2::Settings;
 use serial2_tokio::SerialPort;
 use std::env;
+use std::future;
 use std::net::SocketAddr;
+use std::sync::{Arc, Mutex};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::runtime::LocalRuntime;
 use tokio::sync::broadcast;
 use tokio::task::spawn_local;
-
-use std::sync::Arc;
 
 use ziggurat::ieee_802154::types::{Eui64, Key, Nwk, PanId};
 use ziggurat::spinel_client::SpinelClient;
@@ -33,122 +33,146 @@ struct CommandResponse {
     data: serde_json::Value,
 }
 
-pub struct ZigguratServer {
+/// Holds the state that exists only after the Zigbee stack is initialized.
+struct ServerState {
     zigbee_stack: Arc<ZigbeeStack>,
     notification_rx: broadcast::Receiver<ZigbeeNotification>,
 }
 
+pub struct ZigguratServer {
+    serial_path: String,
+    server_state: Mutex<Option<ServerState>>,
+    is_client_connected: Mutex<bool>,
+}
+
 impl ZigguratServer {
-    pub fn new(serial_path: &str) -> Result<Self, Box<dyn std::error::Error>> {
-        // Open a serial port
-        let port = SerialPort::open(serial_path, |mut settings: Settings| {
-            settings.set_raw();
-            settings.set_baud_rate(460_800)?;
-            Ok(settings)
-        })?;
-
-        let spinel = SpinelClient::new(port);
-        spinel.spawn_reader();
-
-        let (zigbee_stack, notification_rx) = ZigbeeStack::new(spinel);
-        let server = ZigguratServer {
-            zigbee_stack: zigbee_stack,
-            notification_rx: notification_rx,
-        };
-
-        Ok(server)
-    }
-
-    pub async fn start(&self) {
-        self.zigbee_stack.run().await;
-    }
-
-    pub async fn run_tcp_server(&self, listen_addr: &str) -> std::io::Result<()> {
-        let listener = TcpListener::bind(listen_addr).await?;
-        log::debug!("Listening for TCP connections on {}", listen_addr);
-
-        loop {
-            let (socket, addr) = listener.accept().await?;
-            log::debug!("New TCP client from {}", addr);
-
-            if let Err(e) = self.handle_client(socket, addr).await {
-                log::warn!("Error handling client {}: {:?}", addr, e);
-            } else {
-                log::debug!("Client {} disconnected", addr);
-            }
+    /// The serial port is not opened and the Zigbee stack is not created until a client
+    /// connects and sends the `set_network_settings` command.
+    pub fn new(serial_path: &str) -> Self {
+        Self {
+            serial_path: serial_path.to_string(),
+            server_state: Mutex::new(None),
+            is_client_connected: Mutex::new(false),
         }
     }
 
-    // TODO replace with tokio-serde
-    async fn handle_client(
+    /// Listens for and handles incoming TCP connections.
+    pub async fn run_tcp_server(self: Arc<Self>, listen_addr: &str) -> std::io::Result<()> {
+        let listener = TcpListener::bind(listen_addr).await?;
+        log::info!("Listening for a single TCP client on {}", listen_addr);
+
+        loop {
+            let (socket, addr) = listener.accept().await?;
+
+            // Enforce the single-client rule.
+            if *self.is_client_connected.lock().unwrap() {
+                log::warn!(
+                    "Rejecting connection from {}: another client is already connected.",
+                    addr
+                );
+                drop(socket);
+                continue;
+            }
+
+            log::info!("Accepted new TCP client from {}", addr);
+            *self.is_client_connected.lock().unwrap() = true;
+
+            // Clone the Arc to move it into the client handling task.
+            let server_clone = self.clone();
+            spawn_local(async move {
+                server_clone.handle_client(socket, addr).await;
+            });
+        }
+    }
+
+    /// Manages the entire lifecycle of a single client connection.
+    /// This is a wrapper function that ensures the connection flag is reset
+    /// regardless of how the client handler exits.
+    async fn handle_client(self: Arc<Self>, stream: TcpStream, addr: SocketAddr) {
+        if let Err(e) = self.handle_client_loop(stream, addr).await {
+            log::warn!("Error handling client {}: {:?}", addr, e);
+        }
+
+        log::info!("Client {} disconnected.", addr);
+        *self.is_client_connected.lock().unwrap() = false;
+        // When a client disconnects, we also tear down the Zigbee stack.
+        // A new client will have to re-initialize it.
+        *self.server_state.lock().unwrap() = None;
+        log::info!("Zigbee stack has been reset.");
+    }
+
+    /// The core logic loop for handling client messages and Zigbee notifications.
+    async fn handle_client_loop(
         &self,
         stream: TcpStream,
         addr: SocketAddr,
     ) -> Result<(), Box<dyn std::error::Error>> {
         let (reader, mut writer) = stream.into_split();
         let mut reader = BufReader::new(reader);
-        let mut notification_rx = self.notification_rx.resubscribe();
         let mut line = String::new();
 
+        // The notification receiver might not exist yet. We will acquire it
+        // after the stack is initialized by the client.
+        let mut maybe_notification_rx: Option<broadcast::Receiver<ZigbeeNotification>> = None;
+
         loop {
+            // If the stack was initialized in a previous loop iteration,
+            // we subscribe to the notification channel here.
+            if maybe_notification_rx.is_none() {
+                if let Some(state) = self.server_state.lock().unwrap().as_ref() {
+                    maybe_notification_rx = Some(state.notification_rx.resubscribe());
+                }
+            }
+
             line.clear();
 
             tokio::select! {
+                // Handle incoming TCP commands from the client.
                 read_result = reader.read_line(&mut line) => {
                     let n = read_result?;
                     if n == 0 {
-                        break; // EOF reached
+                        break; // EOF reached, client disconnected.
                     }
+
                     match serde_json::from_str::<CommandRequest>(line.trim()) {
                         Ok(cmd) => {
                             log::debug!("Received command from {}: {:?}", addr, cmd);
-
                             let resp = self.process_command(cmd).await;
-                            let resp_str = serde_json::to_string(&resp).unwrap();
-
-                            log::debug!("Sending response: {:?}", resp_str);
-                            writer.write_all(resp_str.as_bytes()).await.unwrap();
-                            writer.write_all(b"\n").await.unwrap();
+                            let resp_str = serde_json::to_string(&resp)?;
+                            log::debug!("Sending response: {}", resp_str);
+                            writer.write_all(resp_str.as_bytes()).await?;
+                            writer.write_all(b"\n").await?;
                         },
                         Err(e) => {
-                            log::warn!("JSON parse error from {}: {:?}", addr, e);
-                            let err_response = json!({
-                                "tid": 0,
-                                "cmd": "error",
-                                "data": {
-                                    "reason": "invalid_json",
-                                    "details": e.to_string()
-                                }
-                            });
-                            writer.write_all(err_response.to_string().as_bytes()).await?;
+                            log::warn!("JSON parse error from {}: {}", addr, e);
+                            let resp = json!({"tid": 0, "cmd": "error", "data": {"reason": "invalid_json", "details": e.to_string()}});
+                            writer.write_all(resp.to_string().as_bytes()).await?;
                             writer.write_all(b"\n").await?;
                         }
                     }
-                }
-                notify_event = notification_rx.recv() => {
-                    match notify_event {
+                },
+
+                // Handle notifications from the Zigbee stack.
+                // This branch effectively does nothing until `maybe_notification_rx` is `Some`.
+                // `future::pending()` creates a future that never resolves, which is perfect
+                // for disabling a select branch until it's ready.
+                notify_event = async {
+                    if let Some(ref mut rx) = maybe_notification_rx {
+                        rx.recv().await
+                    } else {
+                        future::pending().await
+                    }
+                } => {
+                     match notify_event {
                         Ok(ZigbeeNotification::ReceivedApsCommand {
-                            source,
-                            profile_id,
-                            cluster_id,
-                            src_ep,
-                            dst_ep,
-                            lqi,
-                            rssi,
-                            data,
+                            source, profile_id, cluster_id, src_ep, dst_ep, lqi, rssi, data,
                         }) => {
                             let event = json!({
-                                "tid": 0,
-                                "cmd": "received_aps_command",
+                                "tid": 0, "cmd": "received_aps_command",
                                 "data": {
-                                    "source": hex::encode(source.to_bytes()),
-                                    "profile_id": profile_id,
-                                    "cluster_id": cluster_id,
-                                    "src_ep": src_ep,
-                                    "dst_ep": dst_ep,
-                                    "lqi": lqi,
-                                    "rssi": rssi,
-                                    "data": hex::encode(data),
+                                    "source": hex::encode(source.to_bytes()), "profile_id": profile_id,
+                                    "cluster_id": cluster_id, "src_ep": src_ep, "dst_ep": dst_ep,
+                                    "lqi": lqi, "rssi": rssi, "data": hex::encode(data),
                                 }
                             });
                             log::debug!("Sending APS frame notification: {:?}", event);
@@ -167,14 +191,24 @@ impl ZigguratServer {
                 }
             }
         }
-
         Ok(())
     }
 
+    /// Processes a single command from the client, mutating the server state if necessary.
     async fn process_command(&self, cmd: CommandRequest) -> CommandResponse {
         match cmd.cmd.as_str() {
             "set_network_settings" => {
-                // Extract parameters from the data
+                // This command is special: it creates the ZigbeeStack.
+                if self.server_state.lock().unwrap().is_some() {
+                    return CommandResponse {
+                        tid: cmd.tid,
+                        cmd: cmd.cmd,
+                        data: json!({"status": "error", "reason": "stack_already_initialized"}),
+                    };
+                }
+
+                // NOTE: The extensive use of `unwrap()` here matches the original code's style.
+                // A production implementation should handle parsing errors gracefully.
                 let channel = cmd.data.get("channel").unwrap().as_u64().unwrap() as u8;
                 let nwk_update_id = cmd.data.get("nwk_update_id").unwrap().as_u64().unwrap() as u8;
                 let pan_id = PanId::from_hex(cmd.data.get("pan_id").unwrap().as_str().unwrap());
@@ -195,80 +229,121 @@ impl ZigguratServer {
                     .as_u64()
                     .unwrap() as u32;
 
-                let status = self
-                    .zigbee_stack
-                    .set_network_settings(
-                        channel,
-                        nwk_update_id,
-                        pan_id,
-                        extended_pan_id,
-                        nwk_address,
-                        ieee_address,
-                        network_key,
-                        network_key_seq,
-                        network_key_tx_counter,
-                    )
-                    .await;
-
-                if status.is_ok() {
-                    CommandResponse {
-                        tid: cmd.tid,
-                        cmd: cmd.cmd,
-                        data: json!({"status": "success"}),
-                    }
-                } else {
-                    CommandResponse {
-                        tid: cmd.tid,
-                        cmd: cmd.cmd,
-                        data: json!({"status": "error", "reason": status.err().map(|e| e.to_string())}),
-                    }
-                }
-            }
-            "send_aps_command" => {
-                let delivery_mode = match cmd.data.get("delivery_mode").unwrap().as_str().unwrap() {
-                    "unicast" => ApsDeliveryMode::Unicast,
-                    "broadcast" => ApsDeliveryMode::Broadcast,
-                    "multicast" => ApsDeliveryMode::Multicast,
-                    _ => {
+                // --- Begin Initialization ---
+                log::info!("Initializing Zigbee stack with new settings...");
+                let port = match SerialPort::open(&self.serial_path, |mut settings: Settings| {
+                    settings.set_raw();
+                    settings.set_baud_rate(460_800)?;
+                    Ok(settings)
+                }) {
+                    Ok(p) => p,
+                    Err(e) => {
                         return CommandResponse {
                             tid: cmd.tid,
                             cmd: cmd.cmd,
-                            data: json!({"status": "error", "reason": "invalid_delivery_mode"}),
+                            data: json!({"status": "error", "reason": format!("serial_port_error: {}", e)}),
                         };
                     }
                 };
 
-                let destination =
-                    Nwk::from_hex(cmd.data.get("destination").unwrap().as_str().unwrap());
-                let profile_id = cmd.data.get("profile_id").unwrap().as_u64().unwrap() as u16;
-                let cluster_id = cmd.data.get("cluster_id").unwrap().as_u64().unwrap() as u16;
-                let src_ep = cmd.data.get("src_ep").unwrap().as_u64().unwrap() as u8;
-                let dst_ep = cmd.data.get("dst_ep").unwrap().as_u64().unwrap() as u8;
-                let aps_ack = cmd.data.get("aps_ack").unwrap().as_bool().unwrap();
-                let aps_seq = cmd.data.get("aps_seq").unwrap().as_u64().unwrap() as u8;
-                let radius = cmd.data.get("radius").unwrap().as_u64().unwrap() as u8;
-                let data = hex::decode(cmd.data.get("data").unwrap().as_str().unwrap()).unwrap();
+                let spinel = SpinelClient::new(port);
+                spinel.spawn_reader();
 
-                let status = self
-                    .zigbee_stack
-                    .send_aps_command(
-                        delivery_mode,
-                        destination,
-                        profile_id,
-                        cluster_id,
-                        src_ep,
-                        dst_ep,
-                        aps_ack,
-                        radius,
-                        aps_seq,
-                        data,
-                    )
-                    .await;
+                let (zigbee_stack, notification_rx) = ZigbeeStack::new(
+                    spinel,
+                    channel,
+                    nwk_update_id,
+                    pan_id,
+                    extended_pan_id,
+                    nwk_address,
+                    ieee_address,
+                    network_key,
+                    network_key_seq,
+                    network_key_tx_counter,
+                );
 
+                // Spawn the main stack runner task.
+                let stack_clone = zigbee_stack.clone();
+                spawn_local(async move {
+                    stack_clone.run().await;
+                });
+
+                // Store the initialized stack and notifier in our state.
+                *self.server_state.lock().unwrap() = Some(ServerState {
+                    zigbee_stack,
+                    notification_rx,
+                });
+
+                log::info!("Zigbee stack initialized and running.");
                 CommandResponse {
                     tid: cmd.tid,
                     cmd: cmd.cmd,
-                    data: json!({"status": if status.is_ok() { "success" } else { "error" } }),
+                    data: json!({"status": "success"}),
+                }
+            }
+
+            "send_aps_command" => {
+                // This command depends on the stack being initialized first.
+                let state = self.server_state.lock().unwrap();
+                if let Some(server_state) = &*state {
+                    let delivery_mode = match cmd
+                        .data
+                        .get("delivery_mode")
+                        .unwrap()
+                        .as_str()
+                        .unwrap()
+                    {
+                        "unicast" => ApsDeliveryMode::Unicast,
+                        "broadcast" => ApsDeliveryMode::Broadcast,
+                        "multicast" => ApsDeliveryMode::Multicast,
+                        _ => {
+                            return CommandResponse {
+                                tid: cmd.tid,
+                                cmd: cmd.cmd,
+                                data: json!({"status": "error", "reason": "invalid_delivery_mode"}),
+                            };
+                        }
+                    };
+                    let destination =
+                        Nwk::from_hex(cmd.data.get("destination").unwrap().as_str().unwrap());
+                    let profile_id = cmd.data.get("profile_id").unwrap().as_u64().unwrap() as u16;
+                    let cluster_id = cmd.data.get("cluster_id").unwrap().as_u64().unwrap() as u16;
+                    let src_ep = cmd.data.get("src_ep").unwrap().as_u64().unwrap() as u8;
+                    let dst_ep = cmd.data.get("dst_ep").unwrap().as_u64().unwrap() as u8;
+                    let aps_ack = cmd.data.get("aps_ack").unwrap().as_bool().unwrap();
+                    let aps_seq = cmd.data.get("aps_seq").unwrap().as_u64().unwrap() as u8;
+                    let radius = cmd.data.get("radius").unwrap().as_u64().unwrap() as u8;
+                    let data =
+                        hex::decode(cmd.data.get("data").unwrap().as_str().unwrap()).unwrap();
+
+                    let status = server_state
+                        .zigbee_stack
+                        .send_aps_command(
+                            delivery_mode,
+                            destination,
+                            profile_id,
+                            cluster_id,
+                            src_ep,
+                            dst_ep,
+                            aps_ack,
+                            radius,
+                            aps_seq,
+                            data,
+                        )
+                        .await;
+
+                    CommandResponse {
+                        tid: cmd.tid,
+                        cmd: cmd.cmd,
+                        data: json!({"status": if status.is_ok() { "success" } else { "error" }, "reason": status.err().map(|e| e.to_string())}),
+                    }
+                } else {
+                    // Return error if stack is not yet initialized.
+                    CommandResponse {
+                        tid: cmd.tid,
+                        cmd: cmd.cmd,
+                        data: json!({"status": "error", "reason": "stack_not_initialized"}),
+                    }
                 }
             }
 
@@ -301,10 +376,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             .cloned()
             .unwrap_or_else(|| "0.0.0.0:9999".to_string());
 
-        let server = Arc::new(ZigguratServer::new(serial_path)?);
-
-        let server_clone = server.clone();
-        spawn_local(async move { server_clone.start().await });
+        let server = Arc::new(ZigguratServer::new(serial_path));
 
         server.run_tcp_server(&tcp_listen_addr).await?;
 

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -41,7 +41,6 @@ struct ServerState {
 
 pub struct ZigguratServer {
     serial_path: String,
-    // Use tokio::sync::Mutex for async-aware locking
     server_state: Mutex<Option<ServerState>>,
     is_client_connected: Mutex<bool>,
 }
@@ -99,8 +98,7 @@ impl ZigguratServer {
         log::info!("Zigbee stack has been reset.");
     }
 
-    /// The core logic loop for handling client messages. This function now correctly
-    /// separates the uninitialized and initialized states.
+    /// The core logic loop for handling client messages.
     async fn handle_client_loop(
         &self,
         stream: TcpStream,

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -27,7 +27,6 @@ use zigbee_parts::commands::{
 use parking_lot::Mutex;
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::mem::drop;
 use std::sync::{Arc, Weak};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::spawn_local;
@@ -477,9 +476,7 @@ impl ZigbeeStack {
         self.start_network().await.expect("Failed to start network");
 
         loop {
-            log::debug!("Waiting for incoming APS frames...");
             let (packet, ieee802154_frame) = self.recv_frame().await;
-            log::debug!("Got an incoming frame");
 
             match self.process_802154_frame(&ieee802154_frame, packet.lqi, packet.rssi) {
                 Some(nwk_frame) => {
@@ -554,11 +551,14 @@ impl ZigbeeStack {
                     continue;
                 }
             };
+
             if packet.psdu.len() < 2 {
                 log::warn!("Packet too short to contain FCS");
                 continue;
             }
+
             let frame_data = &packet.psdu[..packet.psdu.len() - 2];
+
             match Ieee802154Frame::from_bytes_without_fcs(frame_data) {
                 Ok(frame) => {
                     log::debug!("Received 802.15.4 frame: {:?}", frame);
@@ -582,7 +582,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::PhyChan,
-                vec![{ *self.state.channel.try_lock().unwrap() }],
+                vec![*self.state.channel.try_lock().unwrap()],
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -619,9 +619,10 @@ impl ZigbeeStack {
             .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
-            .prop_value_set(SpinelPropertyId::Mac154Panid, {
-                self.state.pan_id.try_lock().unwrap().to_bytes().to_vec()
-            })
+            .prop_value_set(
+                SpinelPropertyId::Mac154Panid,
+                self.state.pan_id.try_lock().unwrap().to_bytes().to_vec(),
+            )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
@@ -679,24 +680,22 @@ impl ZigbeeStack {
         }
 
         // Only process packets destined for our PAN ID
-        {
-            let pan_id = *self.state.pan_id.try_lock().unwrap();
+        let pan_id = *self.state.pan_id.try_lock().unwrap();
 
-            match frame.dest_pan_id {
-                None => {
-                    log::debug!("Ignoring frame, destination PAN ID is not present");
-                    return None;
-                }
-                Some(dest_pan_id) if dest_pan_id != pan_id => {
-                    log::debug!(
-                        "Ignoring frame, PAN ID does not match {:?} != {:?}",
-                        dest_pan_id,
-                        pan_id
-                    );
-                    return None;
-                }
-                Some(_) => (),
+        match frame.dest_pan_id {
+            None => {
+                log::debug!("Ignoring frame, destination PAN ID is not present");
+                return None;
             }
+            Some(dest_pan_id) if dest_pan_id != pan_id => {
+                log::debug!(
+                    "Ignoring frame, PAN ID does not match {:?} != {:?}",
+                    dest_pan_id,
+                    pan_id
+                );
+                return None;
+            }
+            Some(_) => (),
         }
 
         // Next, try to parse the NWK frame
@@ -899,10 +898,8 @@ impl ZigbeeStack {
         }
 
         // Handle LQA calculation
-        {
-            self.maybe_age_neighbors();
-            self.maybe_recompute_lqa(nwk_frame, lqi, rssi);
-        }
+        self.maybe_age_neighbors();
+        self.maybe_recompute_lqa(nwk_frame, lqi, rssi);
 
         // Ignore frames that aren't destined for us
         if nwk_frame.nwk_header.destination.as_u16()
@@ -1016,21 +1013,20 @@ impl ZigbeeStack {
         // mutating the state
         self.maybe_age_neighbors();
 
-        let neighbors_with_nonzero_outgoing_cost = {
-            self.state
-                .neighbor_table
-                .try_lock()
-                .unwrap()
-                .iter()
-                .filter_map(|(_, neighbor_entry)| {
-                    if neighbor_entry.outgoing_cost > 0 {
-                        Some(neighbor_entry.network_address)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<HashSet<Nwk>>()
-        };
+        let neighbors_with_nonzero_outgoing_cost = self
+            .state
+            .neighbor_table
+            .try_lock()
+            .unwrap()
+            .iter()
+            .filter_map(|(_, neighbor_entry)| {
+                if neighbor_entry.outgoing_cost > 0 {
+                    Some(neighbor_entry.network_address)
+                } else {
+                    None
+                }
+            })
+            .collect::<HashSet<Nwk>>();
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
         let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
@@ -1159,95 +1155,99 @@ impl ZigbeeStack {
         let updated_path_cost = route_reply_cmd
             .path_cost
             .saturating_add(neighbor.outgoing_cost);
+
         let route_discovery_table_key = (
             route_reply_cmd.originator_nwk,
             route_reply_cmd.route_request_identifier,
         );
 
-        // TODO: clean this up, the mutability problems caused by the shared state mutex
-        // make having two mutable borrows at once very difficult
-        let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
-        let Some(discovery_entry) = route_discovery_table.get_mut(&route_discovery_table_key)
-        else {
-            log::debug!("Route reply for unknown route discovery, ignoring");
-            return;
-        };
+        let next_hop_nwk;
 
-        let mut route_table = self.state.route_table.try_lock().unwrap();
-        let Some(routing_entry) = route_table.get_mut(&route_reply_cmd.responder_nwk) else {
-            log::debug!("Route reply with unknown responder, ignoring");
-            return;
-        };
+        // Hold mutable references to `route_table` and `route_discovery_table` for as
+        // little time as possible.
+        {
+            let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
+            let Some(discovery_entry) = route_discovery_table.get_mut(&route_discovery_table_key)
+            else {
+                log::debug!("Route reply for unknown route discovery, ignoring");
+                return;
+            };
 
-        // If we are the originator, handling is simplified
-        if route_reply_cmd.originator_nwk == our_nwk_address {
-            match routing_entry.status {
-                route::Status::Inactive
-                | route::Status::DiscoveryFailed  // Is this correct to have?
-                | route::Status::DiscoveryUnderway => {
-                    log::debug!("Setting routing entry for NWK {:?} to active, with next hop {:?} (residual cost {})", 
-                        route_reply_cmd.responder_nwk,
-                        nwk_frame.nwk_header.source,
-                        updated_path_cost);
+            let mut route_table = self.state.route_table.try_lock().unwrap();
+            let Some(routing_entry) = route_table.get_mut(&route_reply_cmd.responder_nwk) else {
+                log::debug!("Route reply with unknown responder, ignoring");
+                return;
+            };
 
-                    // Mutate the routing entry
-                    routing_entry.status = route::Status::Active;
-                    routing_entry.next_hop_address = nwk_frame.nwk_header.source;
+            // If we are the originator, handling is simplified
+            if route_reply_cmd.originator_nwk == our_nwk_address {
+                match routing_entry.status {
+                    route::Status::Inactive
+                    | route::Status::DiscoveryFailed  // Is this correct to have?
+                    | route::Status::DiscoveryUnderway => {
+                        log::debug!("Setting routing entry for NWK {:?} to active, with next hop {:?} (residual cost {})", 
+                            route_reply_cmd.responder_nwk,
+                            nwk_frame.nwk_header.source,
+                            updated_path_cost);
 
-                    // Mutate the discovery entry
-                    discovery_entry.residual_cost = updated_path_cost;
+                        // Mutate the routing entry
+                        routing_entry.status = route::Status::Active;
+                        routing_entry.next_hop_address = nwk_frame.nwk_header.source;
 
-                    self.notify_routing_change(&route_reply_cmd.responder_nwk);
-                },
-                route::Status::Active => {
-                    if updated_path_cost >= discovery_entry.residual_cost {
-                        log::debug!("Ignoring route reply for us with higher cost ({} > {})", updated_path_cost, discovery_entry.residual_cost);
-                        return;
-                    }
+                        // Mutate the discovery entry
+                        discovery_entry.residual_cost = updated_path_cost;
+
+                        self.notify_routing_change(&route_reply_cmd.responder_nwk);
+                    },
+                    route::Status::Active => {
+                        if updated_path_cost >= discovery_entry.residual_cost {
+                            log::debug!("Ignoring route reply for us with higher cost ({} > {})", updated_path_cost, discovery_entry.residual_cost);
+                            return;
+                        }
 
 
-                    log::debug!("Updating routing entry for NWK {:?} from next hop {:?} (residual cost {}) to next hop {:?} (residual cost {})",
-                        route_reply_cmd.responder_nwk,
-                        routing_entry.next_hop_address,
-                        discovery_entry.residual_cost,
-                        nwk_frame.nwk_header.source,
-                        updated_path_cost);
+                        log::debug!("Updating routing entry for NWK {:?} from next hop {:?} (residual cost {}) to next hop {:?} (residual cost {})",
+                            route_reply_cmd.responder_nwk,
+                            routing_entry.next_hop_address,
+                            discovery_entry.residual_cost,
+                            nwk_frame.nwk_header.source,
+                            updated_path_cost);
 
-                    // Mutate the routing entry
-                    routing_entry.next_hop_address = nwk_frame.nwk_header.source;
+                        // Mutate the routing entry
+                        routing_entry.next_hop_address = nwk_frame.nwk_header.source;
 
-                    // Mutate the discovery entry
-                    discovery_entry.residual_cost = updated_path_cost;
+                        // Mutate the discovery entry
+                        discovery_entry.residual_cost = updated_path_cost;
 
-                    self.notify_routing_change(&route_reply_cmd.responder_nwk);
-                },
+                        self.notify_routing_change(&route_reply_cmd.responder_nwk);
+                    },
+                }
+
+                return;
             }
 
-            return;
+            // Otherwise, we need to decide if we need to update our own routes and possibly
+            // relay the frame
+            if updated_path_cost >= discovery_entry.residual_cost {
+                log::debug!(
+                    "Ignoring unsolicited route reply with higher cost ({} > {})",
+                    updated_path_cost,
+                    discovery_entry.residual_cost
+                );
+                return;
+            }
+
+            // Mutate the routing entry
+            routing_entry.next_hop_address = nwk_frame.nwk_header.source;
+
+            // Mutate the discovery entry
+            discovery_entry.residual_cost = updated_path_cost;
+
+            // Find the next hop to the destination
+            next_hop_nwk = discovery_entry.sender_address;
         }
-
-        // Otherwise, we need to decide if we need to update our own routes and possibly
-        // relay the frame
-        if updated_path_cost >= discovery_entry.residual_cost {
-            log::debug!(
-                "Ignoring unsolicited route reply with higher cost ({} > {})",
-                updated_path_cost,
-                discovery_entry.residual_cost
-            );
-            return;
-        }
-
-        // Mutate the routing entry
-        routing_entry.next_hop_address = nwk_frame.nwk_header.source;
-        drop(route_table);
-
-        // Mutate the discovery entry
-        discovery_entry.residual_cost = updated_path_cost;
 
         self.notify_routing_change(&route_reply_cmd.responder_nwk);
-
-        // Find the next hop to the destination
-        let next_hop_nwk = discovery_entry.sender_address;
 
         let Some(next_hop_neighbor) = neighbor_table
             .values()
@@ -1273,7 +1273,7 @@ impl ZigbeeStack {
                 destination: next_hop_nwk,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
+                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -1515,9 +1515,8 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.destination,
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
-                    sequence_number: {
-                        *self.state.sequence_number.try_lock().unwrap() // TODO: do we change this?
-                    },
+                    // TODO: do we change this?
+                    sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
                     multicast_control: None,
@@ -1553,7 +1552,7 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.source,
                     source: self.state.network_address,
                     radius: 2 * self.constants.max_depth,
-                    sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
+                    sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
@@ -1596,7 +1595,7 @@ impl ZigbeeStack {
                 destination: nwk_frame.nwk_header.source,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
+                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1733,13 +1732,14 @@ impl ZigbeeStack {
         for attempt in 0..=self.constants.unicast_retries {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut security_material_primary =
-                    self.state.security_material_primary.try_lock().unwrap();
-                security_material_primary.outgoing_frame_counter = security_material_primary
-                    .outgoing_frame_counter
-                    .wrapping_add(1);
-
-                security_material_primary.outgoing_frame_counter
+                let mut outgoing_frame_counter = self
+                    .state
+                    .security_material_primary
+                    .try_lock()
+                    .unwrap()
+                    .outgoing_frame_counter;
+                outgoing_frame_counter = outgoing_frame_counter.wrapping_add(1);
+                outgoing_frame_counter
             };
 
             let encrypted_nwk_frame = {
@@ -1760,10 +1760,8 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: {
-                    Some(*self.state.ieee802154_sequence_number.try_lock().unwrap())
-                },
-                dest_pan_id: { Some(*self.state.pan_id.try_lock().unwrap()) },
+                sequence_number: Some(*self.state.ieee802154_sequence_number.try_lock().unwrap()),
+                dest_pan_id: Some(*self.state.pan_id.try_lock().unwrap()),
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
                 src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
@@ -1774,30 +1772,41 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
-
-            let address_map = self.state.address_map.try_lock().unwrap();
-
-            if let Some(relaying_ieee) = address_map.iter().find_map(|(&eui64, &nwk)| {
-                if nwk == next_hop_address {
-                    Some(eui64)
-                } else {
-                    None
-                }
-            }) {
-                if let Some(neighbor_entry) = neighbor_table.get_mut(&relaying_ieee) {
+            if let Some(relaying_ieee) =
+                self.state
+                    .address_map
+                    .try_lock()
+                    .unwrap()
+                    .iter()
+                    .find_map(|(&eui64, &nwk)| {
+                        if nwk == next_hop_address {
+                            Some(eui64)
+                        } else {
+                            None
+                        }
+                    })
+            {
+                if let Some(neighbor_entry) = self
+                    .state
+                    .neighbor_table
+                    .try_lock()
+                    .unwrap()
+                    .get_mut(&relaying_ieee)
+                {
                     // Update the neighbor table counters
                     neighbor_entry.router_outbound_activity =
                         neighbor_entry.router_outbound_activity.saturating_add(1);
                 }
             }
 
-            drop(address_map);
-
-            let mut route_table = self.state.route_table.try_lock().unwrap();
-
             // And the routing table counters
-            if let Some(route_entry) = route_table.get_mut(&nwk_frame.nwk_header.destination) {
+            if let Some(route_entry) = self
+                .state
+                .route_table
+                .try_lock()
+                .unwrap()
+                .get_mut(&nwk_frame.nwk_header.destination)
+            {
                 route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
                 route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
             }
@@ -1811,13 +1820,10 @@ impl ZigbeeStack {
 
             // Handle `tx_total` wrapping
             if tx_total == 0x0000 {
-                for (_, neighbor) in neighbor_table.iter_mut() {
+                for (_, neighbor) in self.state.neighbor_table.try_lock().unwrap().iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
-
-            drop(neighbor_table);
-            drop(route_table);
 
             match self.send_802154_frame(ieee802154_frame).await {
                 Ok(_) => {
@@ -1869,13 +1875,14 @@ impl ZigbeeStack {
         for attempt in 0..=self.constants.max_broadcast_retries {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut security_material_primary =
-                    self.state.security_material_primary.try_lock().unwrap();
-                security_material_primary.outgoing_frame_counter = security_material_primary
-                    .outgoing_frame_counter
-                    .wrapping_add(1);
-
-                security_material_primary.outgoing_frame_counter
+                let mut outgoing_frame_counter = self
+                    .state
+                    .security_material_primary
+                    .try_lock()
+                    .unwrap()
+                    .outgoing_frame_counter;
+                outgoing_frame_counter = outgoing_frame_counter.wrapping_add(1);
+                outgoing_frame_counter
             };
 
             let encrypted_nwk_frame = {
@@ -1896,9 +1903,7 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: {
-                    Some(*self.state.ieee802154_sequence_number.try_lock().unwrap())
-                },
+                sequence_number: Some(*self.state.ieee802154_sequence_number.try_lock().unwrap()),
                 dest_pan_id: Some(*self.state.pan_id.try_lock().unwrap()),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
@@ -1910,20 +1915,16 @@ impl ZigbeeStack {
             };
 
             // Increment counters before sending
-            {
-                let tx_total = {
-                    let mut tx_total = self.state.tx_total.try_lock().unwrap();
-                    *tx_total = tx_total.wrapping_add(1);
-                    *tx_total
-                };
+            let tx_total = {
+                let mut tx_total = self.state.tx_total.try_lock().unwrap();
+                *tx_total = tx_total.wrapping_add(1);
+                *tx_total
+            };
 
-                // Handle `tx_total` wrapping
-                let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
-
-                if tx_total == 0x0000 {
-                    for (_, neighbor) in neighbor_table.iter_mut() {
-                        neighbor.transmit_failure = 0;
-                    }
+            // Handle `tx_total` wrapping
+            if tx_total == 0x0000 {
+                for (_, neighbor) in self.state.neighbor_table.try_lock().unwrap().iter_mut() {
+                    neighbor.transmit_failure = 0;
                 }
             }
 
@@ -2046,15 +2047,14 @@ impl ZigbeeStack {
             }
         };
 
-        let next_hop_address = {
-            self.state
-                .route_table
-                .try_lock()
-                .unwrap()
-                .get(&destination)
-                .unwrap()
-                .next_hop_address
-        };
+        let next_hop_address = self
+            .state
+            .route_table
+            .try_lock()
+            .unwrap()
+            .get(&destination)
+            .unwrap()
+            .next_hop_address;
 
         Ok(next_hop_address)
     }
@@ -2122,7 +2122,7 @@ impl ZigbeeStack {
         }
 
         // If we know the EUI64 corresponding to the NWK, use it
-        let destination_eui64 = {
+        let destination_eui64 =
             self.state
                 .address_map
                 .try_lock()
@@ -2134,8 +2134,7 @@ impl ZigbeeStack {
                     } else {
                         None
                     }
-                })
-        };
+                });
 
         // Construct a frame
         let route_request_frame = NwkFrame {
@@ -2154,7 +2153,7 @@ impl ZigbeeStack {
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
+                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                 destination_ieee: None,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -2260,7 +2259,7 @@ impl ZigbeeStack {
                 destination: destination,
                 source: self.state.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
+                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2386,7 +2385,7 @@ impl ZigbeeStack {
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                     source: self.state.network_address,
                     radius: 1,
-                    sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
+                    sequence_number: *self.state.sequence_number.try_lock().unwrap(),
                     destination_ieee: None,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -36,7 +36,8 @@ use tokio::time::{Duration, Instant};
 mod neighbor;
 mod route;
 
-const MAX_LOCK_DURATION: Duration = Duration::from_millis(100);
+// TODO: remove this once all long locks have been found
+const MAX_LOCK_DURATION: Duration = Duration::from_millis(10);
 
 const APS_ACK_TIMEOUT: Duration = Duration::from_millis(5000);
 

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -24,15 +24,19 @@ use zigbee_parts::commands::{
     NwkRouteRequestCommand, NwkRouteRequestManyToOne,
 };
 
+use parking_lot::Mutex;
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::sync::{Arc, Mutex, Weak};
+use std::mem::drop;
+use std::sync::{Arc, Weak};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::spawn_local;
 use tokio::time::{Duration, Instant};
 
 mod neighbor;
 mod route;
+
+const MAX_LOCK_DURATION: Duration = Duration::from_millis(100);
 
 const APS_ACK_TIMEOUT: Duration = Duration::from_millis(5000);
 
@@ -470,8 +474,12 @@ impl ZigbeeStack {
     }
 
     pub async fn run(&self) {
+        self.start_network().await.expect("Failed to start network");
+
         loop {
+            log::debug!("Waiting for incoming APS frames...");
             let (packet, ieee802154_frame) = self.recv_frame().await;
+            log::debug!("Got an incoming frame");
 
             match self.process_802154_frame(&ieee802154_frame, packet.lqi, packet.rssi) {
                 Some(nwk_frame) => {
@@ -488,7 +496,7 @@ impl ZigbeeStack {
 
                             self.state
                                 .pending_aps_acks
-                                .lock()
+                                .try_lock_for(MAX_LOCK_DURATION)
                                 .unwrap()
                                 .remove(&ack_data)
                                 .map(|tx| {
@@ -530,7 +538,7 @@ impl ZigbeeStack {
         loop {
             let Some(spinel_frame) = self
                 .raw_frame_rx
-                .lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .expect("No thread should panic")
                 .recv()
                 .await
@@ -538,6 +546,7 @@ impl ZigbeeStack {
                 log::warn!("Frame sender hung up");
                 continue;
             };
+
             let packet = match SpinelRxFrame::from_bytes(&spinel_frame.value) {
                 Ok(p) => p,
                 Err(e) => {
@@ -573,7 +582,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::PhyChan,
-                vec![*self.state.channel.lock().unwrap()],
+                vec![{ *self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap() }],
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -610,10 +619,14 @@ impl ZigbeeStack {
             .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
-            .prop_value_set(
-                SpinelPropertyId::Mac154Panid,
-                self.state.pan_id.lock().unwrap().to_bytes().to_vec(),
-            )
+            .prop_value_set(SpinelPropertyId::Mac154Panid, {
+                self.state
+                    .pan_id
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .to_bytes()
+                    .to_vec()
+            })
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
@@ -630,6 +643,7 @@ impl ZigbeeStack {
         // To kick things off, send a link status broadcast. Silicon Labs routers will
         // "respond" to empty link status broadcasts proactively, independent of the
         // link status period
+        log::info!("Sending initial link status broadcast");
         self.send_link_status_broadcast(true).await;
 
         let arc_self = self
@@ -671,7 +685,7 @@ impl ZigbeeStack {
 
         // Only process packets destined for our PAN ID
         {
-            let pan_id = *self.state.pan_id.lock().unwrap();
+            let pan_id = *self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap();
 
             match frame.dest_pan_id {
                 None => {
@@ -756,7 +770,7 @@ impl ZigbeeStack {
         match self
             .state
             .security_material_primary
-            .lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .incoming_frame_counter_set
             .get(&src_eui64)
@@ -782,14 +796,20 @@ impl ZigbeeStack {
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame =
-            match nwk_frame.decrypt(&self.state.security_material_primary.lock().unwrap().key) {
-                Ok(decrypted_frame) => decrypted_frame,
-                Err(err) => {
-                    log::warn!("Ignoring frame, decryption failed: {err:?}");
-                    return None;
-                }
-            };
+        let decrypted_nwk_frame = match nwk_frame.decrypt(
+            &self
+                .state
+                .security_material_primary
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .key,
+        ) {
+            Ok(decrypted_frame) => decrypted_frame,
+            Err(err) => {
+                log::warn!("Ignoring frame, decryption failed: {err:?}");
+                return None;
+            }
+        };
 
         log::info!("Decrypted frame: {decrypted_nwk_frame:#?}");
 
@@ -806,7 +826,13 @@ impl ZigbeeStack {
     }
 
     pub fn update_nwk_eui64_mapping(&self, nwk: Nwk, eui64: Eui64) {
-        match self.state.address_map.lock().unwrap().insert(eui64, nwk) {
+        match self
+            .state
+            .address_map
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .insert(eui64, nwk)
+        {
             None => {
                 log::debug!("Added new address mapping: {eui64:?} -> {nwk:?}")
             }
@@ -835,8 +861,11 @@ impl ZigbeeStack {
         );
 
         // Clean a stale entry first, if one exists.
-        let mut broadcast_transaction_table =
-            self.state.broadcast_transaction_table.lock().unwrap();
+        let mut broadcast_transaction_table = self
+            .state
+            .broadcast_transaction_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         if let Some(entry) = broadcast_transaction_table.get(&key) {
             if entry.expiration_time > now {
@@ -863,7 +892,7 @@ impl ZigbeeStack {
                 Some(relaying_eui64) => {
                     self.state
                         .security_material_primary
-                        .lock()
+                        .try_lock_for(MAX_LOCK_DURATION)
                         .unwrap()
                         .incoming_frame_counter_set
                         .insert(relaying_eui64, aux_header.frame_counter);
@@ -920,7 +949,7 @@ impl ZigbeeStack {
                     );
                     self.state
                         .route_record_table
-                        .lock()
+                        .try_lock_for(MAX_LOCK_DURATION)
                         .unwrap()
                         .insert(nwk_frame.nwk_header.source, route_record_cmd.relays);
                 }
@@ -940,7 +969,11 @@ impl ZigbeeStack {
 
     fn maybe_recompute_lqa(&self, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
         // Find the source node via its EUI64 address (preferred) or its NWK address
-        let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+        let mut neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             neighbor_table.get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
@@ -968,7 +1001,13 @@ impl ZigbeeStack {
         let max_neighbor_age =
             (self.constants.router_age_limit as u32) * self.constants.link_status_period;
 
-        for neighbor in self.state.neighbor_table.lock().unwrap().values_mut() {
+        for neighbor in self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .values_mut()
+        {
             if neighbor.outgoing_cost > 0
                 && neighbor.last_link_status_timestamp >= now + max_neighbor_age
             {
@@ -1000,23 +1039,28 @@ impl ZigbeeStack {
         // mutating the state
         self.maybe_age_neighbors();
 
-        let neighbors_with_nonzero_outgoing_cost = self
-            .state
-            .neighbor_table
-            .lock()
-            .unwrap()
-            .iter()
-            .filter_map(|(_, neighbor_entry)| {
-                if neighbor_entry.outgoing_cost > 0 {
-                    Some(neighbor_entry.network_address)
-                } else {
-                    None
-                }
-            })
-            .collect::<HashSet<Nwk>>();
+        let neighbors_with_nonzero_outgoing_cost = {
+            self.state
+                .neighbor_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .iter()
+                .filter_map(|(_, neighbor_entry)| {
+                    if neighbor_entry.outgoing_cost > 0 {
+                        Some(neighbor_entry.network_address)
+                    } else {
+                        None
+                    }
+                })
+                .collect::<HashSet<Nwk>>()
+        };
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
-        let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+        let mut neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         let neighbor_entry = match neighbor_table.get_mut(&source_ieee) {
             Some(entry) => entry,
@@ -1093,7 +1137,11 @@ impl ZigbeeStack {
     }
 
     fn notify_routing_change(&self, nwk: &Nwk) {
-        let pending_route_notifications = self.state.pending_route_notifications.lock().unwrap();
+        let pending_route_notifications = self
+            .state
+            .pending_route_notifications
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         if !pending_route_notifications.contains_key(nwk) {
             return;
@@ -1119,7 +1167,11 @@ impl ZigbeeStack {
 
         let our_nwk_address = self.state.network_address;
 
-        let neighbor_table = self.state.neighbor_table.lock().unwrap();
+        let neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
         let neighbor = {
             match neighbor_table
                 .values()
@@ -1148,14 +1200,22 @@ impl ZigbeeStack {
 
         // TODO: clean this up, the mutability problems caused by the shared state mutex
         // make having two mutable borrows at once very difficult
-        let mut route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+        let mut route_discovery_table = self
+            .state
+            .route_discovery_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
         let Some(discovery_entry) = route_discovery_table.get_mut(&route_discovery_table_key)
         else {
             log::debug!("Route reply for unknown route discovery, ignoring");
             return;
         };
 
-        let mut route_table = self.state.route_table.lock().unwrap();
+        let mut route_table = self
+            .state
+            .route_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
         let Some(routing_entry) = route_table.get_mut(&route_reply_cmd.responder_nwk) else {
             log::debug!("Route reply with unknown responder, ignoring");
             return;
@@ -1221,6 +1281,7 @@ impl ZigbeeStack {
 
         // Mutate the routing entry
         routing_entry.next_hop_address = nwk_frame.nwk_header.source;
+        drop(route_table);
 
         // Mutate the discovery entry
         discovery_entry.residual_cost = updated_path_cost;
@@ -1230,7 +1291,6 @@ impl ZigbeeStack {
         // Find the next hop to the destination
         let next_hop_nwk = discovery_entry.sender_address;
 
-        let neighbor_table = self.state.neighbor_table.lock().unwrap();
         let Some(next_hop_neighbor) = neighbor_table
             .values()
             .find(|&entry| entry.network_address == next_hop_nwk)
@@ -1255,7 +1315,13 @@ impl ZigbeeStack {
                 destination: next_hop_nwk,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: *self.state.sequence_number.lock().unwrap(),
+                sequence_number: {
+                    *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                },
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -1292,7 +1358,7 @@ impl ZigbeeStack {
 
         self.state
             .route_discovery_table
-            .lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .retain(|_, entry| {
                 if entry.expiration_time <= now {
@@ -1319,7 +1385,11 @@ impl ZigbeeStack {
         );
 
         let network_address = self.state.network_address;
-        let neighbor_table = self.state.neighbor_table.lock().unwrap();
+        let neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
         // We need to know who sent the frame
         let Some(sender_neighbor) = neighbor_table
             .values()
@@ -1349,7 +1419,11 @@ impl ZigbeeStack {
         // table entry via the relaying device. This is free routing information and
         // should be used.
         {
-            let mut route_table = self.state.route_table.lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             let route_table_entry = route_table
                 .entry(route_request_cmd.destination_address)
@@ -1380,7 +1454,11 @@ impl ZigbeeStack {
         // Create a routing table entry that assigns the node that last-relayed the
         // route request command to be the next-hop for the original sender
         {
-            let mut route_table = self.state.route_table.lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             let route_table_entry = route_table
                 .entry(nwk_frame.nwk_header.source)
@@ -1424,7 +1502,11 @@ impl ZigbeeStack {
         if !is_for_self_or_child {
             self.clean_route_discovery_table();
 
-            let mut route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+            let mut route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
@@ -1452,24 +1534,26 @@ impl ZigbeeStack {
             }
 
             // Create an entry in the routing table as well
-            self.state
-                .route_table
-                .lock()
-                .unwrap()
-                .entry(route_request_cmd.destination_address)
-                .or_insert_with(|| route::TableEntry {
-                    destination: route_request_cmd.destination_address,
-                    status: route::Status::DiscoveryUnderway,
-                    no_route_cache: false,
-                    many_to_one: false,
-                    route_record_required: false,
-                    expired: false,
-                    sequence_number_valid: false,
-                    next_hop_address: Nwk(0xFFFF),
-                    sequence_number: 0,
-                    total_usage_count: 0,
-                    recent_activity: 0,
-                });
+            {
+                self.state
+                    .route_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .entry(route_request_cmd.destination_address)
+                    .or_insert_with(|| route::TableEntry {
+                        destination: route_request_cmd.destination_address,
+                        status: route::Status::DiscoveryUnderway,
+                        no_route_cache: false,
+                        many_to_one: false,
+                        route_record_required: false,
+                        expired: false,
+                        sequence_number_valid: false,
+                        next_hop_address: Nwk(0xFFFF),
+                        sequence_number: 0,
+                        total_usage_count: 0,
+                        recent_activity: 0,
+                    });
+            }
 
             // If we get here, we have a reason to relay
             let rebroadcast_radius = nwk_frame.nwk_header.radius.saturating_sub(1);
@@ -1495,7 +1579,13 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.destination,
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
-                    sequence_number: *self.state.sequence_number.lock().unwrap(), // TODO: do we change this?
+                    sequence_number: {
+                        *self
+                            .state
+                            .sequence_number
+                            .try_lock_for(MAX_LOCK_DURATION)
+                            .unwrap() // TODO: do we change this?
+                    },
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
                     multicast_control: None,
@@ -1531,7 +1621,13 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.source,
                     source: self.state.network_address,
                     radius: 2 * self.constants.max_depth,
-                    sequence_number: *self.state.sequence_number.lock().unwrap(),
+                    sequence_number: {
+                        *self
+                            .state
+                            .sequence_number
+                            .try_lock_for(MAX_LOCK_DURATION)
+                            .unwrap()
+                    },
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
@@ -1574,7 +1670,13 @@ impl ZigbeeStack {
                 destination: nwk_frame.nwk_header.source,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: *self.state.sequence_number.lock().unwrap(),
+                sequence_number: {
+                    *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                },
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1605,8 +1707,11 @@ impl ZigbeeStack {
     async fn send_802154_frame(&self, mut frame: Ieee802154Frame) -> Result<(), ZigbeeStackError> {
         // Increment the 802.15.4 sequence number
         if !frame.frame_control.sequence_number_suppression {
-            let mut ieee802154_sequence_number =
-                self.state.ieee802154_sequence_number.lock().unwrap();
+            let mut ieee802154_sequence_number = self
+                .state
+                .ieee802154_sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *ieee802154_sequence_number = ieee802154_sequence_number.wrapping_add(1);
 
             frame.sequence_number = Some(*ieee802154_sequence_number);
@@ -1624,7 +1729,7 @@ impl ZigbeeStack {
             .spinel
             .transmit_frame(&SpinelTxFrame {
                 psdu: frame.to_bytes(),
-                channel: Some(*self.state.channel.lock().unwrap()),
+                channel: { Some(*self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap()) },
                 max_csma_backoffs: Some(1),
                 max_frame_retries: Some(5),
                 enable_csma_ca: Some(true),
@@ -1691,7 +1796,11 @@ impl ZigbeeStack {
             .await?;
 
         nwk_frame.nwk_header.sequence_number = {
-            let mut sequence_number = self.state.sequence_number.lock().unwrap();
+            let mut sequence_number = self
+                .state
+                .sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *sequence_number = sequence_number.wrapping_add(1);
             *sequence_number
         };
@@ -1711,8 +1820,11 @@ impl ZigbeeStack {
         for attempt in 0..=self.constants.unicast_retries {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut security_material_primary =
-                    self.state.security_material_primary.lock().unwrap();
+                let mut security_material_primary = self
+                    .state
+                    .security_material_primary
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap();
                 security_material_primary.outgoing_frame_counter = security_material_primary
                     .outgoing_frame_counter
                     .wrapping_add(1);
@@ -1720,8 +1832,16 @@ impl ZigbeeStack {
                 security_material_primary.outgoing_frame_counter
             };
 
-            let encrypted_nwk_frame =
-                nwk_frame.encrypt(&self.state.security_material_primary.lock().unwrap().key);
+            let encrypted_nwk_frame = {
+                nwk_frame.encrypt(
+                    &self
+                        .state
+                        .security_material_primary
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                        .key,
+                )
+            };
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1737,8 +1857,16 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: Some(*self.state.ieee802154_sequence_number.lock().unwrap()),
-                dest_pan_id: Some(*self.state.pan_id.lock().unwrap()),
+                sequence_number: {
+                    Some(
+                        *self
+                            .state
+                            .ieee802154_sequence_number
+                            .try_lock_for(MAX_LOCK_DURATION)
+                            .unwrap(),
+                    )
+                },
+                dest_pan_id: { Some(*self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap()) },
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
                 src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
@@ -1749,8 +1877,17 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            let address_map = self.state.address_map.lock().unwrap();
-            let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+            let mut neighbor_table = self
+                .state
+                .neighbor_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
+
+            let address_map = self
+                .state
+                .address_map
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             if let Some(relaying_ieee) = address_map.iter().find_map(|(&eui64, &nwk)| {
                 if nwk == next_hop_address {
@@ -1766,7 +1903,13 @@ impl ZigbeeStack {
                 }
             }
 
-            let mut route_table = self.state.route_table.lock().unwrap();
+            drop(address_map);
+
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             // And the routing table counters
             if let Some(route_entry) = route_table.get_mut(&nwk_frame.nwk_header.destination) {
@@ -1776,7 +1919,7 @@ impl ZigbeeStack {
 
             // Increment counters before sending
             let tx_total = {
-                let mut tx_total = self.state.tx_total.lock().unwrap();
+                let mut tx_total = self.state.tx_total.try_lock_for(MAX_LOCK_DURATION).unwrap();
                 *tx_total = tx_total.wrapping_add(1);
                 *tx_total
             };
@@ -1787,6 +1930,9 @@ impl ZigbeeStack {
                     neighbor.transmit_failure = 0;
                 }
             }
+
+            drop(neighbor_table);
+            drop(route_table);
 
             match self.send_802154_frame(ieee802154_frame).await {
                 Ok(_) => {
@@ -1818,7 +1964,11 @@ impl ZigbeeStack {
         mut nwk_frame: NwkFrame,
     ) -> Result<(), ZigbeeStackError> {
         nwk_frame.nwk_header.sequence_number = {
-            let mut sequence_number = self.state.sequence_number.lock().unwrap();
+            let mut sequence_number = self
+                .state
+                .sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *sequence_number = sequence_number.wrapping_add(1);
             *sequence_number
         };
@@ -1838,8 +1988,11 @@ impl ZigbeeStack {
         for attempt in 0..=self.constants.max_broadcast_retries {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut security_material_primary =
-                    self.state.security_material_primary.lock().unwrap();
+                let mut security_material_primary = self
+                    .state
+                    .security_material_primary
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap();
                 security_material_primary.outgoing_frame_counter = security_material_primary
                     .outgoing_frame_counter
                     .wrapping_add(1);
@@ -1847,8 +2000,16 @@ impl ZigbeeStack {
                 security_material_primary.outgoing_frame_counter
             };
 
-            let encrypted_nwk_frame =
-                nwk_frame.encrypt(&self.state.security_material_primary.lock().unwrap().key);
+            let encrypted_nwk_frame = {
+                nwk_frame.encrypt(
+                    &self
+                        .state
+                        .security_material_primary
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                        .key,
+                )
+            };
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1864,8 +2025,16 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: Some(*self.state.ieee802154_sequence_number.lock().unwrap()),
-                dest_pan_id: Some(*self.state.pan_id.lock().unwrap()),
+                sequence_number: {
+                    Some(
+                        *self
+                            .state
+                            .ieee802154_sequence_number
+                            .try_lock_for(MAX_LOCK_DURATION)
+                            .unwrap(),
+                    )
+                },
+                dest_pan_id: Some(*self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap()),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
@@ -1876,18 +2045,24 @@ impl ZigbeeStack {
             };
 
             // Increment counters before sending
-            let tx_total = {
-                let mut tx_total = self.state.tx_total.lock().unwrap();
-                *tx_total = tx_total.wrapping_add(1);
-                *tx_total
-            };
+            {
+                let tx_total = {
+                    let mut tx_total = self.state.tx_total.try_lock_for(MAX_LOCK_DURATION).unwrap();
+                    *tx_total = tx_total.wrapping_add(1);
+                    *tx_total
+                };
 
-            // Handle `tx_total` wrapping
-            let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+                // Handle `tx_total` wrapping
+                let mut neighbor_table = self
+                    .state
+                    .neighbor_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap();
 
-            if tx_total == 0x0000 {
-                for (_, neighbor) in neighbor_table.iter_mut() {
-                    neighbor.transmit_failure = 0;
+                if tx_total == 0x0000 {
+                    for (_, neighbor) in neighbor_table.iter_mut() {
+                        neighbor.transmit_failure = 0;
+                    }
                 }
             }
 
@@ -1915,19 +2090,24 @@ impl ZigbeeStack {
 
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, ZigbeeStackError> {
         if self.state.hack_force_route_discovery
-            || !self
-                .state
-                .route_table
-                .lock()
-                .unwrap()
-                .contains_key(&destination)
+            || !{
+                self.state
+                    .route_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .contains_key(&destination)
+            }
         {
             log::debug!("Starting route discovery for NWK {destination:?}");
             self.send_route_discovery(destination).await;
         }
 
         let (route_entry_status, route_entry_next_hop_address) = {
-            let route_table = self.state.route_table.lock().unwrap();
+            let route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let entry = route_table.get(&destination).unwrap();
 
             (entry.status, entry.next_hop_address)
@@ -1954,8 +2134,11 @@ impl ZigbeeStack {
 
         // Create a pending route notification
         let mut rx = {
-            let mut pending_route_notifications =
-                self.state.pending_route_notifications.lock().unwrap();
+            let mut pending_route_notifications = self
+                .state
+                .pending_route_notifications
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let tx = pending_route_notifications
                 .entry(destination)
                 .or_insert_with(|| {
@@ -1969,7 +2152,11 @@ impl ZigbeeStack {
         // Pull the current route discovery entry for the device to determine the timeout
         let discovery_timeout = {
             let now = Instant::now();
-            let route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+            let route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             // One should exist
             let route_discovery_entry =
@@ -2002,7 +2189,11 @@ impl ZigbeeStack {
             }
             Err(err) => {
                 log::debug!("Route discovery timed out");
-                let mut route_table = self.state.route_table.lock().unwrap();
+                let mut route_table = self
+                    .state
+                    .route_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap();
                 let entry = route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
                 return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
@@ -2012,7 +2203,7 @@ impl ZigbeeStack {
         let next_hop_address = {
             self.state
                 .route_table
-                .lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap()
                 .get(&destination)
                 .unwrap()
@@ -2028,7 +2219,11 @@ impl ZigbeeStack {
 
         // Get or create a routing table entry without keeping a mutable reference
         {
-            let mut route_table = self.state.route_table.lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let route_table_entry = route_table.entry(destination).or_insert_with(|| {
                 route::TableEntry {
                     destination: destination,
@@ -2049,8 +2244,11 @@ impl ZigbeeStack {
         }
 
         let route_request_identifier = {
-            let mut routing_request_sequence_number =
-                self.state.routing_request_sequence_number.lock().unwrap();
+            let mut routing_request_sequence_number = self
+                .state
+                .routing_request_sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *routing_request_sequence_number = routing_request_sequence_number.wrapping_add(1);
             *routing_request_sequence_number
         };
@@ -2063,7 +2261,11 @@ impl ZigbeeStack {
         self.clean_route_discovery_table();
 
         {
-            let mut route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+            let mut route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
@@ -2082,10 +2284,10 @@ impl ZigbeeStack {
         }
 
         // If we know the EUI64 corresponding to the NWK, use it
-        let destination_eui64 =
+        let destination_eui64 = {
             self.state
                 .address_map
-                .lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap()
                 .iter()
                 .find_map(|(&eui64, &nwk)| {
@@ -2094,7 +2296,8 @@ impl ZigbeeStack {
                     } else {
                         None
                     }
-                });
+                })
+        };
 
         // Construct a frame
         let route_request_frame = NwkFrame {
@@ -2113,7 +2316,13 @@ impl ZigbeeStack {
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: *self.state.sequence_number.lock().unwrap(),
+                sequence_number: {
+                    *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                },
                 destination_ieee: None,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -2219,7 +2428,13 @@ impl ZigbeeStack {
                 destination: destination,
                 source: self.state.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: *self.state.sequence_number.lock().unwrap(),
+                sequence_number: {
+                    *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                },
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2248,11 +2463,13 @@ impl ZigbeeStack {
         let (ack_tx, ack_rx) = oneshot::channel();
 
         log::debug!("APS ACK requested, waiting for {:?}", ack_data);
-        self.state
-            .pending_aps_acks
-            .lock()
-            .unwrap()
-            .insert(ack_data, ack_tx);
+        {
+            self.state
+                .pending_aps_acks
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .insert(ack_data, ack_tx);
+        }
 
         self.background_send_nwk_frame(nwk_frame);
 
@@ -2283,7 +2500,13 @@ impl ZigbeeStack {
         }
 
         // Decrement the `recent_activity` field of every active routing table entry
-        for (_, route_table_entry) in self.state.route_table.lock().unwrap().iter_mut() {
+        for (_, route_table_entry) in self
+            .state
+            .route_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .iter_mut()
+        {
             if route_table_entry.status == route::Status::Active {
                 route_table_entry.recent_activity =
                     route_table_entry.recent_activity.saturating_sub(1);
@@ -2293,7 +2516,13 @@ impl ZigbeeStack {
         // Decrement the inbound and outbound activity fields for neighbors
         self.maybe_age_neighbors();
 
-        for (_, neighbor_entry) in self.state.neighbor_table.lock().unwrap().iter_mut() {
+        for (_, neighbor_entry) in self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .iter_mut()
+        {
             neighbor_entry.router_outbound_activity =
                 neighbor_entry.router_outbound_activity.saturating_sub(1);
             neighbor_entry.router_inbound_activity =
@@ -2303,7 +2532,7 @@ impl ZigbeeStack {
         let mut link_statuses = if !empty {
             self.state
                 .neighbor_table
-                .lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap()
                 .iter()
                 .filter_map(|(_, neighbor)| {
@@ -2343,7 +2572,13 @@ impl ZigbeeStack {
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                     source: self.state.network_address,
                     radius: 1,
-                    sequence_number: *self.state.sequence_number.lock().unwrap(),
+                    sequence_number: {
+                        *self
+                            .state
+                            .sequence_number
+                            .try_lock_for(MAX_LOCK_DURATION)
+                            .unwrap()
+                    },
                     destination_ieee: None,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
@@ -2376,6 +2611,7 @@ impl ZigbeeStack {
 
     pub async fn periodic_link_status_broadcast_task(&self) {
         loop {
+            log::debug!("Sending periodic link status broadcast...");
             tokio::time::sleep(self.constants.link_status_period).await;
 
             self.send_link_status_broadcast(false).await;

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -135,142 +135,6 @@ pub enum NwkDeviceType {
     EndDevice = 0x02,
 }
 
-// TODO, cut this up (nib) into multiple structs
-
-/// Zigbee spec: 3.5.2 NWK Information Base
-///
-/// The NWK information base (NIB) comprises the attributes required to manage
-/// the NWK layer of a device. Each of these attributes can be read or
-/// written using the NLME-GET.request and NLME-SET.request primitives,
-/// respectively. Except those who are read only
-#[derive(Debug)]
-pub struct Nib {
-    pub sequence_number: u8,
-    pub neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
-    pub route_table: HashMap<Nwk, route::TableEntry>,
-    pub route_discovery_table: HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>,
-    pub capability_information: NwkCapabilityInformation,
-    pub manager_addr: Nwk,
-    pub update_id: u8,
-    pub network_address: Nwk,
-    pub broadcast_transaction_table: HashMap<(Nwk, u8), NwkBroadcastTransaction>,
-    pub extended_pan_id: Eui64,
-    pub route_record_table: HashMap<Nwk, Vec<Nwk>>,
-    pub is_concentrator: bool,
-    pub security_level: u8,
-    pub security_material_primary: NwkSecurityDescriptor,
-    pub security_material_alternate: NwkSecurityDescriptor,
-    pub active_key_seq_number: u8,
-    pub all_fresh: bool,
-    pub address_map: HashMap<Eui64, Nwk>,
-
-    /// A flag that determines if a timestamp indication is provided on incoming and
-    /// outgoing packets.
-    pub time_stamp: bool,
-
-    pub pan_id: PanId,
-
-    /// A count of Unicast transmissions made by the NNK layer on this device.
-    /// Each time the NWK layer transmits a Unicast frame, by invoking the
-    /// MCPS-state.request primitive of the MAC sub-layer, it SHALL increment
-    /// this counter. When either the NHL performs an NLME-SET.request on this
-    /// attribute or if the value of `tx_total` rolls over past 0xffff the
-    /// NWK layer SHALL reset to 0x00 each Transmit Failure field contained in
-    /// the neighbor table.
-    pub tx_total: u16,
-
-    /// This policy determines whether or not a remote NWK leave request command frame
-    /// received by the local device is accepted.
-    pub leave_request_allowed: bool,
-
-    pub parent_information: u8,
-
-    /// This is an index into Table 3-54. It indicates the default timeout in minutes for
-    /// any end device that does not negotiate a different timeout value.
-    pub end_device_timeout_default: u8,
-
-    /// This policy determines whether a NWK leave request is accepted when the Rejoin
-    /// bit in the message is set to FALSE
-    pub leave_request_without_rejoin_allowed: bool,
-
-    pub ieee_address: Eui64,
-
-    // A strictly increasing sequence number included in all route request and route
-    // reply command frames to allow other routers to determine the chronological order
-    // of such route discovery messages.
-    // pub nwk_routing_sequence_number: u16,  // Only needed for R23 TLVs
-    //
-    /// Implied from the spec: "notice that this 8-bit identifier is distinct from the
-    /// 16-bit Routing Sequence Number. The former is used to discern route requests
-    /// originating in a particular router; the latter is used to identify stale routing
-    /// information."
-    pub routing_request_sequence_number: u8,
-
-    /// This indicates whether the router has Hub Connectivity as defined by a higher
-    /// level application. The higher level application sets this value and the stack
-    /// advertises it.
-    pub hub_connectivity: bool,
-}
-
-impl Nib {
-    pub fn new() -> Self {
-        Nib {
-            sequence_number: 0,
-            neighbor_table: HashMap::new(),
-            route_table: HashMap::new(),
-            route_discovery_table: HashMap::new(),
-            capability_information: NwkCapabilityInformation {
-                alternate_pan_coordinator: false,
-                device_type: NwkCapabilityInformationDeviceType::EndDevice,
-                power_source: NwkCapabilityInformationPowerSource::MainsPower,
-                receiver_on_when_idle: true,
-                reserved1: false,
-                reserved2: false,
-                security_capability: NwkSecurityCapability::Capable,
-                allocate_address: true,
-            },
-            manager_addr: Nwk(0x0000),
-            update_id: 0,
-            network_address: Nwk(0x0000),
-            broadcast_transaction_table: HashMap::new(),
-            extended_pan_id: Eui64::from_hex("0000000000000000"),
-            route_record_table: HashMap::new(),
-            is_concentrator: true,
-            security_level: 5,
-            security_material_primary: NwkSecurityDescriptor {
-                key_seq_number: 0,
-                outgoing_frame_counter: 0,
-                incoming_frame_counter_set: HashMap::new(),
-                key: Key::from_hex("00000000000000000000000000000000"),
-                network_key_type: NetworkKeyType::Standard,
-            },
-            security_material_alternate: NwkSecurityDescriptor {
-                key_seq_number: 0,
-                outgoing_frame_counter: 0,
-                incoming_frame_counter_set: HashMap::new(),
-                key: Key::from_hex("00000000000000000000000000000000"),
-                network_key_type: NetworkKeyType::Standard,
-            },
-            active_key_seq_number: 0,
-            all_fresh: false,
-            address_map: HashMap::new(),
-            time_stamp: false,
-            pan_id: PanId(0xFFFF),
-            tx_total: 0,
-            leave_request_allowed: false,
-            parent_information: 0,
-            end_device_timeout_default: 0,
-            leave_request_without_rejoin_allowed: false,
-            ieee_address: Eui64::from_hex("0000000000000000"),
-            // TODO: The 16-bit routing sequence number is expected to be
-            // strictly-increasing, it should be persisted to disk
-            // nwk_routing_sequence_number: 0x0000,
-            routing_request_sequence_number: 0x00,
-            hub_connectivity: true,
-        }
-    }
-}
-
 #[derive(Debug)]
 pub struct Constants {
     pub concentrator_radius: u8,
@@ -311,6 +175,10 @@ pub struct Constants {
     pub min_router_bootstrap_jitter: Duration,
     pub max_router_bootstrap_jitter: Duration,
     pub broadcast_delivery_time: Duration,
+
+    /// This is an index into Table 3-54. It indicates the default timeout in minutes for
+    /// any end device that does not negotiate a different timeout value.
+    pub end_device_timeout_default: u8,
 }
 
 impl Constants {
@@ -341,6 +209,7 @@ impl Constants {
             min_router_bootstrap_jitter: Duration::from_millis(500),
             max_router_bootstrap_jitter: Duration::from_millis(1000),
             broadcast_delivery_time: Duration::from_millis(9000),
+            end_device_timeout_default: 0,
         }
     }
 }
@@ -372,7 +241,7 @@ impl ApsAckData {
 pub struct State {
     pub channel: u8,
     pub ieee802154_sequence_number: u8,
-    pub nib: Nib,
+
     pub pending_aps_acks: HashMap<ApsAckData, oneshot::Sender<()>>,
     pub pending_route_notifications: HashMap<Nwk, broadcast::Sender<()>>,
     pub start_time: Option<Instant>,
@@ -391,6 +260,72 @@ pub struct State {
     /// Instead of caching route information, always perform route discovery. This is
     /// much slower but ensures that routing logic is always followed.
     pub hack_force_route_discovery: bool,
+
+    // NIB
+    pub sequence_number: u8,
+    pub neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
+    pub route_table: HashMap<Nwk, route::TableEntry>,
+    pub route_discovery_table: HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>,
+    pub capability_information: NwkCapabilityInformation,
+    pub nwk_manager_addr: Nwk,
+    pub update_id: u8,
+    pub network_address: Nwk,
+    pub broadcast_transaction_table: HashMap<(Nwk, u8), NwkBroadcastTransaction>,
+    pub extended_pan_id: Eui64,
+    pub route_record_table: HashMap<Nwk, Vec<Nwk>>,
+    pub is_concentrator: bool,
+    pub security_level: u8,
+    pub security_material_primary: NwkSecurityDescriptor,
+    pub security_material_alternate: NwkSecurityDescriptor,
+    pub active_key_seq_number: u8,
+
+    /// Indicates whether incoming NWK frames SHALL be all checked for freshness when
+    /// the memory for incoming frame counts is exceeded.
+    pub all_fresh: bool,
+    pub address_map: HashMap<Eui64, Nwk>,
+
+    /// A flag that determines if a timestamp indication is provided on incoming and
+    /// outgoing packets.
+    pub time_stamp: bool,
+
+    pub pan_id: PanId,
+
+    /// A count of Unicast transmissions made by the NNK layer on this device.
+    /// Each time the NWK layer transmits a Unicast frame, by invoking the
+    /// MCPS-state.request primitive of the MAC sub-layer, it SHALL increment
+    /// this counter. When either the NHL performs an NLME-SET.request on this
+    /// attribute or if the value of `tx_total` rolls over past 0xffff the
+    /// NWK layer SHALL reset to 0x00 each Transmit Failure field contained in
+    /// the neighbor table.
+    pub tx_total: u16,
+
+    /// This policy determines whether or not a remote NWK leave request command frame
+    /// received by the local device is accepted.
+    pub leave_request_allowed: bool,
+
+    pub parent_information: u8,
+
+    /// This policy determines whether a NWK leave request is accepted when the Rejoin
+    /// bit in the message is set to FALSE
+    pub leave_request_without_rejoin_allowed: bool,
+
+    pub ieee_address: Eui64,
+
+    // A strictly increasing sequence number included in all route request and route
+    // reply command frames to allow other routers to determine the chronological order
+    // of such route discovery messages.
+    // pub nwk_routing_sequence_number: u16,  // Only needed for R23 TLVs
+    //
+    /// Implied from the spec: "notice that this 8-bit identifier is distinct from the
+    /// 16-bit Routing Sequence Number. The former is used to discern route requests
+    /// originating in a particular router; the latter is used to identify stale routing
+    /// information."
+    pub routing_request_sequence_number: u8,
+
+    /// This indicates whether the router has Hub Connectivity as defined by a higher
+    /// level application. The higher level application sets this value and the stack
+    /// advertises it.
+    pub hub_connectivity: bool,
 }
 
 impl State {
@@ -398,7 +333,6 @@ impl State {
         State {
             channel: 0,
             ieee802154_sequence_number: 0,
-            nib: Nib::new(),
             pending_aps_acks: HashMap::new(),
             pending_route_notifications: HashMap::new(),
             start_time: None,
@@ -406,6 +340,58 @@ impl State {
             hack_ignore_broadcast_startup_wait_period: true,
             hack_disable_tx: false,
             hack_force_route_discovery: false,
+
+            sequence_number: 0,
+            neighbor_table: HashMap::new(),
+            route_table: HashMap::new(),
+            route_discovery_table: HashMap::new(),
+            capability_information: NwkCapabilityInformation {
+                alternate_pan_coordinator: false,
+                device_type: NwkCapabilityInformationDeviceType::EndDevice,
+                power_source: NwkCapabilityInformationPowerSource::MainsPower,
+                receiver_on_when_idle: true,
+                reserved1: false,
+                reserved2: false,
+                security_capability: NwkSecurityCapability::Capable,
+                allocate_address: true,
+            },
+            nwk_manager_addr: Nwk(0x0000),
+            update_id: 0,
+            network_address: Nwk(0x0000),
+            broadcast_transaction_table: HashMap::new(),
+            extended_pan_id: Eui64::from_hex("0000000000000000"),
+            route_record_table: HashMap::new(),
+            is_concentrator: true,
+            security_level: 5,
+            security_material_primary: NwkSecurityDescriptor {
+                key_seq_number: 0,
+                outgoing_frame_counter: 0,
+                incoming_frame_counter_set: HashMap::new(),
+                key: Key::from_hex("00000000000000000000000000000000"),
+                network_key_type: NetworkKeyType::Standard,
+            },
+            security_material_alternate: NwkSecurityDescriptor {
+                key_seq_number: 0,
+                outgoing_frame_counter: 0,
+                incoming_frame_counter_set: HashMap::new(),
+                key: Key::from_hex("00000000000000000000000000000000"),
+                network_key_type: NetworkKeyType::Standard,
+            },
+            active_key_seq_number: 0,
+            all_fresh: false,
+            address_map: HashMap::new(),
+            time_stamp: false,
+            pan_id: PanId(0xFFFF),
+            tx_total: 0,
+            leave_request_allowed: false,
+            parent_information: 0,
+            leave_request_without_rejoin_allowed: false,
+            ieee_address: Eui64::from_hex("0000000000000000"),
+            // TODO: The 16-bit routing sequence number is expected to be
+            // strictly-increasing, it should be persisted to disk
+            // nwk_routing_sequence_number: 0x0000,
+            routing_request_sequence_number: 0x00,
+            hub_connectivity: true,
         }
     }
 }
@@ -549,7 +535,7 @@ impl ZigbeeStack {
 
     pub async fn set_network_settings(
         &self,
-        nwk_channel: u8,
+        channel: u8,
         update_id: u8,
         pan_id: PanId,
         extended_pan_id: Eui64,
@@ -560,15 +546,15 @@ impl ZigbeeStack {
         outgoing_frame_counter: u32,
     ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
-        state.channel = nwk_channel;
-        state.nib.update_id = update_id;
-        state.nib.pan_id = pan_id;
-        state.nib.extended_pan_id = extended_pan_id;
-        state.nib.network_address = network_address;
-        state.nib.ieee_address = ieee_address;
-        state.nib.security_material_primary.key = key;
-        state.nib.security_material_primary.key_seq_number = key_seq_number;
-        state.nib.security_material_primary.outgoing_frame_counter = outgoing_frame_counter;
+        state.channel = channel;
+        state.update_id = update_id;
+        state.pan_id = pan_id;
+        state.extended_pan_id = extended_pan_id;
+        state.network_address = network_address;
+        state.ieee_address = ieee_address;
+        state.security_material_primary.key = key;
+        state.security_material_primary.key_seq_number = key_seq_number;
+        state.security_material_primary.outgoing_frame_counter = outgoing_frame_counter;
 
         // Update the hardware with new settings.
         self.spinel
@@ -577,7 +563,7 @@ impl ZigbeeStack {
             .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
-            .prop_value_set(SpinelPropertyId::PhyChan, vec![nwk_channel])
+            .prop_value_set(SpinelPropertyId::PhyChan, vec![channel])
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
@@ -599,7 +585,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Laddr,
-                state.nib.ieee_address.to_bytes().to_vec(),
+                state.ieee_address.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -607,7 +593,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Saddr,
-                state.nib.network_address.to_bytes().to_vec(),
+                state.network_address.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -615,7 +601,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Panid,
-                state.nib.pan_id.to_bytes().to_vec(),
+                state.pan_id.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -684,11 +670,11 @@ impl ZigbeeStack {
                 log::debug!("Ignoring frame, destination PAN ID is not present");
                 return None;
             }
-            Some(dest_pan_id) if dest_pan_id != state.nib.pan_id => {
+            Some(dest_pan_id) if dest_pan_id != state.pan_id => {
                 log::debug!(
                     "Ignoring frame, PAN ID does not match {:?} != {:?}",
                     dest_pan_id,
-                    state.nib.pan_id
+                    state.pan_id
                 );
                 return None;
             }
@@ -705,7 +691,7 @@ impl ZigbeeStack {
         };
 
         // Ignore frames that aren't destined for us
-        if nwk_frame.nwk_header.destination != state.nib.network_address
+        if nwk_frame.nwk_header.destination != state.network_address
             && nwk_frame.nwk_header.destination.as_u16()
                 < BROADCAST_ALL_ROUTERS_AND_COORDINATOR.as_u16()
         {
@@ -740,7 +726,7 @@ impl ZigbeeStack {
         }
 
         // Validate the network key sequence number
-        if aux_header.key_sequence_number != state.nib.active_key_seq_number {
+        if aux_header.key_sequence_number != state.active_key_seq_number {
             log::debug!("Ignoring frame, key sequence number is unknown");
             return None;
         }
@@ -759,7 +745,6 @@ impl ZigbeeStack {
         }
 
         match state
-            .nib
             .security_material_primary
             .incoming_frame_counter_set
             .get(&src_eui64)
@@ -781,12 +766,11 @@ impl ZigbeeStack {
         log::debug!(
             "Attempting to decrypt {:?} with {:?}",
             nwk_frame,
-            state.nib.security_material_primary
+            state.security_material_primary
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame = match nwk_frame.decrypt(&state.nib.security_material_primary.key)
-        {
+        let decrypted_nwk_frame = match nwk_frame.decrypt(&state.security_material_primary.key) {
             Ok(decrypted_frame) => decrypted_frame,
             Err(err) => {
                 log::warn!("Ignoring frame, decryption failed: {err:?}");
@@ -814,7 +798,7 @@ impl ZigbeeStack {
     pub fn update_nwk_eui64_mapping(&self, nwk: Nwk, eui64: Eui64) {
         let mut state = self.state.lock().unwrap();
 
-        match state.nib.address_map.insert(eui64, nwk) {
+        match state.address_map.insert(eui64, nwk) {
             None => {
                 log::debug!("Added new address mapping: {eui64:?} -> {nwk:?}")
             }
@@ -845,13 +829,13 @@ impl ZigbeeStack {
         );
 
         // Clean a stale entry first, if one exists.
-        if let Some(entry) = state.nib.broadcast_transaction_table.get(&key) {
+        if let Some(entry) = state.broadcast_transaction_table.get(&key) {
             if entry.expiration_time > now {
                 return true;
             }
         }
 
-        state.nib.broadcast_transaction_table.insert(
+        state.broadcast_transaction_table.insert(
             key,
             NwkBroadcastTransaction {
                 source_nwk: nwk_frame.nwk_header.source,
@@ -870,7 +854,6 @@ impl ZigbeeStack {
                 Some(relaying_eui64) => {
                     let mut state = self.state.lock().unwrap();
                     state
-                        .nib
                         .security_material_primary
                         .incoming_frame_counter_set
                         .insert(relaying_eui64, aux_header.frame_counter);
@@ -928,7 +911,6 @@ impl ZigbeeStack {
                     );
                     let mut state = self.state.lock().unwrap();
                     state
-                        .nib
                         .route_record_table
                         .insert(nwk_frame.nwk_header.source, route_record_cmd.relays);
                 }
@@ -950,12 +932,10 @@ impl ZigbeeStack {
         // Find the source node via its EUI64 address (preferred) or its NWK address
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             state
-                .nib
                 .neighbor_table
                 .get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
         } else {
             state
-                .nib
                 .neighbor_table
                 .values_mut()
                 .find(|e| e.network_address == nwk_frame.nwk_header.source)
@@ -979,7 +959,7 @@ impl ZigbeeStack {
         let max_neighbor_age =
             (self.constants.router_age_limit as u32) * self.constants.link_status_period;
 
-        for neighbor in state.nib.neighbor_table.values_mut() {
+        for neighbor in state.neighbor_table.values_mut() {
             if neighbor.outgoing_cost > 0
                 && neighbor.last_link_status_timestamp >= now + max_neighbor_age
             {
@@ -1014,7 +994,6 @@ impl ZigbeeStack {
             self.maybe_age_neighbors(&mut state);
 
             state
-                .nib
                 .neighbor_table
                 .iter()
                 .filter_map(|(_, neighbor_entry)| {
@@ -1027,12 +1006,12 @@ impl ZigbeeStack {
                 .collect::<HashSet<Nwk>>()
         };
 
-        let network_address = self.state.lock().unwrap().nib.network_address;
+        let network_address = self.state.lock().unwrap().network_address;
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
 
         let mut state = self.state.lock().unwrap();
-        let neighbor_entry = match state.nib.neighbor_table.get_mut(&source_ieee) {
+        let neighbor_entry = match state.neighbor_table.get_mut(&source_ieee) {
             Some(entry) => entry,
             None => {
                 // Create one
@@ -1064,8 +1043,8 @@ impl ZigbeeStack {
                     security_timer: 0,
                 };
 
-                state.nib.neighbor_table.insert(source_ieee, entry);
-                state.nib.neighbor_table.get_mut(&source_ieee).unwrap()
+                state.neighbor_table.insert(source_ieee, entry);
+                state.neighbor_table.get_mut(&source_ieee).unwrap()
             }
         };
 
@@ -1130,10 +1109,9 @@ impl ZigbeeStack {
         // R23 spec but real devices do not do this
 
         let mut state = self.state.lock().unwrap();
-        let our_nwk_address = state.nib.network_address;
+        let our_nwk_address = state.network_address;
 
         let neighbor = match state
-            .nib
             .neighbor_table
             .values()
             .find(|&entry| entry.network_address == nwk_frame.nwk_header.source)
@@ -1160,16 +1138,13 @@ impl ZigbeeStack {
 
         // TODO: clean this up, the mutability problems caused by the shared state mutex
         // make having two mutable borrows at once very difficult
-        let Some(discovery_entry) = state
-            .nib
-            .route_discovery_table
-            .get(&route_discovery_table_key)
+        let Some(discovery_entry) = state.route_discovery_table.get(&route_discovery_table_key)
         else {
             log::debug!("Route reply for unknown route discovery, ignoring");
             return;
         };
 
-        let Some(routing_entry) = state.nib.route_table.get(&route_reply_cmd.responder_nwk) else {
+        let Some(routing_entry) = state.route_table.get(&route_reply_cmd.responder_nwk) else {
             log::debug!("Route reply with unknown responder, ignoring");
             return;
         };
@@ -1188,7 +1163,6 @@ impl ZigbeeStack {
                     // Mutate the routing entry
                     {
                         let routing_entry = state
-                            .nib
                             .route_table
                             .get_mut(&route_reply_cmd.responder_nwk).unwrap();
                         routing_entry.status = route::Status::Active;
@@ -1198,7 +1172,6 @@ impl ZigbeeStack {
                     // Mutate the discovery entry
                     {
                         let discovery_entry = state
-                            .nib
                             .route_discovery_table
                             .get_mut(&route_discovery_table_key).unwrap();
                         discovery_entry.residual_cost = updated_path_cost;
@@ -1223,7 +1196,6 @@ impl ZigbeeStack {
                     // Mutate the routing entry
                     {
                         let routing_entry = state
-                            .nib
                             .route_table
                             .get_mut(&route_reply_cmd.responder_nwk).unwrap();
                         routing_entry.next_hop_address = nwk_frame.nwk_header.source;
@@ -1232,7 +1204,6 @@ impl ZigbeeStack {
                     // Mutate the discovery entry
                     {
                         let discovery_entry = state
-                            .nib
                             .route_discovery_table
                             .get_mut(&route_discovery_table_key).unwrap();
                         discovery_entry.residual_cost = updated_path_cost;
@@ -1259,7 +1230,6 @@ impl ZigbeeStack {
         // Mutate the routing entry
         {
             let routing_entry = state
-                .nib
                 .route_table
                 .get_mut(&route_reply_cmd.responder_nwk)
                 .unwrap();
@@ -1269,7 +1239,6 @@ impl ZigbeeStack {
         // Mutate the discovery entry
         {
             let discovery_entry = state
-                .nib
                 .route_discovery_table
                 .get_mut(&route_discovery_table_key)
                 .unwrap();
@@ -1281,7 +1250,6 @@ impl ZigbeeStack {
         // Find the next hop to the destination
         let next_hop_nwk = {
             let discovery_entry = state
-                .nib
                 .route_discovery_table
                 .get_mut(&route_discovery_table_key)
                 .unwrap();
@@ -1290,7 +1258,6 @@ impl ZigbeeStack {
         };
 
         let Some(next_hop_neighbor) = state
-            .nib
             .neighbor_table
             .values()
             .find(|&entry| entry.network_address == next_hop_nwk)
@@ -1313,11 +1280,11 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: next_hop_nwk,
-                source: state.nib.network_address,
+                source: state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: state.nib.sequence_number,
+                sequence_number: state.sequence_number,
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
-                source_ieee: Some(state.nib.ieee_address),
+                source_ieee: Some(state.ieee_address),
                 multicast_control: None,
                 source_route: None,
             },
@@ -1379,10 +1346,9 @@ impl ZigbeeStack {
 
         let mut state = self.state.lock().unwrap();
 
-        let network_address = state.nib.network_address;
+        let network_address = state.network_address;
         // We need to know who sent the frame
         let Some(sender_neighbor) = state
-            .nib
             .neighbor_table
             .values()
             .find(|&entry| entry.network_address == sender_nwk)
@@ -1412,7 +1378,6 @@ impl ZigbeeStack {
         // should be used.
         {
             let route_table_entry = state
-                .nib
                 .route_table
                 .entry(route_request_cmd.destination_address)
                 .or_insert_with(|| {
@@ -1443,7 +1408,6 @@ impl ZigbeeStack {
         // route request command to be the next-hop for the original sender
         {
             let route_table_entry = state
-                .nib
                 .route_table
                 .entry(nwk_frame.nwk_header.source)
                 .or_insert_with(|| route::TableEntry {
@@ -1484,10 +1448,9 @@ impl ZigbeeStack {
         );
 
         if !is_for_self_or_child {
-            self.clean_route_discovery_table(&mut state.nib.route_discovery_table);
+            self.clean_route_discovery_table(&mut state.route_discovery_table);
 
             let route_discovery_entry = state
-                .nib
                 .route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
@@ -1515,7 +1478,6 @@ impl ZigbeeStack {
 
             // Create an entry in the routing table as well
             state
-                .nib
                 .route_table
                 .entry(route_request_cmd.destination_address)
                 .or_insert_with(|| route::TableEntry {
@@ -1556,7 +1518,7 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.destination,
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
-                    sequence_number: state.nib.sequence_number, // TODO: do we change this?
+                    sequence_number: state.sequence_number, // TODO: do we change this?
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
                     multicast_control: None,
@@ -1590,11 +1552,11 @@ impl ZigbeeStack {
                         end_device_initiator: false,
                     },
                     destination: nwk_frame.nwk_header.source,
-                    source: state.nib.network_address,
+                    source: state.network_address,
                     radius: 2 * self.constants.max_depth,
-                    sequence_number: state.nib.sequence_number,
+                    sequence_number: state.sequence_number,
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
-                    source_ieee: Some(state.nib.ieee_address),
+                    source_ieee: Some(state.ieee_address),
                     multicast_control: None,
                     source_route: None,
                 },
@@ -1602,10 +1564,10 @@ impl ZigbeeStack {
                 payload: NwkRouteReplyCommand {
                     route_request_identifier: route_request_cmd.route_request_identifier,
                     originator_nwk: nwk_frame.nwk_header.source,
-                    responder_nwk: state.nib.network_address,
+                    responder_nwk: state.network_address,
                     path_cost: updated_path_cost,
                     originator_eui64: nwk_frame.nwk_header.source_ieee,
-                    responder_eui64: Some(state.nib.ieee_address),
+                    responder_eui64: Some(state.ieee_address),
                 }
                 .serialize()
                 .unwrap(),
@@ -1634,9 +1596,9 @@ impl ZigbeeStack {
                 },
                 // Send our ACK back to the sender
                 destination: nwk_frame.nwk_header.source,
-                source: state.nib.network_address,
+                source: state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: state.nib.sequence_number,
+                sequence_number: state.sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1762,8 +1724,8 @@ impl ZigbeeStack {
             .await?;
         let mut state = self.state.lock().unwrap();
 
-        state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
-        nwk_frame.nwk_header.sequence_number = state.nib.sequence_number;
+        state.sequence_number = state.sequence_number.wrapping_add(1);
+        nwk_frame.nwk_header.sequence_number = state.sequence_number;
         nwk_frame.aux_header = Some(NwkAuxHeader {
             security_control: NwkSecurityHeaderControlField {
                 security_level: NwkSecurityLevel::NoSecurity,
@@ -1772,8 +1734,8 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
             },
             frame_counter: 0, // This field is rewritten and is always up-to-date
-            extended_source: Some(state.nib.ieee_address),
-            key_sequence_number: state.nib.active_key_seq_number,
+            extended_source: Some(state.ieee_address),
+            key_sequence_number: state.active_key_seq_number,
         });
 
         drop(state);
@@ -1782,16 +1744,15 @@ impl ZigbeeStack {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
-            state.nib.security_material_primary.outgoing_frame_counter = state
-                .nib
+            state.security_material_primary.outgoing_frame_counter = state
                 .security_material_primary
                 .outgoing_frame_counter
                 .wrapping_add(1);
 
             nwk_frame.aux_header.as_mut().unwrap().frame_counter =
-                state.nib.security_material_primary.outgoing_frame_counter;
+                state.security_material_primary.outgoing_frame_counter;
 
-            let encrypted_nwk_frame = nwk_frame.encrypt(&state.nib.security_material_primary.key);
+            let encrypted_nwk_frame = nwk_frame.encrypt(&state.security_material_primary.key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1808,10 +1769,10 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(state.ieee802154_sequence_number),
-                dest_pan_id: Some(state.nib.pan_id),
+                dest_pan_id: Some(state.pan_id),
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
-                src_address: Some(Ieee802154Address::Nwk(state.nib.network_address)),
+                src_address: Some(Ieee802154Address::Nwk(state.network_address)),
                 payload: encrypted_nwk_frame.to_bytes(),
                 fcs: 0x0000, // It'll be replaced
             };
@@ -1819,14 +1780,14 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            if let Some(relaying_ieee) = state.nib.address_map.iter().find_map(|(&eui64, &nwk)| {
+            if let Some(relaying_ieee) = state.address_map.iter().find_map(|(&eui64, &nwk)| {
                 if nwk == next_hop_address {
                     Some(eui64)
                 } else {
                     None
                 }
             }) {
-                if let Some(neighbor_entry) = state.nib.neighbor_table.get_mut(&relaying_ieee) {
+                if let Some(neighbor_entry) = state.neighbor_table.get_mut(&relaying_ieee) {
                     // Update the neighbor table counters
                     neighbor_entry.router_outbound_activity =
                         neighbor_entry.router_outbound_activity.saturating_add(1);
@@ -1834,21 +1795,18 @@ impl ZigbeeStack {
             }
 
             // And the routing table counters
-            if let Some(route_entry) = state
-                .nib
-                .route_table
-                .get_mut(&nwk_frame.nwk_header.destination)
+            if let Some(route_entry) = state.route_table.get_mut(&nwk_frame.nwk_header.destination)
             {
                 route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
                 route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
             }
 
             // Increment counters before sending
-            state.nib.tx_total = state.nib.tx_total.wrapping_add(1);
+            state.tx_total = state.tx_total.wrapping_add(1);
 
             // Handle `tx_total` wrapping
-            if state.nib.tx_total == 0x0000 {
-                for (_, neighbor) in state.nib.neighbor_table.iter_mut() {
+            if state.tx_total == 0x0000 {
+                for (_, neighbor) in state.neighbor_table.iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
@@ -1885,8 +1843,8 @@ impl ZigbeeStack {
     ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
 
-        state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
-        nwk_frame.nwk_header.sequence_number = state.nib.sequence_number;
+        state.sequence_number = state.sequence_number.wrapping_add(1);
+        nwk_frame.nwk_header.sequence_number = state.sequence_number;
         nwk_frame.aux_header = Some(NwkAuxHeader {
             security_control: NwkSecurityHeaderControlField {
                 security_level: NwkSecurityLevel::NoSecurity,
@@ -1895,8 +1853,8 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
             },
             frame_counter: 0, // This field is rewritten and is always up-to-date
-            extended_source: Some(state.nib.ieee_address),
-            key_sequence_number: state.nib.active_key_seq_number,
+            extended_source: Some(state.ieee_address),
+            key_sequence_number: state.active_key_seq_number,
         });
 
         drop(state);
@@ -1905,16 +1863,15 @@ impl ZigbeeStack {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
-            state.nib.security_material_primary.outgoing_frame_counter = state
-                .nib
+            state.security_material_primary.outgoing_frame_counter = state
                 .security_material_primary
                 .outgoing_frame_counter
                 .wrapping_add(1);
 
             nwk_frame.aux_header.as_mut().unwrap().frame_counter =
-                state.nib.security_material_primary.outgoing_frame_counter;
+                state.security_material_primary.outgoing_frame_counter;
 
-            let encrypted_nwk_frame = nwk_frame.encrypt(&state.nib.security_material_primary.key);
+            let encrypted_nwk_frame = nwk_frame.encrypt(&state.security_material_primary.key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1931,22 +1888,22 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(state.ieee802154_sequence_number),
-                dest_pan_id: Some(state.nib.pan_id),
+                dest_pan_id: Some(state.pan_id),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
                 src_pan_id: None,
-                src_address: Some(Ieee802154Address::Nwk(state.nib.network_address)),
+                src_address: Some(Ieee802154Address::Nwk(state.network_address)),
                 payload: encrypted_nwk_frame.to_bytes(),
                 fcs: 0x0000, // It'll be replaced
             };
 
             // Increment counters before sending
-            state.nib.tx_total = state.nib.tx_total.wrapping_add(1);
+            state.tx_total = state.tx_total.wrapping_add(1);
 
             // Handle `tx_total` wrapping
-            if state.nib.tx_total == 0x0000 {
-                for (_, neighbor) in state.nib.neighbor_table.iter_mut() {
+            if state.tx_total == 0x0000 {
+                for (_, neighbor) in state.neighbor_table.iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
@@ -1977,7 +1934,7 @@ impl ZigbeeStack {
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, ZigbeeStackError> {
         let state = self.state.lock().unwrap();
 
-        if state.hack_force_route_discovery || !state.nib.route_table.contains_key(&destination) {
+        if state.hack_force_route_discovery || !state.route_table.contains_key(&destination) {
             drop(state);
             log::debug!("Starting route discovery for NWK {destination:?}");
             self.send_route_discovery(destination).await;
@@ -1987,7 +1944,7 @@ impl ZigbeeStack {
 
         let (route_entry_status, route_entry_next_hop_address) = {
             let state = self.state.lock().unwrap();
-            let entry = state.nib.route_table.get(&destination).unwrap();
+            let entry = state.route_table.get(&destination).unwrap();
 
             (entry.status, entry.next_hop_address)
         };
@@ -2033,7 +1990,6 @@ impl ZigbeeStack {
             let state = self.state.lock().unwrap();
             let route_discovery_entry =
                 match state
-                    .nib
                     .route_discovery_table
                     .iter()
                     .find_map(|(&(_, _), entry)| {
@@ -2067,7 +2023,7 @@ impl ZigbeeStack {
             Err(err) => {
                 log::debug!("Route discovery timed out");
                 let mut state = self.state.lock().unwrap();
-                let entry = state.nib.route_table.get_mut(&destination).unwrap();
+                let entry = state.route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
                 return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
             }
@@ -2076,7 +2032,6 @@ impl ZigbeeStack {
         let next_hop_address = {
             let state = self.state.lock().unwrap();
             state
-                .nib
                 .route_table
                 .get(&destination)
                 .unwrap()
@@ -2094,7 +2049,7 @@ impl ZigbeeStack {
 
         // Get or create a routing table entry without keeping a mutable reference
         {
-            let route_table_entry = state.nib.route_table.entry(destination).or_insert_with(|| {
+            let route_table_entry = state.route_table.entry(destination).or_insert_with(|| {
                 route::TableEntry {
                     destination: destination,
                     status: route::Status::Inactive,
@@ -2113,20 +2068,19 @@ impl ZigbeeStack {
             route_table_entry.status = route::Status::DiscoveryUnderway;
         }
 
-        state.nib.routing_request_sequence_number =
-            state.nib.routing_request_sequence_number.wrapping_add(1);
+        state.routing_request_sequence_number =
+            state.routing_request_sequence_number.wrapping_add(1);
 
-        let route_request_identifier = state.nib.routing_request_sequence_number;
-        let route_discovery_table_key = (state.nib.network_address, route_request_identifier);
+        let route_request_identifier = state.routing_request_sequence_number;
+        let route_discovery_table_key = (state.network_address, route_request_identifier);
 
         // We initiated discovery so insert an entry keyed by our NWK and request ID
-        let network_address = state.nib.network_address;
+        let network_address = state.network_address;
 
         {
-            self.clean_route_discovery_table(&mut state.nib.route_discovery_table);
+            self.clean_route_discovery_table(&mut state.route_discovery_table);
 
             let route_discovery_entry = state
-                .nib
                 .route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
@@ -2145,10 +2099,10 @@ impl ZigbeeStack {
         }
 
         // Construct a frame
-        state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
+        state.sequence_number = state.sequence_number.wrapping_add(1);
 
         // If we know the EUI64 corresponding to the NWK, use it
-        let destination_eui64 = state.nib.address_map.iter().find_map(|(&eui64, &nwk)| {
+        let destination_eui64 = state.address_map.iter().find_map(|(&eui64, &nwk)| {
             if nwk == destination {
                 Some(eui64)
             } else {
@@ -2170,11 +2124,11 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
-                source: state.nib.network_address,
+                source: state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: state.nib.sequence_number,
+                sequence_number: state.sequence_number,
                 destination_ieee: None,
-                source_ieee: Some(state.nib.ieee_address),
+                source_ieee: Some(state.ieee_address),
                 multicast_control: None,
                 source_route: None,
             },
@@ -2277,9 +2231,9 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: destination,
-                source: state.nib.network_address,
+                source: state.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: state.nib.sequence_number,
+                sequence_number: state.sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2334,13 +2288,13 @@ impl ZigbeeStack {
         let mut state = self.state.lock().unwrap();
         log::debug!("Sending periodic link status broadcast");
 
-        if state.nib.network_address == Nwk(0xFFFF) {
+        if state.network_address == Nwk(0xFFFF) {
             log::debug!("Skipping, stack has not been initialized yet");
             return;
         }
 
         // Decrement the `recent_activity` field of every active routing table entry
-        for (_, route_table_entry) in state.nib.route_table.iter_mut() {
+        for (_, route_table_entry) in state.route_table.iter_mut() {
             if route_table_entry.status == route::Status::Active {
                 route_table_entry.recent_activity =
                     route_table_entry.recent_activity.saturating_sub(1);
@@ -2350,7 +2304,7 @@ impl ZigbeeStack {
         // Decrement the inbound and outbound activity fields for neighbors
         self.maybe_age_neighbors(&mut state);
 
-        for (_, neighbor_entry) in state.nib.neighbor_table.iter_mut() {
+        for (_, neighbor_entry) in state.neighbor_table.iter_mut() {
             neighbor_entry.router_outbound_activity =
                 neighbor_entry.router_outbound_activity.saturating_sub(1);
             neighbor_entry.router_inbound_activity =
@@ -2359,7 +2313,6 @@ impl ZigbeeStack {
 
         let mut link_statuses = if !empty {
             state
-                .nib
                 .neighbor_table
                 .iter()
                 .filter_map(|(_, neighbor)| {
@@ -2387,7 +2340,7 @@ impl ZigbeeStack {
         loop {
             let mut state = self.state.lock().unwrap();
 
-            state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
+            state.sequence_number = state.sequence_number.wrapping_add(1);
 
             let link_status_frame = NwkFrame {
                 nwk_header: NwkHeader {
@@ -2403,11 +2356,11 @@ impl ZigbeeStack {
                         end_device_initiator: false,
                     },
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
-                    source: state.nib.network_address,
+                    source: state.network_address,
                     radius: 1,
-                    sequence_number: state.nib.sequence_number,
+                    sequence_number: state.sequence_number,
                     destination_ieee: None,
-                    source_ieee: Some(state.nib.ieee_address),
+                    source_ieee: Some(state.ieee_address),
                     multicast_control: None,
                     source_route: None,
                 },

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -212,48 +212,6 @@ pub struct Nib {
     pub hub_connectivity: bool,
 }
 
-#[derive(Debug)]
-pub struct Constants {
-    pub concentrator_radius: u8,
-    pub concentrator_discovery_time: Duration,
-    pub stack_profile: u8,
-    pub transaction_persistence_time: Duration,
-    pub max_source_route: u8,
-    pub max_children: u8,
-
-    pub passive_ack_timeout: Duration,
-
-    /// The maximum number of retries allowed after a broadcast transmission failure.
-    pub max_broadcast_retries: u8,
-
-    /// The minimum time, in seconds, between two consecutive concentrator route
-    /// discoveries. If set to 0x00, there is no minimum separation. This only applies
-    /// when the device is operating as a Concentrator.
-    pub concentrator_discovery_separation_time: Duration,
-
-    /// The time between link status command frames.
-    pub link_status_period: Duration,
-
-    /// The number of missed link status command frames before resetting the link costs
-    /// to zero.
-    pub router_age_limit: u8,
-
-    pub protocol_version: u8,
-    pub route_discovery_time: Duration,
-    pub max_broadcast_jitter: Duration,
-    pub initial_rreq_retries: u8,
-    pub rreq_retries: u8,
-    pub rreq_retry_interval: Duration,
-    pub min_rreq_jitter: Duration,
-    pub max_rreq_jitter: Duration,
-    pub max_depth: u8,
-    pub unicast_retries: u8,
-    pub unicast_retry_delay: Duration,
-    pub min_router_bootstrap_jitter: Duration,
-    pub max_router_bootstrap_jitter: Duration,
-    pub broadcast_delivery_time: Duration,
-}
-
 impl Nib {
     pub fn new() -> Self {
         Nib {
@@ -311,6 +269,48 @@ impl Nib {
             hub_connectivity: true,
         }
     }
+}
+
+#[derive(Debug)]
+pub struct Constants {
+    pub concentrator_radius: u8,
+    pub concentrator_discovery_time: Duration,
+    pub stack_profile: u8,
+    pub transaction_persistence_time: Duration,
+    pub max_source_route: u8,
+    pub max_children: u8,
+
+    pub passive_ack_timeout: Duration,
+
+    /// The maximum number of retries allowed after a broadcast transmission failure.
+    pub max_broadcast_retries: u8,
+
+    /// The minimum time, in seconds, between two consecutive concentrator route
+    /// discoveries. If set to 0x00, there is no minimum separation. This only applies
+    /// when the device is operating as a Concentrator.
+    pub concentrator_discovery_separation_time: Duration,
+
+    /// The time between link status command frames.
+    pub link_status_period: Duration,
+
+    /// The number of missed link status command frames before resetting the link costs
+    /// to zero.
+    pub router_age_limit: u8,
+
+    pub protocol_version: u8,
+    pub route_discovery_time: Duration,
+    pub max_broadcast_jitter: Duration,
+    pub initial_rreq_retries: u8,
+    pub rreq_retries: u8,
+    pub rreq_retry_interval: Duration,
+    pub min_rreq_jitter: Duration,
+    pub max_rreq_jitter: Duration,
+    pub max_depth: u8,
+    pub unicast_retries: u8,
+    pub unicast_retry_delay: Duration,
+    pub min_router_bootstrap_jitter: Duration,
+    pub max_router_bootstrap_jitter: Duration,
+    pub broadcast_delivery_time: Duration,
 }
 
 impl Constants {

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -26,8 +26,7 @@ use zigbee_parts::commands::{
 
 use std::cmp;
 use std::collections::{HashMap, HashSet, VecDeque};
-use std::mem::drop;
-use std::sync::{Arc, Mutex, MutexGuard, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use tokio::sync::{broadcast, mpsc, oneshot};
 use tokio::task::spawn_local;
 use tokio::time::{Duration, Instant};
@@ -240,10 +239,10 @@ impl ApsAckData {
 #[derive(Debug)]
 pub struct State {
     pub channel: u8,
-    pub ieee802154_sequence_number: u8,
+    pub ieee802154_sequence_number: Mutex<u8>,
 
-    pub pending_aps_acks: HashMap<ApsAckData, oneshot::Sender<()>>,
-    pub pending_route_notifications: HashMap<Nwk, broadcast::Sender<()>>,
+    pub pending_aps_acks: Mutex<HashMap<ApsAckData, oneshot::Sender<()>>>,
+    pub pending_route_notifications: Mutex<HashMap<Nwk, broadcast::Sender<()>>>,
     pub start_time: Option<Instant>,
 
     // We intentionally violate the spec with these options
@@ -262,27 +261,27 @@ pub struct State {
     pub hack_force_route_discovery: bool,
 
     // NIB
-    pub sequence_number: u8,
-    pub neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
-    pub route_table: HashMap<Nwk, route::TableEntry>,
-    pub route_discovery_table: HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>,
+    pub sequence_number: Mutex<u8>,
+    pub neighbor_table: Mutex<HashMap<Eui64, neighbor::TableEntry>>,
+    pub route_table: Mutex<HashMap<Nwk, route::TableEntry>>,
+    pub route_discovery_table: Mutex<HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>>,
     pub capability_information: NwkCapabilityInformation,
     pub nwk_manager_addr: Nwk,
     pub update_id: u8,
     pub network_address: Nwk,
-    pub broadcast_transaction_table: HashMap<(Nwk, u8), NwkBroadcastTransaction>,
+    pub broadcast_transaction_table: Mutex<HashMap<(Nwk, u8), NwkBroadcastTransaction>>,
     pub extended_pan_id: Eui64,
-    pub route_record_table: HashMap<Nwk, Vec<Nwk>>,
+    pub route_record_table: Mutex<HashMap<Nwk, Vec<Nwk>>>,
     pub is_concentrator: bool,
     pub security_level: u8,
-    pub security_material_primary: NwkSecurityDescriptor,
-    pub security_material_alternate: NwkSecurityDescriptor,
+    pub security_material_primary: Mutex<NwkSecurityDescriptor>,
+    pub security_material_alternate: Mutex<NwkSecurityDescriptor>,
     pub active_key_seq_number: u8,
 
     /// Indicates whether incoming NWK frames SHALL be all checked for freshness when
     /// the memory for incoming frame counts is exceeded.
     pub all_fresh: bool,
-    pub address_map: HashMap<Eui64, Nwk>,
+    pub address_map: Mutex<HashMap<Eui64, Nwk>>,
 
     /// A flag that determines if a timestamp indication is provided on incoming and
     /// outgoing packets.
@@ -297,7 +296,7 @@ pub struct State {
     /// attribute or if the value of `tx_total` rolls over past 0xffff the
     /// NWK layer SHALL reset to 0x00 each Transmit Failure field contained in
     /// the neighbor table.
-    pub tx_total: u16,
+    pub tx_total: Mutex<u16>,
 
     /// This policy determines whether or not a remote NWK leave request command frame
     /// received by the local device is accepted.
@@ -320,7 +319,7 @@ pub struct State {
     /// 16-bit Routing Sequence Number. The former is used to discern route requests
     /// originating in a particular router; the latter is used to identify stale routing
     /// information."
-    pub routing_request_sequence_number: u8,
+    pub routing_request_sequence_number: Mutex<u8>,
 
     /// This indicates whether the router has Hub Connectivity as defined by a higher
     /// level application. The higher level application sets this value and the stack
@@ -332,19 +331,19 @@ impl State {
     pub fn new() -> Self {
         State {
             channel: 0,
-            ieee802154_sequence_number: 0,
-            pending_aps_acks: HashMap::new(),
-            pending_route_notifications: HashMap::new(),
+            ieee802154_sequence_number: Mutex::new(0),
+            pending_aps_acks: Mutex::new(HashMap::new()),
+            pending_route_notifications: Mutex::new(HashMap::new()),
             start_time: None,
 
             hack_ignore_broadcast_startup_wait_period: true,
             hack_disable_tx: false,
             hack_force_route_discovery: false,
 
-            sequence_number: 0,
-            neighbor_table: HashMap::new(),
-            route_table: HashMap::new(),
-            route_discovery_table: HashMap::new(),
+            sequence_number: Mutex::new(0),
+            neighbor_table: Mutex::new(HashMap::new()),
+            route_table: Mutex::new(HashMap::new()),
+            route_discovery_table: Mutex::new(HashMap::new()),
             capability_information: NwkCapabilityInformation {
                 alternate_pan_coordinator: false,
                 device_type: NwkCapabilityInformationDeviceType::EndDevice,
@@ -358,31 +357,31 @@ impl State {
             nwk_manager_addr: Nwk(0x0000),
             update_id: 0,
             network_address: Nwk(0x0000),
-            broadcast_transaction_table: HashMap::new(),
+            broadcast_transaction_table: Mutex::new(HashMap::new()),
             extended_pan_id: Eui64::from_hex("0000000000000000"),
-            route_record_table: HashMap::new(),
+            route_record_table: Mutex::new(HashMap::new()),
             is_concentrator: true,
             security_level: 5,
-            security_material_primary: NwkSecurityDescriptor {
+            security_material_primary: Mutex::new(NwkSecurityDescriptor {
                 key_seq_number: 0,
                 outgoing_frame_counter: 0,
                 incoming_frame_counter_set: HashMap::new(),
                 key: Key::from_hex("00000000000000000000000000000000"),
                 network_key_type: NetworkKeyType::Standard,
-            },
-            security_material_alternate: NwkSecurityDescriptor {
+            }),
+            security_material_alternate: Mutex::new(NwkSecurityDescriptor {
                 key_seq_number: 0,
                 outgoing_frame_counter: 0,
                 incoming_frame_counter_set: HashMap::new(),
                 key: Key::from_hex("00000000000000000000000000000000"),
                 network_key_type: NetworkKeyType::Standard,
-            },
+            }),
             active_key_seq_number: 0,
             all_fresh: false,
-            address_map: HashMap::new(),
+            address_map: Mutex::new(HashMap::new()),
             time_stamp: false,
             pan_id: PanId(0xFFFF),
-            tx_total: 0,
+            tx_total: Mutex::new(0),
             leave_request_allowed: false,
             parent_information: 0,
             leave_request_without_rejoin_allowed: false,
@@ -390,7 +389,7 @@ impl State {
             // TODO: The 16-bit routing sequence number is expected to be
             // strictly-increasing, it should be persisted to disk
             // nwk_routing_sequence_number: 0x0000,
-            routing_request_sequence_number: 0x00,
+            routing_request_sequence_number: Mutex::new(0x00),
             hub_connectivity: true,
         }
     }
@@ -414,7 +413,7 @@ pub enum ZigbeeNotification {
 pub struct ZigbeeStack {
     self_weak: Weak<ZigbeeStack>,
 
-    pub state: Mutex<State>,
+    pub state: State,
     pub constants: Constants,
     pub spinel: SpinelClient,
     pub notification_tx: broadcast::Sender<ZigbeeNotification>,
@@ -429,7 +428,7 @@ impl ZigbeeStack {
 
         let arc_stack = Arc::new_cyclic(|weak_self| ZigbeeStack {
             self_weak: weak_self.clone(),
-            state: Mutex::new(State::new()),
+            state: State::new(),
             constants: Constants::new(),
             spinel,
             notification_tx,
@@ -457,9 +456,9 @@ impl ZigbeeStack {
                             log::debug!("Received APS ack: {:?}", ack_data);
 
                             self.state
+                                .pending_aps_acks
                                 .lock()
                                 .unwrap()
-                                .pending_aps_acks
                                 .remove(&ack_data)
                                 .map(|tx| {
                                     let _ = tx.send(());
@@ -534,7 +533,7 @@ impl ZigbeeStack {
     }
 
     pub async fn set_network_settings(
-        &self,
+        &mut self,
         channel: u8,
         update_id: u8,
         pan_id: PanId,
@@ -545,16 +544,20 @@ impl ZigbeeStack {
         key_seq_number: u8,
         outgoing_frame_counter: u32,
     ) -> Result<(), ZigbeeStackError> {
-        let mut state = self.state.lock().unwrap();
-        state.channel = channel;
-        state.update_id = update_id;
-        state.pan_id = pan_id;
-        state.extended_pan_id = extended_pan_id;
-        state.network_address = network_address;
-        state.ieee_address = ieee_address;
-        state.security_material_primary.key = key;
-        state.security_material_primary.key_seq_number = key_seq_number;
-        state.security_material_primary.outgoing_frame_counter = outgoing_frame_counter;
+        self.state.channel = channel;
+        self.state.update_id = update_id;
+        self.state.pan_id = pan_id;
+        self.state.extended_pan_id = extended_pan_id;
+        self.state.network_address = network_address;
+        self.state.ieee_address = ieee_address;
+
+        {
+            let mut security_material_primary =
+                self.state.security_material_primary.lock().unwrap();
+            security_material_primary.key = key;
+            security_material_primary.key_seq_number = key_seq_number;
+            security_material_primary.outgoing_frame_counter = outgoing_frame_counter;
+        }
 
         // Update the hardware with new settings.
         self.spinel
@@ -585,7 +588,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Laddr,
-                state.ieee_address.to_bytes().to_vec(),
+                self.state.ieee_address.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -593,7 +596,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Saddr,
-                state.network_address.to_bytes().to_vec(),
+                self.state.network_address.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -601,7 +604,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Panid,
-                state.pan_id.to_bytes().to_vec(),
+                self.state.pan_id.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -617,8 +620,7 @@ impl ZigbeeStack {
             .map_err(ZigbeeStackError::SpinelError)?;
 
         // This is treated as the start time of the stack
-        state.start_time = Some(Instant::now());
-        drop(state);
+        self.state.start_time = Some(Instant::now());
 
         // To kick things off, send a link status broadcast. Silicon Labs routers will
         // "respond" to empty link status broadcasts proactively, independent of the
@@ -644,8 +646,6 @@ impl ZigbeeStack {
         lqi: u8,
         rssi: i8,
     ) -> Option<NwkFrame> {
-        let state = self.state.lock().unwrap();
-
         // 802.15.4 encrypted frames can't be Zigbee NWK
         if frame.frame_control.security_enabled {
             log::debug!("Ignoring frame, 802.15.4 security bit is enabled");
@@ -670,11 +670,11 @@ impl ZigbeeStack {
                 log::debug!("Ignoring frame, destination PAN ID is not present");
                 return None;
             }
-            Some(dest_pan_id) if dest_pan_id != state.pan_id => {
+            Some(dest_pan_id) if dest_pan_id != self.state.pan_id => {
                 log::debug!(
                     "Ignoring frame, PAN ID does not match {:?} != {:?}",
                     dest_pan_id,
-                    state.pan_id
+                    self.state.pan_id
                 );
                 return None;
             }
@@ -691,7 +691,7 @@ impl ZigbeeStack {
         };
 
         // Ignore frames that aren't destined for us
-        if nwk_frame.nwk_header.destination != state.network_address
+        if nwk_frame.nwk_header.destination != self.state.network_address
             && nwk_frame.nwk_header.destination.as_u16()
                 < BROADCAST_ALL_ROUTERS_AND_COORDINATOR.as_u16()
         {
@@ -726,7 +726,7 @@ impl ZigbeeStack {
         }
 
         // Validate the network key sequence number
-        if aux_header.key_sequence_number != state.active_key_seq_number {
+        if aux_header.key_sequence_number != self.state.active_key_seq_number {
             log::debug!("Ignoring frame, key sequence number is unknown");
             return None;
         }
@@ -744,8 +744,11 @@ impl ZigbeeStack {
             }
         }
 
-        match state
+        match self
+            .state
             .security_material_primary
+            .lock()
+            .unwrap()
             .incoming_frame_counter_set
             .get(&src_eui64)
         {
@@ -766,20 +769,18 @@ impl ZigbeeStack {
         log::debug!(
             "Attempting to decrypt {:?} with {:?}",
             nwk_frame,
-            state.security_material_primary
+            self.state.security_material_primary
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame = match nwk_frame.decrypt(&state.security_material_primary.key) {
-            Ok(decrypted_frame) => decrypted_frame,
-            Err(err) => {
-                log::warn!("Ignoring frame, decryption failed: {err:?}");
-                return None;
-            }
-        };
-
-        // At this point we no longer need to lock `state`
-        drop(state);
+        let decrypted_nwk_frame =
+            match nwk_frame.decrypt(&self.state.security_material_primary.lock().unwrap().key) {
+                Ok(decrypted_frame) => decrypted_frame,
+                Err(err) => {
+                    log::warn!("Ignoring frame, decryption failed: {err:?}");
+                    return None;
+                }
+            };
 
         log::info!("Decrypted frame: {decrypted_nwk_frame:#?}");
 
@@ -796,9 +797,7 @@ impl ZigbeeStack {
     }
 
     pub fn update_nwk_eui64_mapping(&self, nwk: Nwk, eui64: Eui64) {
-        let mut state = self.state.lock().unwrap();
-
-        match state.address_map.insert(eui64, nwk) {
+        match self.state.address_map.lock().unwrap().insert(eui64, nwk) {
             None => {
                 log::debug!("Added new address mapping: {eui64:?} -> {nwk:?}")
             }
@@ -811,13 +810,12 @@ impl ZigbeeStack {
     /// Filter broadcast frames based on the NWK broadcast transaction table
     pub fn filter_broadcast(&self, nwk_frame: &NwkFrame) -> bool {
         let now = Instant::now();
-        let mut state = self.state.lock().unwrap();
 
         // We cannot handle broadcasts until the network has been running for at least
         // the time it takes to deliver one broadcast
-        if !state.hack_ignore_broadcast_startup_wait_period
-            && (state.start_time.is_none()
-                || state.start_time.unwrap() + self.constants.broadcast_delivery_time > now)
+        if !self.state.hack_ignore_broadcast_startup_wait_period
+            && (self.state.start_time.is_none()
+                || self.state.start_time.unwrap() + self.constants.broadcast_delivery_time > now)
         {
             log::debug!("Filtering broadcast, network started too recently.");
             return true;
@@ -829,13 +827,16 @@ impl ZigbeeStack {
         );
 
         // Clean a stale entry first, if one exists.
-        if let Some(entry) = state.broadcast_transaction_table.get(&key) {
+        let mut broadcast_transaction_table =
+            self.state.broadcast_transaction_table.lock().unwrap();
+
+        if let Some(entry) = broadcast_transaction_table.get(&key) {
             if entry.expiration_time > now {
                 return true;
             }
         }
 
-        state.broadcast_transaction_table.insert(
+        broadcast_transaction_table.insert(
             key,
             NwkBroadcastTransaction {
                 source_nwk: nwk_frame.nwk_header.source,
@@ -852,9 +853,10 @@ impl ZigbeeStack {
         if let Some(aux_header) = &nwk_frame.aux_header {
             match aux_header.extended_source {
                 Some(relaying_eui64) => {
-                    let mut state = self.state.lock().unwrap();
-                    state
+                    self.state
                         .security_material_primary
+                        .lock()
+                        .unwrap()
                         .incoming_frame_counter_set
                         .insert(relaying_eui64, aux_header.frame_counter);
 
@@ -874,9 +876,8 @@ impl ZigbeeStack {
 
         // Handle LQA calculation
         {
-            let mut state = self.state.lock().unwrap();
-            self.maybe_age_neighbors(&mut state);
-            self.maybe_recompute_lqa(&mut state, nwk_frame, lqi, rssi);
+            self.maybe_age_neighbors();
+            self.maybe_recompute_lqa(nwk_frame, lqi, rssi);
         }
 
         // Ignore frames that aren't destined for us
@@ -909,9 +910,10 @@ impl ZigbeeStack {
                         "Route record command frame received: {:#?}",
                         route_record_cmd
                     );
-                    let mut state = self.state.lock().unwrap();
-                    state
+                    self.state
                         .route_record_table
+                        .lock()
+                        .unwrap()
                         .insert(nwk_frame.nwk_header.source, route_record_cmd.relays);
                 }
                 Ok(NwkCommandId::RouteRequest) => {
@@ -928,15 +930,14 @@ impl ZigbeeStack {
         }
     }
 
-    fn maybe_recompute_lqa(&self, state: &mut State, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
+    fn maybe_recompute_lqa(&self, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
         // Find the source node via its EUI64 address (preferred) or its NWK address
+        let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+
         match if nwk_frame.nwk_header.source_ieee.is_some() {
-            state
-                .neighbor_table
-                .get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
+            neighbor_table.get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
         } else {
-            state
-                .neighbor_table
+            neighbor_table
                 .values_mut()
                 .find(|e| e.network_address == nwk_frame.nwk_header.source)
         } {
@@ -953,13 +954,13 @@ impl ZigbeeStack {
         }
     }
 
-    fn maybe_age_neighbors(&self, state: &mut State) {
+    fn maybe_age_neighbors(&self) {
         // TODO: this function should be replaced by real timers
         let now = Instant::now();
         let max_neighbor_age =
             (self.constants.router_age_limit as u32) * self.constants.link_status_period;
 
-        for neighbor in state.neighbor_table.values_mut() {
+        for neighbor in self.state.neighbor_table.lock().unwrap().values_mut() {
             if neighbor.outgoing_cost > 0
                 && neighbor.last_link_status_timestamp >= now + max_neighbor_age
             {
@@ -989,29 +990,27 @@ impl ZigbeeStack {
 
         // We collect a list of neighbors with non-zero outgoing cost up here, before
         // mutating the state
-        let neighbors_with_nonzero_outgoing_cost = {
-            let mut state = self.state.lock().unwrap();
-            self.maybe_age_neighbors(&mut state);
+        self.maybe_age_neighbors();
 
-            state
-                .neighbor_table
-                .iter()
-                .filter_map(|(_, neighbor_entry)| {
-                    if neighbor_entry.outgoing_cost > 0 {
-                        Some(neighbor_entry.network_address)
-                    } else {
-                        None
-                    }
-                })
-                .collect::<HashSet<Nwk>>()
-        };
-
-        let network_address = self.state.lock().unwrap().network_address;
+        let neighbors_with_nonzero_outgoing_cost = self
+            .state
+            .neighbor_table
+            .lock()
+            .unwrap()
+            .iter()
+            .filter_map(|(_, neighbor_entry)| {
+                if neighbor_entry.outgoing_cost > 0 {
+                    Some(neighbor_entry.network_address)
+                } else {
+                    None
+                }
+            })
+            .collect::<HashSet<Nwk>>();
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
+        let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
 
-        let mut state = self.state.lock().unwrap();
-        let neighbor_entry = match state.neighbor_table.get_mut(&source_ieee) {
+        let neighbor_entry = match neighbor_table.get_mut(&source_ieee) {
             Some(entry) => entry,
             None => {
                 // Create one
@@ -1043,8 +1042,8 @@ impl ZigbeeStack {
                     security_timer: 0,
                 };
 
-                state.neighbor_table.insert(source_ieee, entry);
-                state.neighbor_table.get_mut(&source_ieee).unwrap()
+                neighbor_table.insert(source_ieee, entry);
+                neighbor_table.get_mut(&source_ieee).unwrap()
             }
         };
 
@@ -1072,7 +1071,7 @@ impl ZigbeeStack {
                 }
             }
 
-            if link_status.address == network_address {
+            if link_status.address == self.state.network_address {
                 neighbor_entry.outgoing_cost = link_status.incoming_cost;
             }
         }
@@ -1085,12 +1084,14 @@ impl ZigbeeStack {
         log::debug!("Updated neighbor table entry: {neighbor_entry:#?}");
     }
 
-    fn notify_routing_change(&self, state: &State, nwk: &Nwk) {
-        if !state.pending_route_notifications.contains_key(nwk) {
+    fn notify_routing_change(&self, nwk: &Nwk) {
+        let pending_route_notifications = self.state.pending_route_notifications.lock().unwrap();
+
+        if !pending_route_notifications.contains_key(nwk) {
             return;
         }
 
-        let tx = state.pending_route_notifications.get(nwk).unwrap();
+        let tx = pending_route_notifications.get(nwk).unwrap();
         let _ = tx.send(());
     }
 
@@ -1108,18 +1109,19 @@ impl ZigbeeStack {
         // Both `responder_eui64` and `originator_eui64` SHALL be set according to the
         // R23 spec but real devices do not do this
 
-        let mut state = self.state.lock().unwrap();
-        let our_nwk_address = state.network_address;
+        let our_nwk_address = self.state.network_address;
 
-        let neighbor = match state
-            .neighbor_table
-            .values()
-            .find(|&entry| entry.network_address == nwk_frame.nwk_header.source)
-        {
-            Some(neighbor) => neighbor,
-            None => {
-                log::debug!("Ignoring route reply from unknown neighbor");
-                return;
+        let neighbor_table = self.state.neighbor_table.lock().unwrap();
+        let neighbor = {
+            match neighbor_table
+                .values()
+                .find(|&entry| entry.network_address == nwk_frame.nwk_header.source)
+            {
+                Some(neighbor) => neighbor,
+                None => {
+                    log::debug!("Ignoring route reply from unknown neighbor");
+                    return;
+                }
             }
         };
 
@@ -1138,13 +1140,15 @@ impl ZigbeeStack {
 
         // TODO: clean this up, the mutability problems caused by the shared state mutex
         // make having two mutable borrows at once very difficult
-        let Some(discovery_entry) = state.route_discovery_table.get(&route_discovery_table_key)
+        let mut route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+        let Some(discovery_entry) = route_discovery_table.get_mut(&route_discovery_table_key)
         else {
             log::debug!("Route reply for unknown route discovery, ignoring");
             return;
         };
 
-        let Some(routing_entry) = state.route_table.get(&route_reply_cmd.responder_nwk) else {
+        let mut route_table = self.state.route_table.lock().unwrap();
+        let Some(routing_entry) = route_table.get_mut(&route_reply_cmd.responder_nwk) else {
             log::debug!("Route reply with unknown responder, ignoring");
             return;
         };
@@ -1161,23 +1165,13 @@ impl ZigbeeStack {
                         updated_path_cost);
 
                     // Mutate the routing entry
-                    {
-                        let routing_entry = state
-                            .route_table
-                            .get_mut(&route_reply_cmd.responder_nwk).unwrap();
-                        routing_entry.status = route::Status::Active;
-                        routing_entry.next_hop_address = nwk_frame.nwk_header.source;
-                    }
+                    routing_entry.status = route::Status::Active;
+                    routing_entry.next_hop_address = nwk_frame.nwk_header.source;
 
                     // Mutate the discovery entry
-                    {
-                        let discovery_entry = state
-                            .route_discovery_table
-                            .get_mut(&route_discovery_table_key).unwrap();
-                        discovery_entry.residual_cost = updated_path_cost;
-                    }
+                    discovery_entry.residual_cost = updated_path_cost;
 
-                    self.notify_routing_change(&state, &route_reply_cmd.responder_nwk);
+                    self.notify_routing_change(&route_reply_cmd.responder_nwk);
                 },
                 route::Status::Active => {
                     if updated_path_cost >= discovery_entry.residual_cost {
@@ -1194,22 +1188,12 @@ impl ZigbeeStack {
                         updated_path_cost);
 
                     // Mutate the routing entry
-                    {
-                        let routing_entry = state
-                            .route_table
-                            .get_mut(&route_reply_cmd.responder_nwk).unwrap();
-                        routing_entry.next_hop_address = nwk_frame.nwk_header.source;
-                    }
+                    routing_entry.next_hop_address = nwk_frame.nwk_header.source;
 
                     // Mutate the discovery entry
-                    {
-                        let discovery_entry = state
-                            .route_discovery_table
-                            .get_mut(&route_discovery_table_key).unwrap();
-                        discovery_entry.residual_cost = updated_path_cost;
-                    }
+                    discovery_entry.residual_cost = updated_path_cost;
 
-                    self.notify_routing_change(&state, &route_reply_cmd.responder_nwk);
+                    self.notify_routing_change(&route_reply_cmd.responder_nwk);
                 },
             }
 
@@ -1228,37 +1212,18 @@ impl ZigbeeStack {
         }
 
         // Mutate the routing entry
-        {
-            let routing_entry = state
-                .route_table
-                .get_mut(&route_reply_cmd.responder_nwk)
-                .unwrap();
-            routing_entry.next_hop_address = nwk_frame.nwk_header.source;
-        }
+        routing_entry.next_hop_address = nwk_frame.nwk_header.source;
 
         // Mutate the discovery entry
-        {
-            let discovery_entry = state
-                .route_discovery_table
-                .get_mut(&route_discovery_table_key)
-                .unwrap();
-            discovery_entry.residual_cost = updated_path_cost;
-        }
+        discovery_entry.residual_cost = updated_path_cost;
 
-        self.notify_routing_change(&state, &route_reply_cmd.responder_nwk);
+        self.notify_routing_change(&route_reply_cmd.responder_nwk);
 
         // Find the next hop to the destination
-        let next_hop_nwk = {
-            let discovery_entry = state
-                .route_discovery_table
-                .get_mut(&route_discovery_table_key)
-                .unwrap();
+        let next_hop_nwk = discovery_entry.sender_address;
 
-            discovery_entry.sender_address
-        };
-
-        let Some(next_hop_neighbor) = state
-            .neighbor_table
+        let neighbor_table = self.state.neighbor_table.lock().unwrap();
+        let Some(next_hop_neighbor) = neighbor_table
             .values()
             .find(|&entry| entry.network_address == next_hop_nwk)
         else {
@@ -1280,11 +1245,11 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: next_hop_nwk,
-                source: state.network_address,
+                source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: state.sequence_number,
+                sequence_number: *self.state.sequence_number.lock().unwrap(),
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
-                source_ieee: Some(state.ieee_address),
+                source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
                 source_route: None,
             },
@@ -1302,7 +1267,7 @@ impl ZigbeeStack {
             .unwrap(),
         };
 
-        self.background_send_nwk_frame(state, relayed_route_reply_frame);
+        self.background_send_nwk_frame(relayed_route_reply_frame);
     }
 
     /// Clean expired entries from the route discovery table. Their lifetime is ~10s.
@@ -1314,20 +1279,21 @@ impl ZigbeeStack {
     ///
     /// TODO: Alternatively, we can look into a way to tie timers to these entries and
     /// expire them directly from the event loop.
-    fn clean_route_discovery_table(
-        &self,
-        route_discovery_table: &mut HashMap<(Nwk, u8), route::DiscoveryEntry>,
-    ) {
+    fn clean_route_discovery_table(&self) {
         let now = Instant::now();
 
-        route_discovery_table.retain(|_, entry| {
-            if entry.expiration_time <= now {
-                log::debug!("Removing expired route discovery entry: {entry:#?}");
-                false
-            } else {
-                true
-            }
-        });
+        self.state
+            .route_discovery_table
+            .lock()
+            .unwrap()
+            .retain(|_, entry| {
+                if entry.expiration_time <= now {
+                    log::debug!("Removing expired route discovery entry: {entry:#?}");
+                    false
+                } else {
+                    true
+                }
+            });
     }
 
     fn handle_route_request(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk) {
@@ -1344,12 +1310,10 @@ impl ZigbeeStack {
             route_request_cmd
         );
 
-        let mut state = self.state.lock().unwrap();
-
-        let network_address = state.network_address;
+        let network_address = self.state.network_address;
+        let neighbor_table = self.state.neighbor_table.lock().unwrap();
         // We need to know who sent the frame
-        let Some(sender_neighbor) = state
-            .neighbor_table
+        let Some(sender_neighbor) = neighbor_table
             .values()
             .find(|&entry| entry.network_address == sender_nwk)
         else {
@@ -1377,8 +1341,9 @@ impl ZigbeeStack {
         // table entry via the relaying device. This is free routing information and
         // should be used.
         {
-            let route_table_entry = state
-                .route_table
+            let mut route_table = self.state.route_table.lock().unwrap();
+
+            let route_table_entry = route_table
                 .entry(route_request_cmd.destination_address)
                 .or_insert_with(|| {
                     route::TableEntry {
@@ -1401,14 +1366,15 @@ impl ZigbeeStack {
                 route_table_entry.next_hop_address = sender_nwk;
             }
 
-            self.notify_routing_change(&state, &route_request_cmd.destination_address);
+            self.notify_routing_change(&route_request_cmd.destination_address);
         }
 
         // Create a routing table entry that assigns the node that last-relayed the
         // route request command to be the next-hop for the original sender
         {
-            let route_table_entry = state
-                .route_table
+            let mut route_table = self.state.route_table.lock().unwrap();
+
+            let route_table_entry = route_table
                 .entry(nwk_frame.nwk_header.source)
                 .or_insert_with(|| route::TableEntry {
                     destination: nwk_frame.nwk_header.source,
@@ -1429,7 +1395,7 @@ impl ZigbeeStack {
                 route_table_entry.next_hop_address = sender_nwk;
             }
 
-            self.notify_routing_change(&state, &nwk_frame.nwk_header.source);
+            self.notify_routing_change(&nwk_frame.nwk_header.source);
         }
 
         // TODO: what do we do if one of these values doesn't match? This would be
@@ -1448,10 +1414,11 @@ impl ZigbeeStack {
         );
 
         if !is_for_self_or_child {
-            self.clean_route_discovery_table(&mut state.route_discovery_table);
+            self.clean_route_discovery_table();
 
-            let route_discovery_entry = state
-                .route_discovery_table
+            let mut route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+
+            let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
                     route_request_id: route_request_cmd.route_request_identifier,
@@ -1477,8 +1444,10 @@ impl ZigbeeStack {
             }
 
             // Create an entry in the routing table as well
-            state
+            self.state
                 .route_table
+                .lock()
+                .unwrap()
                 .entry(route_request_cmd.destination_address)
                 .or_insert_with(|| route::TableEntry {
                     destination: route_request_cmd.destination_address,
@@ -1518,7 +1487,7 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.destination,
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
-                    sequence_number: state.sequence_number, // TODO: do we change this?
+                    sequence_number: *self.state.sequence_number.lock().unwrap(), // TODO: do we change this?
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
                     multicast_control: None,
@@ -1536,7 +1505,7 @@ impl ZigbeeStack {
                 .unwrap(),
             };
 
-            self.background_send_nwk_frame(state, relayed_route_request_cmd);
+            self.background_send_nwk_frame(relayed_route_request_cmd);
         } else {
             let route_reply_frame = NwkFrame {
                 nwk_header: NwkHeader {
@@ -1552,11 +1521,11 @@ impl ZigbeeStack {
                         end_device_initiator: false,
                     },
                     destination: nwk_frame.nwk_header.source,
-                    source: state.network_address,
+                    source: self.state.network_address,
                     radius: 2 * self.constants.max_depth,
-                    sequence_number: state.sequence_number,
+                    sequence_number: *self.state.sequence_number.lock().unwrap(),
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
-                    source_ieee: Some(state.ieee_address),
+                    source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
                     source_route: None,
                 },
@@ -1564,23 +1533,22 @@ impl ZigbeeStack {
                 payload: NwkRouteReplyCommand {
                     route_request_identifier: route_request_cmd.route_request_identifier,
                     originator_nwk: nwk_frame.nwk_header.source,
-                    responder_nwk: state.network_address,
+                    responder_nwk: self.state.network_address,
                     path_cost: updated_path_cost,
                     originator_eui64: nwk_frame.nwk_header.source_ieee,
-                    responder_eui64: Some(state.ieee_address),
+                    responder_eui64: Some(self.state.ieee_address),
                 }
                 .serialize()
                 .unwrap(),
             };
 
-            self.background_send_nwk_frame(state, route_reply_frame);
+            self.background_send_nwk_frame(route_reply_frame);
         }
     }
 
     fn handle_aps_ack_request(&self, aps_frame: &ApsDataFrame, nwk_frame: &NwkFrame) {
         log::debug!("Sending back an APS ACK");
 
-        let state = self.state.lock().unwrap();
         let aps_ack_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
@@ -1596,9 +1564,9 @@ impl ZigbeeStack {
                 },
                 // Send our ACK back to the sender
                 destination: nwk_frame.nwk_header.source,
-                source: state.network_address,
+                source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: state.sequence_number,
+                sequence_number: *self.state.sequence_number.lock().unwrap(),
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1623,37 +1591,32 @@ impl ZigbeeStack {
             .to_bytes(),
         };
 
-        self.background_send_nwk_frame(state, aps_ack_frame);
+        self.background_send_nwk_frame(aps_ack_frame);
     }
 
     async fn send_802154_frame(&self, mut frame: Ieee802154Frame) -> Result<(), ZigbeeStackError> {
-        // Briefly grab the channel when sending, we don't want to hold the lock while
-        // waiting for an ACK
-        let mut state = self.state.lock().unwrap();
-        let channel = state.channel;
-
         // Increment the 802.15.4 sequence number
         if !frame.frame_control.sequence_number_suppression {
-            state.ieee802154_sequence_number = state.ieee802154_sequence_number.wrapping_add(1);
-            frame.sequence_number = Some(state.ieee802154_sequence_number);
+            let mut ieee802154_sequence_number =
+                self.state.ieee802154_sequence_number.lock().unwrap();
+            *ieee802154_sequence_number = ieee802154_sequence_number.wrapping_add(1);
+
+            frame.sequence_number = Some(*ieee802154_sequence_number);
         }
 
         log::info!("Sending 802.15.4 frame: {:#?}", frame);
         log::info!("Sending 802.15.4 frame bytes: {:02X?}", frame.to_bytes());
 
-        if state.hack_disable_tx {
-            drop(state);
+        if self.state.hack_disable_tx {
             log::debug!("Not transmitting the frame, TX is disabled");
             return Ok(());
         }
-
-        drop(state);
 
         let status = self
             .spinel
             .transmit_frame(&SpinelTxFrame {
                 psdu: frame.to_bytes(),
-                channel: Some(channel),
+                channel: Some(self.state.channel),
                 max_csma_backoffs: Some(1),
                 max_frame_retries: Some(5),
                 enable_csma_ca: Some(true),
@@ -1686,11 +1649,7 @@ impl ZigbeeStack {
         }
     }
 
-    pub fn background_send_nwk_frame(&self, state: MutexGuard<State>, nwk_frame: NwkFrame) {
-        // This function takes ownership of `state` to force it to be dropped before we
-        // transmit.
-        drop(state);
-
+    pub fn background_send_nwk_frame(&self, nwk_frame: NwkFrame) {
         let arc_self = self
             .self_weak
             .upgrade()
@@ -1722,10 +1681,13 @@ impl ZigbeeStack {
         let next_hop_address = self
             .discover_route(nwk_frame.nwk_header.destination)
             .await?;
-        let mut state = self.state.lock().unwrap();
 
-        state.sequence_number = state.sequence_number.wrapping_add(1);
-        nwk_frame.nwk_header.sequence_number = state.sequence_number;
+        nwk_frame.nwk_header.sequence_number = {
+            let mut sequence_number = self.state.sequence_number.lock().unwrap();
+            *sequence_number = sequence_number.wrapping_add(1);
+            *sequence_number
+        };
+
         nwk_frame.aux_header = Some(NwkAuxHeader {
             security_control: NwkSecurityHeaderControlField {
                 security_level: NwkSecurityLevel::NoSecurity,
@@ -1734,25 +1696,24 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
             },
             frame_counter: 0, // This field is rewritten and is always up-to-date
-            extended_source: Some(state.ieee_address),
-            key_sequence_number: state.active_key_seq_number,
+            extended_source: Some(self.state.ieee_address),
+            key_sequence_number: self.state.active_key_seq_number,
         });
 
-        drop(state);
-
         for attempt in 0..=self.constants.unicast_retries {
-            state = self.state.lock().unwrap();
-
             // The encryption frame counter always increments
-            state.security_material_primary.outgoing_frame_counter = state
-                .security_material_primary
-                .outgoing_frame_counter
-                .wrapping_add(1);
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
+                let mut security_material_primary =
+                    self.state.security_material_primary.lock().unwrap();
+                security_material_primary.outgoing_frame_counter = security_material_primary
+                    .outgoing_frame_counter
+                    .wrapping_add(1);
 
-            nwk_frame.aux_header.as_mut().unwrap().frame_counter =
-                state.security_material_primary.outgoing_frame_counter;
+                security_material_primary.outgoing_frame_counter
+            };
 
-            let encrypted_nwk_frame = nwk_frame.encrypt(&state.security_material_primary.key);
+            let encrypted_nwk_frame =
+                nwk_frame.encrypt(&self.state.security_material_primary.lock().unwrap().key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1768,11 +1729,11 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: Some(state.ieee802154_sequence_number),
-                dest_pan_id: Some(state.pan_id),
+                sequence_number: Some(*self.state.ieee802154_sequence_number.lock().unwrap()),
+                dest_pan_id: Some(self.state.pan_id),
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
-                src_address: Some(Ieee802154Address::Nwk(state.network_address)),
+                src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
                 payload: encrypted_nwk_frame.to_bytes(),
                 fcs: 0x0000, // It'll be replaced
             };
@@ -1780,37 +1741,44 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            if let Some(relaying_ieee) = state.address_map.iter().find_map(|(&eui64, &nwk)| {
+            let address_map = self.state.address_map.lock().unwrap();
+            let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+
+            if let Some(relaying_ieee) = address_map.iter().find_map(|(&eui64, &nwk)| {
                 if nwk == next_hop_address {
                     Some(eui64)
                 } else {
                     None
                 }
             }) {
-                if let Some(neighbor_entry) = state.neighbor_table.get_mut(&relaying_ieee) {
+                if let Some(neighbor_entry) = neighbor_table.get_mut(&relaying_ieee) {
                     // Update the neighbor table counters
                     neighbor_entry.router_outbound_activity =
                         neighbor_entry.router_outbound_activity.saturating_add(1);
                 }
             }
 
+            let mut route_table = self.state.route_table.lock().unwrap();
+
             // And the routing table counters
-            if let Some(route_entry) = state.route_table.get_mut(&nwk_frame.nwk_header.destination)
-            {
+            if let Some(route_entry) = route_table.get_mut(&nwk_frame.nwk_header.destination) {
                 route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
                 route_entry.total_usage_count = route_entry.total_usage_count.saturating_add(1);
             }
 
             // Increment counters before sending
-            state.tx_total = state.tx_total.wrapping_add(1);
+            let tx_total = {
+                let mut tx_total = self.state.tx_total.lock().unwrap();
+                *tx_total = tx_total.wrapping_add(1);
+                *tx_total
+            };
 
             // Handle `tx_total` wrapping
-            if state.tx_total == 0x0000 {
-                for (_, neighbor) in state.neighbor_table.iter_mut() {
+            if tx_total == 0x0000 {
+                for (_, neighbor) in neighbor_table.iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
-            drop(state);
 
             match self.send_802154_frame(ieee802154_frame).await {
                 Ok(_) => {
@@ -1841,10 +1809,12 @@ impl ZigbeeStack {
         &self,
         mut nwk_frame: NwkFrame,
     ) -> Result<(), ZigbeeStackError> {
-        let mut state = self.state.lock().unwrap();
+        nwk_frame.nwk_header.sequence_number = {
+            let mut sequence_number = self.state.sequence_number.lock().unwrap();
+            *sequence_number = sequence_number.wrapping_add(1);
+            *sequence_number
+        };
 
-        state.sequence_number = state.sequence_number.wrapping_add(1);
-        nwk_frame.nwk_header.sequence_number = state.sequence_number;
         nwk_frame.aux_header = Some(NwkAuxHeader {
             security_control: NwkSecurityHeaderControlField {
                 security_level: NwkSecurityLevel::NoSecurity,
@@ -1853,25 +1823,24 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
             },
             frame_counter: 0, // This field is rewritten and is always up-to-date
-            extended_source: Some(state.ieee_address),
-            key_sequence_number: state.active_key_seq_number,
+            extended_source: Some(self.state.ieee_address),
+            key_sequence_number: self.state.active_key_seq_number,
         });
 
-        drop(state);
-
         for attempt in 0..=self.constants.max_broadcast_retries {
-            state = self.state.lock().unwrap();
-
             // The encryption frame counter always increments
-            state.security_material_primary.outgoing_frame_counter = state
-                .security_material_primary
-                .outgoing_frame_counter
-                .wrapping_add(1);
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
+                let mut security_material_primary =
+                    self.state.security_material_primary.lock().unwrap();
+                security_material_primary.outgoing_frame_counter = security_material_primary
+                    .outgoing_frame_counter
+                    .wrapping_add(1);
 
-            nwk_frame.aux_header.as_mut().unwrap().frame_counter =
-                state.security_material_primary.outgoing_frame_counter;
+                security_material_primary.outgoing_frame_counter
+            };
 
-            let encrypted_nwk_frame = nwk_frame.encrypt(&state.security_material_primary.key);
+            let encrypted_nwk_frame =
+                nwk_frame.encrypt(&self.state.security_material_primary.lock().unwrap().key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1887,27 +1856,32 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: Some(state.ieee802154_sequence_number),
-                dest_pan_id: Some(state.pan_id),
+                sequence_number: Some(*self.state.ieee802154_sequence_number.lock().unwrap()),
+                dest_pan_id: Some(self.state.pan_id),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
                 src_pan_id: None,
-                src_address: Some(Ieee802154Address::Nwk(state.network_address)),
+                src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
                 payload: encrypted_nwk_frame.to_bytes(),
                 fcs: 0x0000, // It'll be replaced
             };
 
             // Increment counters before sending
-            state.tx_total = state.tx_total.wrapping_add(1);
+            let tx_total = {
+                let mut tx_total = self.state.tx_total.lock().unwrap();
+                *tx_total = tx_total.wrapping_add(1);
+                *tx_total
+            };
 
             // Handle `tx_total` wrapping
-            if state.tx_total == 0x0000 {
-                for (_, neighbor) in state.neighbor_table.iter_mut() {
+            let mut neighbor_table = self.state.neighbor_table.lock().unwrap();
+
+            if tx_total == 0x0000 {
+                for (_, neighbor) in neighbor_table.iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
-            drop(state);
 
             // TODO: implement logic to detect when broadcasts have been successfully
             // sent. This is done by keeping track of which neighbor routers have been
@@ -1932,19 +1906,21 @@ impl ZigbeeStack {
     }
 
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, ZigbeeStackError> {
-        let state = self.state.lock().unwrap();
-
-        if state.hack_force_route_discovery || !state.route_table.contains_key(&destination) {
-            drop(state);
+        if self.state.hack_force_route_discovery
+            || !self
+                .state
+                .route_table
+                .lock()
+                .unwrap()
+                .contains_key(&destination)
+        {
             log::debug!("Starting route discovery for NWK {destination:?}");
             self.send_route_discovery(destination).await;
-        } else {
-            drop(state);
         }
 
         let (route_entry_status, route_entry_next_hop_address) = {
-            let state = self.state.lock().unwrap();
-            let entry = state.route_table.get(&destination).unwrap();
+            let route_table = self.state.route_table.lock().unwrap();
+            let entry = route_table.get(&destination).unwrap();
 
             (entry.status, entry.next_hop_address)
         };
@@ -1970,9 +1946,9 @@ impl ZigbeeStack {
 
         // Create a pending route notification
         let mut rx = {
-            let mut state = self.state.lock().unwrap();
-            let tx = state
-                .pending_route_notifications
+            let mut pending_route_notifications =
+                self.state.pending_route_notifications.lock().unwrap();
+            let tx = pending_route_notifications
                 .entry(destination)
                 .or_insert_with(|| {
                     let (tx, _) = broadcast::channel(1);
@@ -1985,21 +1961,17 @@ impl ZigbeeStack {
         // Pull the current route discovery entry for the device to determine the timeout
         let discovery_timeout = {
             let now = Instant::now();
+            let route_discovery_table = self.state.route_discovery_table.lock().unwrap();
 
             // One should exist
-            let state = self.state.lock().unwrap();
             let route_discovery_entry =
-                match state
-                    .route_discovery_table
-                    .iter()
-                    .find_map(|(&(_, _), entry)| {
-                        if entry.expiration_time >= now && entry.destination_address == destination
-                        {
-                            Some(entry)
-                        } else {
-                            None
-                        }
-                    }) {
+                match route_discovery_table.iter().find_map(|(&(_, _), entry)| {
+                    if entry.expiration_time >= now && entry.destination_address == destination {
+                        Some(entry)
+                    } else {
+                        None
+                    }
+                }) {
                     Some(entry) => entry,
                     None => {
                         log::warn!("No route discovery entry found for {destination:?}");
@@ -2022,17 +1994,18 @@ impl ZigbeeStack {
             }
             Err(err) => {
                 log::debug!("Route discovery timed out");
-                let mut state = self.state.lock().unwrap();
-                let entry = state.route_table.get_mut(&destination).unwrap();
+                let mut route_table = self.state.route_table.lock().unwrap();
+                let entry = route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
                 return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
             }
         };
 
         let next_hop_address = {
-            let state = self.state.lock().unwrap();
-            state
+            self.state
                 .route_table
+                .lock()
+                .unwrap()
                 .get(&destination)
                 .unwrap()
                 .next_hop_address
@@ -2043,13 +2016,12 @@ impl ZigbeeStack {
 
     pub async fn send_route_discovery(&self, destination: Nwk) {
         // Discover next hop route
-        let mut state = self.state.lock().unwrap();
-
         log::debug!("Sending route discovery for NWK {destination:?}");
 
         // Get or create a routing table entry without keeping a mutable reference
         {
-            let route_table_entry = state.route_table.entry(destination).or_insert_with(|| {
+            let mut route_table = self.state.route_table.lock().unwrap();
+            let route_table_entry = route_table.entry(destination).or_insert_with(|| {
                 route::TableEntry {
                     destination: destination,
                     status: route::Status::Inactive,
@@ -2068,20 +2040,23 @@ impl ZigbeeStack {
             route_table_entry.status = route::Status::DiscoveryUnderway;
         }
 
-        state.routing_request_sequence_number =
-            state.routing_request_sequence_number.wrapping_add(1);
+        let route_request_identifier = {
+            let mut routing_request_sequence_number =
+                self.state.routing_request_sequence_number.lock().unwrap();
+            *routing_request_sequence_number = routing_request_sequence_number.wrapping_add(1);
+            *routing_request_sequence_number
+        };
 
-        let route_request_identifier = state.routing_request_sequence_number;
-        let route_discovery_table_key = (state.network_address, route_request_identifier);
+        let route_discovery_table_key = (self.state.network_address, route_request_identifier);
 
         // We initiated discovery so insert an entry keyed by our NWK and request ID
-        let network_address = state.network_address;
+        let network_address = self.state.network_address;
+
+        self.clean_route_discovery_table();
 
         {
-            self.clean_route_discovery_table(&mut state.route_discovery_table);
-
-            let route_discovery_entry = state
-                .route_discovery_table
+            let mut route_discovery_table = self.state.route_discovery_table.lock().unwrap();
+            let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
                     route_request_id: route_request_identifier,
@@ -2098,18 +2073,22 @@ impl ZigbeeStack {
             );
         }
 
-        // Construct a frame
-        state.sequence_number = state.sequence_number.wrapping_add(1);
-
         // If we know the EUI64 corresponding to the NWK, use it
-        let destination_eui64 = state.address_map.iter().find_map(|(&eui64, &nwk)| {
-            if nwk == destination {
-                Some(eui64)
-            } else {
-                None
-            }
-        });
+        let destination_eui64 =
+            self.state
+                .address_map
+                .lock()
+                .unwrap()
+                .iter()
+                .find_map(|(&eui64, &nwk)| {
+                    if nwk == destination {
+                        Some(eui64)
+                    } else {
+                        None
+                    }
+                });
 
+        // Construct a frame
         let route_request_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
@@ -2124,11 +2103,11 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
-                source: state.network_address,
+                source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: state.sequence_number,
+                sequence_number: *self.state.sequence_number.lock().unwrap(),
                 destination_ieee: None,
-                source_ieee: Some(state.ieee_address),
+                source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
                 source_route: None,
             },
@@ -2144,7 +2123,7 @@ impl ZigbeeStack {
             .unwrap(),
         };
 
-        self.background_send_nwk_frame(state, route_request_frame);
+        self.background_send_nwk_frame(route_request_frame);
     }
 
     pub async fn send_aps_command(
@@ -2216,7 +2195,6 @@ impl ZigbeeStack {
 
         log::debug!("Prepared APS frame: {:#?}", aps_frame);
 
-        let mut state = self.state.lock().unwrap();
         let nwk_frame = NwkFrame {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
@@ -2231,9 +2209,9 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: destination,
-                source: state.network_address,
+                source: self.state.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: state.sequence_number,
+                sequence_number: *self.state.sequence_number.lock().unwrap(),
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2246,7 +2224,7 @@ impl ZigbeeStack {
         log::debug!("Prepared NWK frame: {:#?}", nwk_frame);
 
         if !aps_ack {
-            self.background_send_nwk_frame(state, nwk_frame);
+            self.background_send_nwk_frame(nwk_frame);
             return Ok(());
         }
 
@@ -2262,9 +2240,13 @@ impl ZigbeeStack {
         let (ack_tx, ack_rx) = oneshot::channel();
 
         log::debug!("APS ACK requested, waiting for {:?}", ack_data);
-        state.pending_aps_acks.insert(ack_data, ack_tx);
+        self.state
+            .pending_aps_acks
+            .lock()
+            .unwrap()
+            .insert(ack_data, ack_tx);
 
-        self.background_send_nwk_frame(state, nwk_frame);
+        self.background_send_nwk_frame(nwk_frame);
 
         // With a 5s timeout
         match tokio::time::timeout(APS_ACK_TIMEOUT, ack_rx).await {
@@ -2285,16 +2267,15 @@ impl ZigbeeStack {
     }
 
     pub async fn send_link_status_broadcast(&self, empty: bool) {
-        let mut state = self.state.lock().unwrap();
         log::debug!("Sending periodic link status broadcast");
 
-        if state.network_address == Nwk(0xFFFF) {
+        if self.state.network_address == Nwk(0xFFFF) {
             log::debug!("Skipping, stack has not been initialized yet");
             return;
         }
 
         // Decrement the `recent_activity` field of every active routing table entry
-        for (_, route_table_entry) in state.route_table.iter_mut() {
+        for (_, route_table_entry) in self.state.route_table.lock().unwrap().iter_mut() {
             if route_table_entry.status == route::Status::Active {
                 route_table_entry.recent_activity =
                     route_table_entry.recent_activity.saturating_sub(1);
@@ -2302,9 +2283,9 @@ impl ZigbeeStack {
         }
 
         // Decrement the inbound and outbound activity fields for neighbors
-        self.maybe_age_neighbors(&mut state);
+        self.maybe_age_neighbors();
 
-        for (_, neighbor_entry) in state.neighbor_table.iter_mut() {
+        for (_, neighbor_entry) in self.state.neighbor_table.lock().unwrap().iter_mut() {
             neighbor_entry.router_outbound_activity =
                 neighbor_entry.router_outbound_activity.saturating_sub(1);
             neighbor_entry.router_inbound_activity =
@@ -2312,8 +2293,10 @@ impl ZigbeeStack {
         }
 
         let mut link_statuses = if !empty {
-            state
+            self.state
                 .neighbor_table
+                .lock()
+                .unwrap()
                 .iter()
                 .filter_map(|(_, neighbor)| {
                     // We only calculate link statuses for neighbors for which we have
@@ -2329,8 +2312,6 @@ impl ZigbeeStack {
             Vec::new()
         };
 
-        drop(state);
-
         // Link statuses are sorted in ascending order
         link_statuses.sort_by(|a, b| a.address.as_u16().cmp(&b.address.as_u16()));
 
@@ -2338,10 +2319,6 @@ impl ZigbeeStack {
         let mut remaining_link_statuses = link_statuses.clone();
 
         loop {
-            let mut state = self.state.lock().unwrap();
-
-            state.sequence_number = state.sequence_number.wrapping_add(1);
-
             let link_status_frame = NwkFrame {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
@@ -2356,11 +2333,11 @@ impl ZigbeeStack {
                         end_device_initiator: false,
                     },
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
-                    source: state.network_address,
+                    source: self.state.network_address,
                     radius: 1,
-                    sequence_number: state.sequence_number,
+                    sequence_number: *self.state.sequence_number.lock().unwrap(),
                     destination_ieee: None,
-                    source_ieee: Some(state.ieee_address),
+                    source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
                     source_route: None,
                 },
@@ -2381,7 +2358,7 @@ impl ZigbeeStack {
                 .unwrap(),
             };
 
-            self.background_send_nwk_frame(state, link_status_frame);
+            self.background_send_nwk_frame(link_status_frame);
 
             if remaining_link_statuses.is_empty() {
                 break;

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -146,44 +146,22 @@ pub enum NwkDeviceType {
 #[derive(Debug)]
 pub struct Nib {
     pub nwk_sequence_number: u8,
-    pub nwk_passive_ack_timeout: Duration,
-    /// The maximum number of retries allowed after a broadcast transmission failure.
-    pub nwkc_max_broadcast_retries: u8,
-    pub nwk_max_children: u8,
-    pub nwk_max_depth: u8,
     pub nwk_neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
     pub nwk_route_table: HashMap<Nwk, route::TableEntry>,
     pub nwk_route_discovery_table: HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>,
     pub nwk_capability_information: NwkCapabilityInformation,
     pub nwk_manager_addr: Nwk,
-    pub nwk_max_source_route: u8,
     pub nwk_update_id: u8,
-    pub nwk_transaction_persistence_time: Duration,
     pub nwk_network_address: Nwk,
-    pub nwk_stack_profile: u8,
     pub nwk_broadcast_transaction_table: HashMap<(Nwk, u8), NwkBroadcastTransaction>,
     pub nwk_extended_pan_id: Eui64,
     pub nwk_route_record_table: HashMap<Nwk, Vec<Nwk>>,
     pub nwk_is_concentrator: bool,
-    pub nwk_concentrator_radius: u8,
-    pub nwk_concentrator_discovery_time: Duration,
     pub nwk_security_level: u8,
     pub nwk_security_material_primary: NwkSecurityDescriptor,
     pub nwk_security_material_alternate: NwkSecurityDescriptor,
     pub nwk_active_key_seq_number: u8,
     pub nwk_all_fresh: bool,
-
-    /// The minimum time, in seconds, between two consecutive concentrator route
-    /// discoveries. If set to 0x00, there is no minimum separation. This only applies
-    /// when the device is operating as a Concentrator.
-    pub nwk_concentrator_discovery_separation_time: Duration,
-
-    /// The time between link status command frames.
-    pub nwk_link_status_period: Duration,
-
-    /// The number of missed link status command frames before resetting the link costs
-    /// to zero.
-    pub nwk_router_age_limit: u8,
     pub nwk_address_map: HashMap<Eui64, Nwk>,
 
     /// A flag that determines if a timestamp indication is provided on incoming and
@@ -232,44 +210,54 @@ pub struct Nib {
     /// level application. The higher level application sets this value and the stack
     /// advertises it.
     pub nwk_hub_connectivity: bool,
+}
 
-    // nwkMacInterfaceTable
-    // nwkNetworkWideBeaconAppendixTLVs
-    // nwkDeviceLocalBeaconAppendixTLVs
-    // nwkDiscoveryTable
-    // nwkDiscoveryTableSize = 6
-    // nwkNextPanId = 0xFFFF
-    // nwkNextChannelChange = 0
-    // nwkPerformAdditionalMacDataPollRetries = 0
-    // nwkPreferredParent
-    // nwkGoodParentLQA = 75
-    // nwkPanIdConflictCount = 0
-    // nwkMaxInitialJoinParentAttempts = 1
-    // nwkMaxRejoinParentAttempts = 3
-    pub nwkc_protocol_version: u8,
-    pub nwkc_route_discovery_time: Duration,
-    pub nwkc_max_broadcast_jitter: Duration,
-    pub nwkc_initial_rreq_retries: u8,
-    pub nwkc_rreq_retries: u8,
-    pub nwkc_rreq_retry_interval: Duration,
-    pub nwkc_min_rreq_jitter: Duration,
-    pub nwkc_max_rreq_jitter: Duration,
-    pub nwkc_max_depth: u8,
-    pub nwkc_unicast_retries: u8,
-    pub nwkc_unicast_retry_delay: Duration,
-    pub nwkc_min_router_bootstrap_jitter: Duration,
-    pub nwkc_max_router_bootstrap_jitter: Duration,
-    pub nwkc_broadcast_delivery_time: Duration,
+#[derive(Debug)]
+pub struct Constants {
+    pub concentrator_radius: u8,
+    pub concentrator_discovery_time: Duration,
+    pub stack_profile: u8,
+    pub transaction_persistence_time: Duration,
+    pub max_source_route: u8,
+    pub max_children: u8,
+
+    pub passive_ack_timeout: Duration,
+
+    /// The maximum number of retries allowed after a broadcast transmission failure.
+    pub max_broadcast_retries: u8,
+
+    /// The minimum time, in seconds, between two consecutive concentrator route
+    /// discoveries. If set to 0x00, there is no minimum separation. This only applies
+    /// when the device is operating as a Concentrator.
+    pub concentrator_discovery_separation_time: Duration,
+
+    /// The time between link status command frames.
+    pub link_status_period: Duration,
+
+    /// The number of missed link status command frames before resetting the link costs
+    /// to zero.
+    pub router_age_limit: u8,
+
+    pub protocol_version: u8,
+    pub route_discovery_time: Duration,
+    pub max_broadcast_jitter: Duration,
+    pub initial_rreq_retries: u8,
+    pub rreq_retries: u8,
+    pub rreq_retry_interval: Duration,
+    pub min_rreq_jitter: Duration,
+    pub max_rreq_jitter: Duration,
+    pub max_depth: u8,
+    pub unicast_retries: u8,
+    pub unicast_retry_delay: Duration,
+    pub min_router_bootstrap_jitter: Duration,
+    pub max_router_bootstrap_jitter: Duration,
+    pub broadcast_delivery_time: Duration,
 }
 
 impl Nib {
-    pub fn new() -> Nib {
+    pub fn new() -> Self {
         Nib {
             nwk_sequence_number: 0,
-            nwk_passive_ack_timeout: Duration::from_millis(500),
-            nwkc_max_broadcast_retries: 2,
-            nwk_max_children: 32,
-            nwk_max_depth: 15,
             nwk_neighbor_table: HashMap::new(),
             nwk_route_table: HashMap::new(),
             nwk_route_discovery_table: HashMap::new(),
@@ -284,17 +272,12 @@ impl Nib {
                 allocate_address: true,
             },
             nwk_manager_addr: Nwk(0x0000),
-            nwk_max_source_route: 12,
             nwk_update_id: 0,
-            nwk_transaction_persistence_time: Duration::from_millis(7680),
             nwk_network_address: Nwk(0x0000),
-            nwk_stack_profile: 2,
             nwk_broadcast_transaction_table: HashMap::new(),
             nwk_extended_pan_id: Eui64::from_hex("0000000000000000"),
             nwk_route_record_table: HashMap::new(),
             nwk_is_concentrator: true,
-            nwk_concentrator_radius: 10,
-            nwk_concentrator_discovery_time: Duration::from_secs(0),
             nwk_security_level: 5,
             nwk_security_material_primary: NwkSecurityDescriptor {
                 key_seq_number: 0,
@@ -312,9 +295,6 @@ impl Nib {
             },
             nwk_active_key_seq_number: 0,
             nwk_all_fresh: false,
-            nwk_concentrator_discovery_separation_time: Duration::from_secs(0),
-            nwk_link_status_period: Duration::from_secs(15),
-            nwk_router_age_limit: 3,
             nwk_address_map: HashMap::new(),
             nwk_time_stamp: false,
             nwk_pan_id: PanId(0xFFFF),
@@ -329,21 +309,38 @@ impl Nib {
             // nwk_routing_sequence_number: 0x0000,
             nwk_routing_request_sequence_number: 0x00,
             nwk_hub_connectivity: true,
-            // Constants. Theoretically.
-            nwkc_protocol_version: 2,
-            nwkc_route_discovery_time: Duration::from_millis(10000),
-            nwkc_max_broadcast_jitter: Duration::from_millis(64),
-            nwkc_initial_rreq_retries: 3,
-            nwkc_rreq_retries: 2,
-            nwkc_rreq_retry_interval: Duration::from_millis(254),
-            nwkc_min_rreq_jitter: Duration::from_millis(2),
-            nwkc_max_rreq_jitter: Duration::from_millis(128),
-            nwkc_max_depth: 15,
-            nwkc_unicast_retries: 3,
-            nwkc_unicast_retry_delay: Duration::from_millis(50),
-            nwkc_min_router_bootstrap_jitter: Duration::from_millis(500),
-            nwkc_max_router_bootstrap_jitter: Duration::from_millis(1000),
-            nwkc_broadcast_delivery_time: Duration::from_millis(9000),
+        }
+    }
+}
+
+impl Constants {
+    pub fn new() -> Self {
+        Self {
+            passive_ack_timeout: Duration::from_millis(500),
+            max_broadcast_retries: 2,
+            max_children: 32,
+            max_depth: 15,
+            max_source_route: 12,
+            transaction_persistence_time: Duration::from_millis(7680),
+            stack_profile: 2,
+            concentrator_radius: 10,
+            concentrator_discovery_time: Duration::from_secs(0),
+            concentrator_discovery_separation_time: Duration::from_secs(0),
+            link_status_period: Duration::from_secs(15),
+            router_age_limit: 3,
+            protocol_version: 2,
+            route_discovery_time: Duration::from_millis(10000),
+            max_broadcast_jitter: Duration::from_millis(64),
+            initial_rreq_retries: 3,
+            rreq_retries: 2,
+            rreq_retry_interval: Duration::from_millis(254),
+            min_rreq_jitter: Duration::from_millis(2),
+            max_rreq_jitter: Duration::from_millis(128),
+            unicast_retries: 3,
+            unicast_retry_delay: Duration::from_millis(50),
+            min_router_bootstrap_jitter: Duration::from_millis(500),
+            max_router_bootstrap_jitter: Duration::from_millis(1000),
+            broadcast_delivery_time: Duration::from_millis(9000),
         }
     }
 }
@@ -376,6 +373,7 @@ pub struct State {
     pub channel: u8,
     pub ieee802154_sequence_number: u8,
     pub nib: Nib,
+    pub constants: Constants,
     pub pending_aps_acks: HashMap<ApsAckData, oneshot::Sender<()>>,
     pub pending_route_notifications: HashMap<Nwk, broadcast::Sender<()>>,
     pub start_time: Option<Instant>,
@@ -402,6 +400,7 @@ impl State {
             channel: 0,
             ieee802154_sequence_number: 0,
             nib: Nib::new(),
+            constants: Constants::new(),
             pending_aps_acks: HashMap::new(),
             pending_route_notifications: HashMap::new(),
             start_time: None,
@@ -832,7 +831,7 @@ impl ZigbeeStack {
     pub fn filter_broadcast(&self, nwk_frame: &NwkFrame) -> bool {
         let now = Instant::now();
         let mut state = self.state.lock().unwrap();
-        let broadcast_delivery_time = state.nib.nwkc_broadcast_delivery_time;
+        let broadcast_delivery_time = state.constants.broadcast_delivery_time;
 
         // We cannot handle broadcasts until the network has been running for at least
         // the time it takes to deliver one broadcast
@@ -982,7 +981,7 @@ impl ZigbeeStack {
         // TODO: this function should be replaced by real timers
         let now = Instant::now();
         let max_neighbor_age =
-            (state.nib.nwk_router_age_limit as u32) * state.nib.nwk_link_status_period;
+            (state.constants.router_age_limit as u32) * state.constants.link_status_period;
 
         for neighbor in state.nib.nwk_neighbor_table.values_mut() {
             if neighbor.outgoing_cost > 0
@@ -1312,7 +1311,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
-                    protocol_version: state.nib.nwkc_protocol_version,
+                    protocol_version: state.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Suppress,
                     multicast: false,
                     security: true,
@@ -1323,7 +1322,7 @@ impl ZigbeeStack {
                 },
                 destination: next_hop_nwk,
                 source: state.nib.nwk_network_address,
-                radius: 2 * state.nib.nwk_max_depth,
+                radius: 2 * state.constants.max_depth,
                 sequence_number: state.nib.nwk_sequence_number,
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
                 source_ieee: Some(state.nib.nwk_ieee_address),
@@ -1492,7 +1491,7 @@ impl ZigbeeStack {
             route_request_cmd.route_request_identifier,
         );
 
-        let nwkc_route_discovery_time = state.nib.nwkc_route_discovery_time;
+        let route_discovery_time = state.constants.route_discovery_time;
 
         if !is_for_self_or_child {
             self.clean_route_discovery_table(&mut state.nib.nwk_route_discovery_table);
@@ -1507,7 +1506,7 @@ impl ZigbeeStack {
                     sender_address: sender_nwk,
                     forward_cost: updated_path_cost,
                     residual_cost: 0,
-                    expiration_time: Instant::now() + nwkc_route_discovery_time,
+                    expiration_time: Instant::now() + route_discovery_time,
                     destination_address: route_request_cmd.destination_address,
                 });
 
@@ -1555,7 +1554,7 @@ impl ZigbeeStack {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
-                        protocol_version: state.nib.nwkc_protocol_version,
+                        protocol_version: state.constants.protocol_version,
                         discover_route: NwkRouteDiscovery::Suppress,
                         multicast: false,
                         security: true,
@@ -1591,7 +1590,7 @@ impl ZigbeeStack {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
-                        protocol_version: state.nib.nwkc_protocol_version,
+                        protocol_version: state.constants.protocol_version,
                         discover_route: NwkRouteDiscovery::Suppress,
                         multicast: false,
                         security: true,
@@ -1602,7 +1601,7 @@ impl ZigbeeStack {
                     },
                     destination: nwk_frame.nwk_header.source,
                     source: state.nib.nwk_network_address,
-                    radius: 2 * state.nib.nwk_max_depth,
+                    radius: 2 * state.constants.max_depth,
                     sequence_number: state.nib.nwk_sequence_number,
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: Some(state.nib.nwk_ieee_address),
@@ -1634,7 +1633,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
-                    protocol_version: state.nib.nwkc_protocol_version,
+                    protocol_version: state.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Enable,
                     multicast: false,
                     security: true,
@@ -1646,7 +1645,7 @@ impl ZigbeeStack {
                 // Send our ACK back to the sender
                 destination: nwk_frame.nwk_header.source,
                 source: state.nib.nwk_network_address,
-                radius: 2 * state.nib.nwk_max_depth,
+                radius: 2 * state.constants.max_depth,
                 sequence_number: state.nib.nwk_sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
@@ -1787,12 +1786,12 @@ impl ZigbeeStack {
             key_sequence_number: state.nib.nwk_active_key_seq_number,
         });
 
-        let nwkc_unicast_retries = state.nib.nwkc_unicast_retries;
-        let nwkc_unicast_retry_delay = state.nib.nwkc_unicast_retry_delay;
+        let unicast_retries = state.constants.unicast_retries;
+        let unicast_retry_delay = state.constants.unicast_retry_delay;
 
         drop(state);
 
-        for attempt in 0..=nwkc_unicast_retries {
+        for attempt in 0..=unicast_retries {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
@@ -1883,17 +1882,17 @@ impl ZigbeeStack {
                 Err(e) => {
                     log::warn!("Failed to send unicast frame: {e}");
 
-                    if attempt + 1 > nwkc_unicast_retries {
+                    if attempt + 1 > unicast_retries {
                         log::error!("Failed to send unicast frame after {} attempts", attempt);
                         return Err(e);
                     }
                     log::debug!(
                         "Retrying unicast frame send, attempt {} of {}",
                         attempt,
-                        nwkc_unicast_retries
+                        unicast_retries
                     );
 
-                    tokio::time::sleep(nwkc_unicast_retry_delay).await;
+                    tokio::time::sleep(unicast_retry_delay).await;
                 }
             }
         }
@@ -1921,12 +1920,12 @@ impl ZigbeeStack {
             key_sequence_number: state.nib.nwk_active_key_seq_number,
         });
 
-        let nwkc_broadcast_retries = state.nib.nwkc_max_broadcast_retries;
-        let nwkc_max_broadcast_jitter = state.nib.nwkc_max_broadcast_jitter;
+        let broadcast_retries = state.constants.max_broadcast_retries;
+        let max_broadcast_jitter = state.constants.max_broadcast_jitter;
 
         drop(state);
 
-        for attempt in 0..=nwkc_broadcast_retries {
+        for attempt in 0..=broadcast_retries {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
@@ -1988,11 +1987,11 @@ impl ZigbeeStack {
             // "heard" relaying it. For now, we just retry a few times.
             let _ = self.send_802154_frame(ieee802154_frame).await;
 
-            let sleep_time = nwkc_max_broadcast_jitter.mul_f32(rand::random::<f32>());
+            let sleep_time = max_broadcast_jitter.mul_f32(rand::random::<f32>());
             log::debug!(
                 "Retrying broadcast frame send, attempt {} of {} in {:?}",
                 attempt,
-                nwkc_broadcast_retries,
+                broadcast_retries,
                 sleep_time,
             );
 
@@ -2157,7 +2156,7 @@ impl ZigbeeStack {
 
         // We initiated discovery so insert an entry keyed by our NWK and request ID
         let nwk_network_address = state.nib.nwk_network_address;
-        let nwkc_route_discovery_time = state.nib.nwkc_route_discovery_time;
+        let route_discovery_time = state.constants.route_discovery_time;
 
         {
             self.clean_route_discovery_table(&mut state.nib.nwk_route_discovery_table);
@@ -2172,7 +2171,7 @@ impl ZigbeeStack {
                     sender_address: Nwk(0xFFFF),
                     forward_cost: 0,
                     residual_cost: 0,
-                    expiration_time: Instant::now() + nwkc_route_discovery_time,
+                    expiration_time: Instant::now() + route_discovery_time,
                     destination_address: destination,
                 });
 
@@ -2197,7 +2196,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
-                    protocol_version: state.nib.nwkc_protocol_version,
+                    protocol_version: state.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Suppress,
                     multicast: false,
                     security: true,
@@ -2208,7 +2207,7 @@ impl ZigbeeStack {
                 },
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                 source: state.nib.nwk_network_address,
-                radius: 2 * state.nib.nwk_max_depth,
+                radius: 2 * state.constants.max_depth,
                 sequence_number: state.nib.nwk_sequence_number,
                 destination_ieee: None,
                 source_ieee: Some(state.nib.nwk_ieee_address),
@@ -2304,7 +2303,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
-                    protocol_version: state.nib.nwkc_protocol_version,
+                    protocol_version: state.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Enable,
                     multicast: false,
                     security: true,
@@ -2430,7 +2429,7 @@ impl ZigbeeStack {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
-                        protocol_version: state.nib.nwkc_protocol_version,
+                        protocol_version: state.constants.protocol_version,
                         discover_route: NwkRouteDiscovery::Suppress,
                         multicast: false,
                         security: true,
@@ -2475,8 +2474,8 @@ impl ZigbeeStack {
 
     pub async fn periodic_link_status_broadcast_task(&self) {
         loop {
-            let nwk_link_status_period = self.state.lock().unwrap().nib.nwk_link_status_period;
-            tokio::time::sleep(nwk_link_status_period).await;
+            let link_status_period = self.state.lock().unwrap().constants.link_status_period;
+            tokio::time::sleep(link_status_period).await;
 
             self.send_link_status_broadcast(false).await;
         }

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -145,55 +145,55 @@ pub enum NwkDeviceType {
 /// respectively. Except those who are read only
 #[derive(Debug)]
 pub struct Nib {
-    pub nwk_sequence_number: u8,
-    pub nwk_neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
-    pub nwk_route_table: HashMap<Nwk, route::TableEntry>,
-    pub nwk_route_discovery_table: HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>,
-    pub nwk_capability_information: NwkCapabilityInformation,
-    pub nwk_manager_addr: Nwk,
-    pub nwk_update_id: u8,
-    pub nwk_network_address: Nwk,
-    pub nwk_broadcast_transaction_table: HashMap<(Nwk, u8), NwkBroadcastTransaction>,
-    pub nwk_extended_pan_id: Eui64,
-    pub nwk_route_record_table: HashMap<Nwk, Vec<Nwk>>,
-    pub nwk_is_concentrator: bool,
-    pub nwk_security_level: u8,
-    pub nwk_security_material_primary: NwkSecurityDescriptor,
-    pub nwk_security_material_alternate: NwkSecurityDescriptor,
-    pub nwk_active_key_seq_number: u8,
-    pub nwk_all_fresh: bool,
-    pub nwk_address_map: HashMap<Eui64, Nwk>,
+    pub sequence_number: u8,
+    pub neighbor_table: HashMap<Eui64, neighbor::TableEntry>,
+    pub route_table: HashMap<Nwk, route::TableEntry>,
+    pub route_discovery_table: HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>,
+    pub capability_information: NwkCapabilityInformation,
+    pub manager_addr: Nwk,
+    pub update_id: u8,
+    pub network_address: Nwk,
+    pub broadcast_transaction_table: HashMap<(Nwk, u8), NwkBroadcastTransaction>,
+    pub extended_pan_id: Eui64,
+    pub route_record_table: HashMap<Nwk, Vec<Nwk>>,
+    pub is_concentrator: bool,
+    pub security_level: u8,
+    pub security_material_primary: NwkSecurityDescriptor,
+    pub security_material_alternate: NwkSecurityDescriptor,
+    pub active_key_seq_number: u8,
+    pub all_fresh: bool,
+    pub address_map: HashMap<Eui64, Nwk>,
 
     /// A flag that determines if a timestamp indication is provided on incoming and
     /// outgoing packets.
-    pub nwk_time_stamp: bool,
+    pub time_stamp: bool,
 
-    pub nwk_pan_id: PanId,
+    pub pan_id: PanId,
 
     /// A count of Unicast transmissions made by the NNK layer on this device.
     /// Each time the NWK layer transmits a Unicast frame, by invoking the
     /// MCPS-state.request primitive of the MAC sub-layer, it SHALL increment
     /// this counter. When either the NHL performs an NLME-SET.request on this
-    /// attribute or if the value of `nwk_tx_total` rolls over past 0xffff the
+    /// attribute or if the value of `tx_total` rolls over past 0xffff the
     /// NWK layer SHALL reset to 0x00 each Transmit Failure field contained in
     /// the neighbor table.
-    pub nwk_tx_total: u16,
+    pub tx_total: u16,
 
     /// This policy determines whether or not a remote NWK leave request command frame
     /// received by the local device is accepted.
-    pub nwk_leave_request_allowed: bool,
+    pub leave_request_allowed: bool,
 
-    pub nwk_parent_information: u8,
+    pub parent_information: u8,
 
     /// This is an index into Table 3-54. It indicates the default timeout in minutes for
     /// any end device that does not negotiate a different timeout value.
-    pub nwk_end_device_timeout_default: u8,
+    pub end_device_timeout_default: u8,
 
     /// This policy determines whether a NWK leave request is accepted when the Rejoin
     /// bit in the message is set to FALSE
-    pub nwk_leave_request_without_rejoin_allowed: bool,
+    pub leave_request_without_rejoin_allowed: bool,
 
-    pub nwk_ieee_address: Eui64,
+    pub ieee_address: Eui64,
 
     // A strictly increasing sequence number included in all route request and route
     // reply command frames to allow other routers to determine the chronological order
@@ -204,12 +204,12 @@ pub struct Nib {
     /// 16-bit Routing Sequence Number. The former is used to discern route requests
     /// originating in a particular router; the latter is used to identify stale routing
     /// information."
-    pub nwk_routing_request_sequence_number: u8,
+    pub routing_request_sequence_number: u8,
 
     /// This indicates whether the router has Hub Connectivity as defined by a higher
     /// level application. The higher level application sets this value and the stack
     /// advertises it.
-    pub nwk_hub_connectivity: bool,
+    pub hub_connectivity: bool,
 }
 
 #[derive(Debug)]
@@ -257,11 +257,11 @@ pub struct Constants {
 impl Nib {
     pub fn new() -> Self {
         Nib {
-            nwk_sequence_number: 0,
-            nwk_neighbor_table: HashMap::new(),
-            nwk_route_table: HashMap::new(),
-            nwk_route_discovery_table: HashMap::new(),
-            nwk_capability_information: NwkCapabilityInformation {
+            sequence_number: 0,
+            neighbor_table: HashMap::new(),
+            route_table: HashMap::new(),
+            route_discovery_table: HashMap::new(),
+            capability_information: NwkCapabilityInformation {
                 alternate_pan_coordinator: false,
                 device_type: NwkCapabilityInformationDeviceType::EndDevice,
                 power_source: NwkCapabilityInformationPowerSource::MainsPower,
@@ -271,44 +271,44 @@ impl Nib {
                 security_capability: NwkSecurityCapability::Capable,
                 allocate_address: true,
             },
-            nwk_manager_addr: Nwk(0x0000),
-            nwk_update_id: 0,
-            nwk_network_address: Nwk(0x0000),
-            nwk_broadcast_transaction_table: HashMap::new(),
-            nwk_extended_pan_id: Eui64::from_hex("0000000000000000"),
-            nwk_route_record_table: HashMap::new(),
-            nwk_is_concentrator: true,
-            nwk_security_level: 5,
-            nwk_security_material_primary: NwkSecurityDescriptor {
+            manager_addr: Nwk(0x0000),
+            update_id: 0,
+            network_address: Nwk(0x0000),
+            broadcast_transaction_table: HashMap::new(),
+            extended_pan_id: Eui64::from_hex("0000000000000000"),
+            route_record_table: HashMap::new(),
+            is_concentrator: true,
+            security_level: 5,
+            security_material_primary: NwkSecurityDescriptor {
                 key_seq_number: 0,
                 outgoing_frame_counter: 0,
                 incoming_frame_counter_set: HashMap::new(),
                 key: Key::from_hex("00000000000000000000000000000000"),
                 network_key_type: NetworkKeyType::Standard,
             },
-            nwk_security_material_alternate: NwkSecurityDescriptor {
+            security_material_alternate: NwkSecurityDescriptor {
                 key_seq_number: 0,
                 outgoing_frame_counter: 0,
                 incoming_frame_counter_set: HashMap::new(),
                 key: Key::from_hex("00000000000000000000000000000000"),
                 network_key_type: NetworkKeyType::Standard,
             },
-            nwk_active_key_seq_number: 0,
-            nwk_all_fresh: false,
-            nwk_address_map: HashMap::new(),
-            nwk_time_stamp: false,
-            nwk_pan_id: PanId(0xFFFF),
-            nwk_tx_total: 0,
-            nwk_leave_request_allowed: false,
-            nwk_parent_information: 0,
-            nwk_end_device_timeout_default: 0,
-            nwk_leave_request_without_rejoin_allowed: false,
-            nwk_ieee_address: Eui64::from_hex("0000000000000000"),
+            active_key_seq_number: 0,
+            all_fresh: false,
+            address_map: HashMap::new(),
+            time_stamp: false,
+            pan_id: PanId(0xFFFF),
+            tx_total: 0,
+            leave_request_allowed: false,
+            parent_information: 0,
+            end_device_timeout_default: 0,
+            leave_request_without_rejoin_allowed: false,
+            ieee_address: Eui64::from_hex("0000000000000000"),
             // TODO: The 16-bit routing sequence number is expected to be
             // strictly-increasing, it should be persisted to disk
             // nwk_routing_sequence_number: 0x0000,
-            nwk_routing_request_sequence_number: 0x00,
-            nwk_hub_connectivity: true,
+            routing_request_sequence_number: 0x00,
+            hub_connectivity: true,
         }
     }
 }
@@ -550,28 +550,25 @@ impl ZigbeeStack {
     pub async fn set_network_settings(
         &self,
         nwk_channel: u8,
-        nwk_update_id: u8,
-        nwk_pan_id: PanId,
-        nwk_extended_pan_id: Eui64,
-        nwk_network_address: Nwk,
-        nwk_ieee_address: Eui64,
+        update_id: u8,
+        pan_id: PanId,
+        extended_pan_id: Eui64,
+        network_address: Nwk,
+        ieee_address: Eui64,
         key: Key,
         key_seq_number: u8,
         outgoing_frame_counter: u32,
     ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
         state.channel = nwk_channel;
-        state.nib.nwk_update_id = nwk_update_id;
-        state.nib.nwk_pan_id = nwk_pan_id;
-        state.nib.nwk_extended_pan_id = nwk_extended_pan_id;
-        state.nib.nwk_network_address = nwk_network_address;
-        state.nib.nwk_ieee_address = nwk_ieee_address;
-        state.nib.nwk_security_material_primary.key = key;
-        state.nib.nwk_security_material_primary.key_seq_number = key_seq_number;
-        state
-            .nib
-            .nwk_security_material_primary
-            .outgoing_frame_counter = outgoing_frame_counter;
+        state.nib.update_id = update_id;
+        state.nib.pan_id = pan_id;
+        state.nib.extended_pan_id = extended_pan_id;
+        state.nib.network_address = network_address;
+        state.nib.ieee_address = ieee_address;
+        state.nib.security_material_primary.key = key;
+        state.nib.security_material_primary.key_seq_number = key_seq_number;
+        state.nib.security_material_primary.outgoing_frame_counter = outgoing_frame_counter;
 
         // Update the hardware with new settings.
         self.spinel
@@ -602,7 +599,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Laddr,
-                state.nib.nwk_ieee_address.to_bytes().to_vec(),
+                state.nib.ieee_address.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -610,7 +607,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Saddr,
-                state.nib.nwk_network_address.to_bytes().to_vec(),
+                state.nib.network_address.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -618,7 +615,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Panid,
-                state.nib.nwk_pan_id.to_bytes().to_vec(),
+                state.nib.pan_id.to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -687,11 +684,11 @@ impl ZigbeeStack {
                 log::debug!("Ignoring frame, destination PAN ID is not present");
                 return None;
             }
-            Some(dest_pan_id) if dest_pan_id != state.nib.nwk_pan_id => {
+            Some(dest_pan_id) if dest_pan_id != state.nib.pan_id => {
                 log::debug!(
                     "Ignoring frame, PAN ID does not match {:?} != {:?}",
                     dest_pan_id,
-                    state.nib.nwk_pan_id
+                    state.nib.pan_id
                 );
                 return None;
             }
@@ -708,7 +705,7 @@ impl ZigbeeStack {
         };
 
         // Ignore frames that aren't destined for us
-        if nwk_frame.nwk_header.destination != state.nib.nwk_network_address
+        if nwk_frame.nwk_header.destination != state.nib.network_address
             && nwk_frame.nwk_header.destination.as_u16()
                 < BROADCAST_ALL_ROUTERS_AND_COORDINATOR.as_u16()
         {
@@ -743,7 +740,7 @@ impl ZigbeeStack {
         }
 
         // Validate the network key sequence number
-        if aux_header.key_sequence_number != state.nib.nwk_active_key_seq_number {
+        if aux_header.key_sequence_number != state.nib.active_key_seq_number {
             log::debug!("Ignoring frame, key sequence number is unknown");
             return None;
         }
@@ -763,7 +760,7 @@ impl ZigbeeStack {
 
         match state
             .nib
-            .nwk_security_material_primary
+            .security_material_primary
             .incoming_frame_counter_set
             .get(&src_eui64)
         {
@@ -784,18 +781,18 @@ impl ZigbeeStack {
         log::debug!(
             "Attempting to decrypt {:?} with {:?}",
             nwk_frame,
-            state.nib.nwk_security_material_primary
+            state.nib.security_material_primary
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame =
-            match nwk_frame.decrypt(&state.nib.nwk_security_material_primary.key) {
-                Ok(decrypted_frame) => decrypted_frame,
-                Err(err) => {
-                    log::warn!("Ignoring frame, decryption failed: {err:?}");
-                    return None;
-                }
-            };
+        let decrypted_nwk_frame = match nwk_frame.decrypt(&state.nib.security_material_primary.key)
+        {
+            Ok(decrypted_frame) => decrypted_frame,
+            Err(err) => {
+                log::warn!("Ignoring frame, decryption failed: {err:?}");
+                return None;
+            }
+        };
 
         // At this point we no longer need to lock `state`
         drop(state);
@@ -817,7 +814,7 @@ impl ZigbeeStack {
     pub fn update_nwk_eui64_mapping(&self, nwk: Nwk, eui64: Eui64) {
         let mut state = self.state.lock().unwrap();
 
-        match state.nib.nwk_address_map.insert(eui64, nwk) {
+        match state.nib.address_map.insert(eui64, nwk) {
             None => {
                 log::debug!("Added new address mapping: {eui64:?} -> {nwk:?}")
             }
@@ -849,13 +846,13 @@ impl ZigbeeStack {
         );
 
         // Clean a stale entry first, if one exists.
-        if let Some(entry) = state.nib.nwk_broadcast_transaction_table.get(&key) {
+        if let Some(entry) = state.nib.broadcast_transaction_table.get(&key) {
             if entry.expiration_time > now {
                 return true;
             }
         }
 
-        state.nib.nwk_broadcast_transaction_table.insert(
+        state.nib.broadcast_transaction_table.insert(
             key,
             NwkBroadcastTransaction {
                 source_nwk: nwk_frame.nwk_header.source,
@@ -875,7 +872,7 @@ impl ZigbeeStack {
                     let mut state = self.state.lock().unwrap();
                     state
                         .nib
-                        .nwk_security_material_primary
+                        .security_material_primary
                         .incoming_frame_counter_set
                         .insert(relaying_eui64, aux_header.frame_counter);
 
@@ -933,7 +930,7 @@ impl ZigbeeStack {
                     let mut state = self.state.lock().unwrap();
                     state
                         .nib
-                        .nwk_route_record_table
+                        .route_record_table
                         .insert(nwk_frame.nwk_header.source, route_record_cmd.relays);
                 }
                 Ok(NwkCommandId::RouteRequest) => {
@@ -955,12 +952,12 @@ impl ZigbeeStack {
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             state
                 .nib
-                .nwk_neighbor_table
+                .neighbor_table
                 .get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
         } else {
             state
                 .nib
-                .nwk_neighbor_table
+                .neighbor_table
                 .values_mut()
                 .find(|e| e.network_address == nwk_frame.nwk_header.source)
         } {
@@ -983,7 +980,7 @@ impl ZigbeeStack {
         let max_neighbor_age =
             (state.constants.router_age_limit as u32) * state.constants.link_status_period;
 
-        for neighbor in state.nib.nwk_neighbor_table.values_mut() {
+        for neighbor in state.nib.neighbor_table.values_mut() {
             if neighbor.outgoing_cost > 0
                 && neighbor.last_link_status_timestamp >= now + max_neighbor_age
             {
@@ -1019,7 +1016,7 @@ impl ZigbeeStack {
 
             state
                 .nib
-                .nwk_neighbor_table
+                .neighbor_table
                 .iter()
                 .filter_map(|(_, neighbor_entry)| {
                     if neighbor_entry.outgoing_cost > 0 {
@@ -1031,12 +1028,12 @@ impl ZigbeeStack {
                 .collect::<HashSet<Nwk>>()
         };
 
-        let nwk_network_address = self.state.lock().unwrap().nib.nwk_network_address;
+        let network_address = self.state.lock().unwrap().nib.network_address;
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
 
         let mut state = self.state.lock().unwrap();
-        let neighbor_entry = match state.nib.nwk_neighbor_table.get_mut(&source_ieee) {
+        let neighbor_entry = match state.nib.neighbor_table.get_mut(&source_ieee) {
             Some(entry) => entry,
             None => {
                 // Create one
@@ -1068,8 +1065,8 @@ impl ZigbeeStack {
                     security_timer: 0,
                 };
 
-                state.nib.nwk_neighbor_table.insert(source_ieee, entry);
-                state.nib.nwk_neighbor_table.get_mut(&source_ieee).unwrap()
+                state.nib.neighbor_table.insert(source_ieee, entry);
+                state.nib.neighbor_table.get_mut(&source_ieee).unwrap()
             }
         };
 
@@ -1097,7 +1094,7 @@ impl ZigbeeStack {
                 }
             }
 
-            if link_status.address == nwk_network_address {
+            if link_status.address == network_address {
                 neighbor_entry.outgoing_cost = link_status.incoming_cost;
             }
         }
@@ -1134,11 +1131,11 @@ impl ZigbeeStack {
         // R23 spec but real devices do not do this
 
         let mut state = self.state.lock().unwrap();
-        let our_nwk_address = state.nib.nwk_network_address;
+        let our_nwk_address = state.nib.network_address;
 
         let neighbor = match state
             .nib
-            .nwk_neighbor_table
+            .neighbor_table
             .values()
             .find(|&entry| entry.network_address == nwk_frame.nwk_header.source)
         {
@@ -1166,18 +1163,14 @@ impl ZigbeeStack {
         // make having two mutable borrows at once very difficult
         let Some(discovery_entry) = state
             .nib
-            .nwk_route_discovery_table
+            .route_discovery_table
             .get(&route_discovery_table_key)
         else {
             log::debug!("Route reply for unknown route discovery, ignoring");
             return;
         };
 
-        let Some(routing_entry) = state
-            .nib
-            .nwk_route_table
-            .get(&route_reply_cmd.responder_nwk)
-        else {
+        let Some(routing_entry) = state.nib.route_table.get(&route_reply_cmd.responder_nwk) else {
             log::debug!("Route reply with unknown responder, ignoring");
             return;
         };
@@ -1197,7 +1190,7 @@ impl ZigbeeStack {
                     {
                         let routing_entry = state
                             .nib
-                            .nwk_route_table
+                            .route_table
                             .get_mut(&route_reply_cmd.responder_nwk).unwrap();
                         routing_entry.status = route::Status::Active;
                         routing_entry.next_hop_address = nwk_frame.nwk_header.source;
@@ -1207,7 +1200,7 @@ impl ZigbeeStack {
                     {
                         let discovery_entry = state
                             .nib
-                            .nwk_route_discovery_table
+                            .route_discovery_table
                             .get_mut(&route_discovery_table_key).unwrap();
                         discovery_entry.residual_cost = updated_path_cost;
                     }
@@ -1232,7 +1225,7 @@ impl ZigbeeStack {
                     {
                         let routing_entry = state
                             .nib
-                            .nwk_route_table
+                            .route_table
                             .get_mut(&route_reply_cmd.responder_nwk).unwrap();
                         routing_entry.next_hop_address = nwk_frame.nwk_header.source;
                     }
@@ -1241,7 +1234,7 @@ impl ZigbeeStack {
                     {
                         let discovery_entry = state
                             .nib
-                            .nwk_route_discovery_table
+                            .route_discovery_table
                             .get_mut(&route_discovery_table_key).unwrap();
                         discovery_entry.residual_cost = updated_path_cost;
                     }
@@ -1268,7 +1261,7 @@ impl ZigbeeStack {
         {
             let routing_entry = state
                 .nib
-                .nwk_route_table
+                .route_table
                 .get_mut(&route_reply_cmd.responder_nwk)
                 .unwrap();
             routing_entry.next_hop_address = nwk_frame.nwk_header.source;
@@ -1278,7 +1271,7 @@ impl ZigbeeStack {
         {
             let discovery_entry = state
                 .nib
-                .nwk_route_discovery_table
+                .route_discovery_table
                 .get_mut(&route_discovery_table_key)
                 .unwrap();
             discovery_entry.residual_cost = updated_path_cost;
@@ -1290,7 +1283,7 @@ impl ZigbeeStack {
         let next_hop_nwk = {
             let discovery_entry = state
                 .nib
-                .nwk_route_discovery_table
+                .route_discovery_table
                 .get_mut(&route_discovery_table_key)
                 .unwrap();
 
@@ -1299,7 +1292,7 @@ impl ZigbeeStack {
 
         let Some(next_hop_neighbor) = state
             .nib
-            .nwk_neighbor_table
+            .neighbor_table
             .values()
             .find(|&entry| entry.network_address == next_hop_nwk)
         else {
@@ -1321,11 +1314,11 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: next_hop_nwk,
-                source: state.nib.nwk_network_address,
+                source: state.nib.network_address,
                 radius: 2 * state.constants.max_depth,
-                sequence_number: state.nib.nwk_sequence_number,
+                sequence_number: state.nib.sequence_number,
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
-                source_ieee: Some(state.nib.nwk_ieee_address),
+                source_ieee: Some(state.nib.ieee_address),
                 multicast_control: None,
                 source_route: None,
             },
@@ -1357,11 +1350,11 @@ impl ZigbeeStack {
     /// expire them directly from the event loop.
     fn clean_route_discovery_table(
         &self,
-        nwk_route_discovery_table: &mut HashMap<(Nwk, u8), route::DiscoveryEntry>,
+        route_discovery_table: &mut HashMap<(Nwk, u8), route::DiscoveryEntry>,
     ) {
         let now = Instant::now();
 
-        nwk_route_discovery_table.retain(|_, entry| {
+        route_discovery_table.retain(|_, entry| {
             if entry.expiration_time <= now {
                 log::debug!("Removing expired route discovery entry: {entry:#?}");
                 false
@@ -1387,11 +1380,11 @@ impl ZigbeeStack {
 
         let mut state = self.state.lock().unwrap();
 
-        let nwk_network_address = state.nib.nwk_network_address;
+        let network_address = state.nib.network_address;
         // We need to know who sent the frame
         let Some(sender_neighbor) = state
             .nib
-            .nwk_neighbor_table
+            .neighbor_table
             .values()
             .find(|&entry| entry.network_address == sender_nwk)
         else {
@@ -1421,7 +1414,7 @@ impl ZigbeeStack {
         {
             let route_table_entry = state
                 .nib
-                .nwk_route_table
+                .route_table
                 .entry(route_request_cmd.destination_address)
                 .or_insert_with(|| {
                     route::TableEntry {
@@ -1452,7 +1445,7 @@ impl ZigbeeStack {
         {
             let route_table_entry = state
                 .nib
-                .nwk_route_table
+                .route_table
                 .entry(nwk_frame.nwk_header.source)
                 .or_insert_with(|| route::TableEntry {
                     destination: nwk_frame.nwk_header.source,
@@ -1479,7 +1472,7 @@ impl ZigbeeStack {
         // TODO: what do we do if one of these values doesn't match? This would be
         // an error, some device on the network is storing invalid information about
         // either us or a child.
-        let is_for_self_or_child = route_request_cmd.destination_address == nwk_network_address
+        let is_for_self_or_child = route_request_cmd.destination_address == network_address
             || route_request_cmd.destination_eui64 == route_request_cmd.destination_eui64
             /* || destination_is_child */;
 
@@ -1494,11 +1487,11 @@ impl ZigbeeStack {
         let route_discovery_time = state.constants.route_discovery_time;
 
         if !is_for_self_or_child {
-            self.clean_route_discovery_table(&mut state.nib.nwk_route_discovery_table);
+            self.clean_route_discovery_table(&mut state.nib.route_discovery_table);
 
             let route_discovery_entry = state
                 .nib
-                .nwk_route_discovery_table
+                .route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
                     route_request_id: route_request_cmd.route_request_identifier,
@@ -1526,7 +1519,7 @@ impl ZigbeeStack {
             // Create an entry in the routing table as well
             state
                 .nib
-                .nwk_route_table
+                .route_table
                 .entry(route_request_cmd.destination_address)
                 .or_insert_with(|| route::TableEntry {
                     destination: route_request_cmd.destination_address,
@@ -1566,7 +1559,7 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.destination,
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
-                    sequence_number: state.nib.nwk_sequence_number, // TODO: do we change this?
+                    sequence_number: state.nib.sequence_number, // TODO: do we change this?
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
                     multicast_control: None,
@@ -1600,11 +1593,11 @@ impl ZigbeeStack {
                         end_device_initiator: false,
                     },
                     destination: nwk_frame.nwk_header.source,
-                    source: state.nib.nwk_network_address,
+                    source: state.nib.network_address,
                     radius: 2 * state.constants.max_depth,
-                    sequence_number: state.nib.nwk_sequence_number,
+                    sequence_number: state.nib.sequence_number,
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
-                    source_ieee: Some(state.nib.nwk_ieee_address),
+                    source_ieee: Some(state.nib.ieee_address),
                     multicast_control: None,
                     source_route: None,
                 },
@@ -1612,10 +1605,10 @@ impl ZigbeeStack {
                 payload: NwkRouteReplyCommand {
                     route_request_identifier: route_request_cmd.route_request_identifier,
                     originator_nwk: nwk_frame.nwk_header.source,
-                    responder_nwk: state.nib.nwk_network_address,
+                    responder_nwk: state.nib.network_address,
                     path_cost: updated_path_cost,
                     originator_eui64: nwk_frame.nwk_header.source_ieee,
-                    responder_eui64: Some(state.nib.nwk_ieee_address),
+                    responder_eui64: Some(state.nib.ieee_address),
                 }
                 .serialize()
                 .unwrap(),
@@ -1644,9 +1637,9 @@ impl ZigbeeStack {
                 },
                 // Send our ACK back to the sender
                 destination: nwk_frame.nwk_header.source,
-                source: state.nib.nwk_network_address,
+                source: state.nib.network_address,
                 radius: 2 * state.constants.max_depth,
-                sequence_number: state.nib.nwk_sequence_number,
+                sequence_number: state.nib.sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1772,8 +1765,8 @@ impl ZigbeeStack {
             .await?;
         let mut state = self.state.lock().unwrap();
 
-        state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
-        nwk_frame.nwk_header.sequence_number = state.nib.nwk_sequence_number;
+        state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
+        nwk_frame.nwk_header.sequence_number = state.nib.sequence_number;
         nwk_frame.aux_header = Some(NwkAuxHeader {
             security_control: NwkSecurityHeaderControlField {
                 security_level: NwkSecurityLevel::NoSecurity,
@@ -1782,8 +1775,8 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
             },
             frame_counter: 0, // This field is rewritten and is always up-to-date
-            extended_source: Some(state.nib.nwk_ieee_address),
-            key_sequence_number: state.nib.nwk_active_key_seq_number,
+            extended_source: Some(state.nib.ieee_address),
+            key_sequence_number: state.nib.active_key_seq_number,
         });
 
         let unicast_retries = state.constants.unicast_retries;
@@ -1795,22 +1788,16 @@ impl ZigbeeStack {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
-            state
+            state.nib.security_material_primary.outgoing_frame_counter = state
                 .nib
-                .nwk_security_material_primary
-                .outgoing_frame_counter = state
-                .nib
-                .nwk_security_material_primary
+                .security_material_primary
                 .outgoing_frame_counter
                 .wrapping_add(1);
 
-            nwk_frame.aux_header.as_mut().unwrap().frame_counter = state
-                .nib
-                .nwk_security_material_primary
-                .outgoing_frame_counter;
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter =
+                state.nib.security_material_primary.outgoing_frame_counter;
 
-            let encrypted_nwk_frame =
-                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key);
+            let encrypted_nwk_frame = nwk_frame.encrypt(&state.nib.security_material_primary.key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1827,10 +1814,10 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(state.ieee802154_sequence_number),
-                dest_pan_id: Some(state.nib.nwk_pan_id),
+                dest_pan_id: Some(state.nib.pan_id),
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
-                src_address: Some(Ieee802154Address::Nwk(state.nib.nwk_network_address)),
+                src_address: Some(Ieee802154Address::Nwk(state.nib.network_address)),
                 payload: encrypted_nwk_frame.to_bytes(),
                 fcs: 0x0000, // It'll be replaced
             };
@@ -1838,16 +1825,14 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            if let Some(relaying_ieee) =
-                state.nib.nwk_address_map.iter().find_map(|(&eui64, &nwk)| {
-                    if nwk == next_hop_address {
-                        Some(eui64)
-                    } else {
-                        None
-                    }
-                })
-            {
-                if let Some(neighbor_entry) = state.nib.nwk_neighbor_table.get_mut(&relaying_ieee) {
+            if let Some(relaying_ieee) = state.nib.address_map.iter().find_map(|(&eui64, &nwk)| {
+                if nwk == next_hop_address {
+                    Some(eui64)
+                } else {
+                    None
+                }
+            }) {
+                if let Some(neighbor_entry) = state.nib.neighbor_table.get_mut(&relaying_ieee) {
                     // Update the neighbor table counters
                     neighbor_entry.router_outbound_activity =
                         neighbor_entry.router_outbound_activity.saturating_add(1);
@@ -1857,7 +1842,7 @@ impl ZigbeeStack {
             // And the routing table counters
             if let Some(route_entry) = state
                 .nib
-                .nwk_route_table
+                .route_table
                 .get_mut(&nwk_frame.nwk_header.destination)
             {
                 route_entry.recent_activity = route_entry.recent_activity.saturating_add(1);
@@ -1865,11 +1850,11 @@ impl ZigbeeStack {
             }
 
             // Increment counters before sending
-            state.nib.nwk_tx_total = state.nib.nwk_tx_total.wrapping_add(1);
+            state.nib.tx_total = state.nib.tx_total.wrapping_add(1);
 
-            // Handle `nwk_tx_total` wrapping
-            if state.nib.nwk_tx_total == 0x0000 {
-                for (_, neighbor) in state.nib.nwk_neighbor_table.iter_mut() {
+            // Handle `tx_total` wrapping
+            if state.nib.tx_total == 0x0000 {
+                for (_, neighbor) in state.nib.neighbor_table.iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
@@ -1906,8 +1891,8 @@ impl ZigbeeStack {
     ) -> Result<(), ZigbeeStackError> {
         let mut state = self.state.lock().unwrap();
 
-        state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
-        nwk_frame.nwk_header.sequence_number = state.nib.nwk_sequence_number;
+        state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
+        nwk_frame.nwk_header.sequence_number = state.nib.sequence_number;
         nwk_frame.aux_header = Some(NwkAuxHeader {
             security_control: NwkSecurityHeaderControlField {
                 security_level: NwkSecurityLevel::NoSecurity,
@@ -1916,8 +1901,8 @@ impl ZigbeeStack {
                 require_verified_frame_counter: false,
             },
             frame_counter: 0, // This field is rewritten and is always up-to-date
-            extended_source: Some(state.nib.nwk_ieee_address),
-            key_sequence_number: state.nib.nwk_active_key_seq_number,
+            extended_source: Some(state.nib.ieee_address),
+            key_sequence_number: state.nib.active_key_seq_number,
         });
 
         let broadcast_retries = state.constants.max_broadcast_retries;
@@ -1929,22 +1914,16 @@ impl ZigbeeStack {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
-            state
+            state.nib.security_material_primary.outgoing_frame_counter = state
                 .nib
-                .nwk_security_material_primary
-                .outgoing_frame_counter = state
-                .nib
-                .nwk_security_material_primary
+                .security_material_primary
                 .outgoing_frame_counter
                 .wrapping_add(1);
 
-            nwk_frame.aux_header.as_mut().unwrap().frame_counter = state
-                .nib
-                .nwk_security_material_primary
-                .outgoing_frame_counter;
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter =
+                state.nib.security_material_primary.outgoing_frame_counter;
 
-            let encrypted_nwk_frame =
-                nwk_frame.encrypt(&state.nib.nwk_security_material_primary.key);
+            let encrypted_nwk_frame = nwk_frame.encrypt(&state.nib.security_material_primary.key);
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1961,22 +1940,22 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(state.ieee802154_sequence_number),
-                dest_pan_id: Some(state.nib.nwk_pan_id),
+                dest_pan_id: Some(state.nib.pan_id),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
                 src_pan_id: None,
-                src_address: Some(Ieee802154Address::Nwk(state.nib.nwk_network_address)),
+                src_address: Some(Ieee802154Address::Nwk(state.nib.network_address)),
                 payload: encrypted_nwk_frame.to_bytes(),
                 fcs: 0x0000, // It'll be replaced
             };
 
             // Increment counters before sending
-            state.nib.nwk_tx_total = state.nib.nwk_tx_total.wrapping_add(1);
+            state.nib.tx_total = state.nib.tx_total.wrapping_add(1);
 
-            // Handle `nwk_tx_total` wrapping
-            if state.nib.nwk_tx_total == 0x0000 {
-                for (_, neighbor) in state.nib.nwk_neighbor_table.iter_mut() {
+            // Handle `tx_total` wrapping
+            if state.nib.tx_total == 0x0000 {
+                for (_, neighbor) in state.nib.neighbor_table.iter_mut() {
                     neighbor.transmit_failure = 0;
                 }
             }
@@ -2004,8 +1983,7 @@ impl ZigbeeStack {
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, ZigbeeStackError> {
         let state = self.state.lock().unwrap();
 
-        if state.hack_force_route_discovery || !state.nib.nwk_route_table.contains_key(&destination)
-        {
+        if state.hack_force_route_discovery || !state.nib.route_table.contains_key(&destination) {
             drop(state);
             log::debug!("Starting route discovery for NWK {destination:?}");
             self.send_route_discovery(destination).await;
@@ -2015,7 +1993,7 @@ impl ZigbeeStack {
 
         let (route_entry_status, route_entry_next_hop_address) = {
             let state = self.state.lock().unwrap();
-            let entry = state.nib.nwk_route_table.get(&destination).unwrap();
+            let entry = state.nib.route_table.get(&destination).unwrap();
 
             (entry.status, entry.next_hop_address)
         };
@@ -2062,7 +2040,7 @@ impl ZigbeeStack {
             let route_discovery_entry =
                 match state
                     .nib
-                    .nwk_route_discovery_table
+                    .route_discovery_table
                     .iter()
                     .find_map(|(&(_, _), entry)| {
                         if entry.expiration_time >= now && entry.destination_address == destination
@@ -2095,7 +2073,7 @@ impl ZigbeeStack {
             Err(err) => {
                 log::debug!("Route discovery timed out");
                 let mut state = self.state.lock().unwrap();
-                let entry = state.nib.nwk_route_table.get_mut(&destination).unwrap();
+                let entry = state.nib.route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
                 return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
             }
@@ -2105,7 +2083,7 @@ impl ZigbeeStack {
             let state = self.state.lock().unwrap();
             state
                 .nib
-                .nwk_route_table
+                .route_table
                 .get(&destination)
                 .unwrap()
                 .next_hop_address
@@ -2122,52 +2100,45 @@ impl ZigbeeStack {
 
         // Get or create a routing table entry without keeping a mutable reference
         {
-            let route_table_entry =
-                state
-                    .nib
-                    .nwk_route_table
-                    .entry(destination)
-                    .or_insert_with(|| {
-                        route::TableEntry {
-                            destination: destination,
-                            status: route::Status::Inactive,
-                            no_route_cache: false,
-                            many_to_one: false,
-                            route_record_required: false,
-                            expired: false,
-                            sequence_number_valid: false,
-                            next_hop_address: Nwk(0xFFFF), // Unknown
-                            sequence_number: 0,
-                            total_usage_count: 0,
-                            recent_activity: 0,
-                        }
-                    });
+            let route_table_entry = state.nib.route_table.entry(destination).or_insert_with(|| {
+                route::TableEntry {
+                    destination: destination,
+                    status: route::Status::Inactive,
+                    no_route_cache: false,
+                    many_to_one: false,
+                    route_record_required: false,
+                    expired: false,
+                    sequence_number_valid: false,
+                    next_hop_address: Nwk(0xFFFF), // Unknown
+                    sequence_number: 0,
+                    total_usage_count: 0,
+                    recent_activity: 0,
+                }
+            });
 
             route_table_entry.status = route::Status::DiscoveryUnderway;
         }
 
-        state.nib.nwk_routing_request_sequence_number = state
-            .nib
-            .nwk_routing_request_sequence_number
-            .wrapping_add(1);
+        state.nib.routing_request_sequence_number =
+            state.nib.routing_request_sequence_number.wrapping_add(1);
 
-        let route_request_identifier = state.nib.nwk_routing_request_sequence_number;
-        let route_discovery_table_key = (state.nib.nwk_network_address, route_request_identifier);
+        let route_request_identifier = state.nib.routing_request_sequence_number;
+        let route_discovery_table_key = (state.nib.network_address, route_request_identifier);
 
         // We initiated discovery so insert an entry keyed by our NWK and request ID
-        let nwk_network_address = state.nib.nwk_network_address;
+        let network_address = state.nib.network_address;
         let route_discovery_time = state.constants.route_discovery_time;
 
         {
-            self.clean_route_discovery_table(&mut state.nib.nwk_route_discovery_table);
+            self.clean_route_discovery_table(&mut state.nib.route_discovery_table);
 
             let route_discovery_entry = state
                 .nib
-                .nwk_route_discovery_table
+                .route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
                     route_request_id: route_request_identifier,
-                    source_address: nwk_network_address,
+                    source_address: network_address,
                     sender_address: Nwk(0xFFFF),
                     forward_cost: 0,
                     residual_cost: 0,
@@ -2181,10 +2152,10 @@ impl ZigbeeStack {
         }
 
         // Construct a frame
-        state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
+        state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
 
         // If we know the EUI64 corresponding to the NWK, use it
-        let destination_eui64 = state.nib.nwk_address_map.iter().find_map(|(&eui64, &nwk)| {
+        let destination_eui64 = state.nib.address_map.iter().find_map(|(&eui64, &nwk)| {
             if nwk == destination {
                 Some(eui64)
             } else {
@@ -2206,11 +2177,11 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
-                source: state.nib.nwk_network_address,
+                source: state.nib.network_address,
                 radius: 2 * state.constants.max_depth,
-                sequence_number: state.nib.nwk_sequence_number,
+                sequence_number: state.nib.sequence_number,
                 destination_ieee: None,
-                source_ieee: Some(state.nib.nwk_ieee_address),
+                source_ieee: Some(state.nib.ieee_address),
                 multicast_control: None,
                 source_route: None,
             },
@@ -2313,9 +2284,9 @@ impl ZigbeeStack {
                     end_device_initiator: false,
                 },
                 destination: destination,
-                source: state.nib.nwk_network_address,
+                source: state.nib.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: state.nib.nwk_sequence_number,
+                sequence_number: state.nib.sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2370,13 +2341,13 @@ impl ZigbeeStack {
         let mut state = self.state.lock().unwrap();
         log::debug!("Sending periodic link status broadcast");
 
-        if state.nib.nwk_network_address == Nwk(0xFFFF) {
+        if state.nib.network_address == Nwk(0xFFFF) {
             log::debug!("Skipping, stack has not been initialized yet");
             return;
         }
 
         // Decrement the `recent_activity` field of every active routing table entry
-        for (_, route_table_entry) in state.nib.nwk_route_table.iter_mut() {
+        for (_, route_table_entry) in state.nib.route_table.iter_mut() {
             if route_table_entry.status == route::Status::Active {
                 route_table_entry.recent_activity =
                     route_table_entry.recent_activity.saturating_sub(1);
@@ -2386,7 +2357,7 @@ impl ZigbeeStack {
         // Decrement the inbound and outbound activity fields for neighbors
         self.maybe_age_neighbors(&mut state);
 
-        for (_, neighbor_entry) in state.nib.nwk_neighbor_table.iter_mut() {
+        for (_, neighbor_entry) in state.nib.neighbor_table.iter_mut() {
             neighbor_entry.router_outbound_activity =
                 neighbor_entry.router_outbound_activity.saturating_sub(1);
             neighbor_entry.router_inbound_activity =
@@ -2396,7 +2367,7 @@ impl ZigbeeStack {
         let mut link_statuses = if !empty {
             state
                 .nib
-                .nwk_neighbor_table
+                .neighbor_table
                 .iter()
                 .filter_map(|(_, neighbor)| {
                     // We only calculate link statuses for neighbors for which we have
@@ -2423,7 +2394,7 @@ impl ZigbeeStack {
         loop {
             let mut state = self.state.lock().unwrap();
 
-            state.nib.nwk_sequence_number = state.nib.nwk_sequence_number.wrapping_add(1);
+            state.nib.sequence_number = state.nib.sequence_number.wrapping_add(1);
 
             let link_status_frame = NwkFrame {
                 nwk_header: NwkHeader {
@@ -2439,11 +2410,11 @@ impl ZigbeeStack {
                         end_device_initiator: false,
                     },
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
-                    source: state.nib.nwk_network_address,
+                    source: state.nib.network_address,
                     radius: 1,
-                    sequence_number: state.nib.nwk_sequence_number,
+                    sequence_number: state.nib.sequence_number,
                     destination_ieee: None,
-                    source_ieee: Some(state.nib.nwk_ieee_address),
+                    source_ieee: Some(state.nib.ieee_address),
                     multicast_control: None,
                     source_route: None,
                 },

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -238,12 +238,12 @@ impl ApsAckData {
 
 #[derive(Debug)]
 pub struct State {
-    pub channel: u8,
+    pub channel: Mutex<u8>,
     pub ieee802154_sequence_number: Mutex<u8>,
 
     pub pending_aps_acks: Mutex<HashMap<ApsAckData, oneshot::Sender<()>>>,
     pub pending_route_notifications: Mutex<HashMap<Nwk, broadcast::Sender<()>>>,
-    pub start_time: Option<Instant>,
+    pub start_time: Instant,
 
     // We intentionally violate the spec with these options
     //
@@ -267,7 +267,7 @@ pub struct State {
     pub route_discovery_table: Mutex<HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>>,
     pub capability_information: NwkCapabilityInformation,
     pub nwk_manager_addr: Nwk,
-    pub update_id: u8,
+    pub update_id: Mutex<u8>,
     pub network_address: Nwk,
     pub broadcast_transaction_table: Mutex<HashMap<(Nwk, u8), NwkBroadcastTransaction>>,
     pub extended_pan_id: Eui64,
@@ -287,7 +287,7 @@ pub struct State {
     /// outgoing packets.
     pub time_stamp: bool,
 
-    pub pan_id: PanId,
+    pub pan_id: Mutex<PanId>,
 
     /// A count of Unicast transmissions made by the NNK layer on this device.
     /// Each time the NWK layer transmits a Unicast frame, by invoking the
@@ -328,13 +328,23 @@ pub struct State {
 }
 
 impl State {
-    pub fn new() -> Self {
+    pub fn new(
+        channel: u8,
+        update_id: u8,
+        pan_id: PanId,
+        extended_pan_id: Eui64,
+        network_address: Nwk,
+        ieee_address: Eui64,
+        key: Key,
+        key_seq_number: u8,
+        outgoing_frame_counter: u32,
+    ) -> Self {
         State {
-            channel: 0,
+            channel: Mutex::new(channel),
             ieee802154_sequence_number: Mutex::new(0),
             pending_aps_acks: Mutex::new(HashMap::new()),
             pending_route_notifications: Mutex::new(HashMap::new()),
-            start_time: None,
+            start_time: Instant::now(),
 
             hack_ignore_broadcast_startup_wait_period: true,
             hack_disable_tx: false,
@@ -355,18 +365,18 @@ impl State {
                 allocate_address: true,
             },
             nwk_manager_addr: Nwk(0x0000),
-            update_id: 0,
-            network_address: Nwk(0x0000),
+            update_id: Mutex::new(update_id),
+            network_address: network_address,
             broadcast_transaction_table: Mutex::new(HashMap::new()),
-            extended_pan_id: Eui64::from_hex("0000000000000000"),
+            extended_pan_id: extended_pan_id,
             route_record_table: Mutex::new(HashMap::new()),
             is_concentrator: true,
             security_level: 5,
             security_material_primary: Mutex::new(NwkSecurityDescriptor {
-                key_seq_number: 0,
-                outgoing_frame_counter: 0,
+                key_seq_number: key_seq_number,
+                outgoing_frame_counter: outgoing_frame_counter,
                 incoming_frame_counter_set: HashMap::new(),
-                key: Key::from_hex("00000000000000000000000000000000"),
+                key: key,
                 network_key_type: NetworkKeyType::Standard,
             }),
             security_material_alternate: Mutex::new(NwkSecurityDescriptor {
@@ -380,12 +390,12 @@ impl State {
             all_fresh: false,
             address_map: Mutex::new(HashMap::new()),
             time_stamp: false,
-            pan_id: PanId(0xFFFF),
+            pan_id: Mutex::new(pan_id),
             tx_total: Mutex::new(0),
             leave_request_allowed: false,
             parent_information: 0,
             leave_request_without_rejoin_allowed: false,
-            ieee_address: Eui64::from_hex("0000000000000000"),
+            ieee_address: ieee_address,
             // TODO: The 16-bit routing sequence number is expected to be
             // strictly-increasing, it should be persisted to disk
             // nwk_routing_sequence_number: 0x0000,
@@ -421,14 +431,35 @@ pub struct ZigbeeStack {
 }
 
 impl ZigbeeStack {
-    pub fn new(spinel: SpinelClient) -> (Arc<Self>, broadcast::Receiver<ZigbeeNotification>) {
+    pub fn new(
+        spinel: SpinelClient,
+        channel: u8,
+        update_id: u8,
+        pan_id: PanId,
+        extended_pan_id: Eui64,
+        network_address: Nwk,
+        ieee_address: Eui64,
+        key: Key,
+        key_seq_number: u8,
+        outgoing_frame_counter: u32,
+    ) -> (Arc<Self>, broadcast::Receiver<ZigbeeNotification>) {
         let (notification_tx, notification_rx) = broadcast::channel::<ZigbeeNotification>(32);
         let (raw_frame_tx, raw_frame_rx) = mpsc::channel::<SpinelFramePropValueIs>(32);
         spinel.set_property_update_receiver(SpinelPropertyId::StreamRaw, raw_frame_tx);
 
         let arc_stack = Arc::new_cyclic(|weak_self| ZigbeeStack {
             self_weak: weak_self.clone(),
-            state: State::new(),
+            state: State::new(
+                channel,
+                update_id,
+                pan_id,
+                extended_pan_id,
+                network_address,
+                ieee_address,
+                key,
+                key_seq_number,
+                outgoing_frame_counter,
+            ),
             constants: Constants::new(),
             spinel,
             notification_tx,
@@ -532,33 +563,7 @@ impl ZigbeeStack {
         }
     }
 
-    pub async fn set_network_settings(
-        &mut self,
-        channel: u8,
-        update_id: u8,
-        pan_id: PanId,
-        extended_pan_id: Eui64,
-        network_address: Nwk,
-        ieee_address: Eui64,
-        key: Key,
-        key_seq_number: u8,
-        outgoing_frame_counter: u32,
-    ) -> Result<(), ZigbeeStackError> {
-        self.state.channel = channel;
-        self.state.update_id = update_id;
-        self.state.pan_id = pan_id;
-        self.state.extended_pan_id = extended_pan_id;
-        self.state.network_address = network_address;
-        self.state.ieee_address = ieee_address;
-
-        {
-            let mut security_material_primary =
-                self.state.security_material_primary.lock().unwrap();
-            security_material_primary.key = key;
-            security_material_primary.key_seq_number = key_seq_number;
-            security_material_primary.outgoing_frame_counter = outgoing_frame_counter;
-        }
-
+    pub async fn start_network(&self) -> Result<(), ZigbeeStackError> {
         // Update the hardware with new settings.
         self.spinel
             .prop_value_set(SpinelPropertyId::PhyEnabled, vec![true as u8])
@@ -566,7 +571,10 @@ impl ZigbeeStack {
             .map_err(ZigbeeStackError::SpinelError)?;
 
         self.spinel
-            .prop_value_set(SpinelPropertyId::PhyChan, vec![channel])
+            .prop_value_set(
+                SpinelPropertyId::PhyChan,
+                vec![*self.state.channel.lock().unwrap()],
+            )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
@@ -604,7 +612,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Panid,
-                self.state.pan_id.to_bytes().to_vec(),
+                self.state.pan_id.lock().unwrap().to_bytes().to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -618,9 +626,6 @@ impl ZigbeeStack {
             .prop_value_set(SpinelPropertyId::MacRawStreamEnabled, vec![true as u8])
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
-
-        // This is treated as the start time of the stack
-        self.state.start_time = Some(Instant::now());
 
         // To kick things off, send a link status broadcast. Silicon Labs routers will
         // "respond" to empty link status broadcasts proactively, independent of the
@@ -665,20 +670,24 @@ impl ZigbeeStack {
         }
 
         // Only process packets destined for our PAN ID
-        match frame.dest_pan_id {
-            None => {
-                log::debug!("Ignoring frame, destination PAN ID is not present");
-                return None;
+        {
+            let pan_id = *self.state.pan_id.lock().unwrap();
+
+            match frame.dest_pan_id {
+                None => {
+                    log::debug!("Ignoring frame, destination PAN ID is not present");
+                    return None;
+                }
+                Some(dest_pan_id) if dest_pan_id != pan_id => {
+                    log::debug!(
+                        "Ignoring frame, PAN ID does not match {:?} != {:?}",
+                        dest_pan_id,
+                        pan_id
+                    );
+                    return None;
+                }
+                Some(_) => (),
             }
-            Some(dest_pan_id) if dest_pan_id != self.state.pan_id => {
-                log::debug!(
-                    "Ignoring frame, PAN ID does not match {:?} != {:?}",
-                    dest_pan_id,
-                    self.state.pan_id
-                );
-                return None;
-            }
-            Some(_) => (),
         }
 
         // Next, try to parse the NWK frame
@@ -814,8 +823,7 @@ impl ZigbeeStack {
         // We cannot handle broadcasts until the network has been running for at least
         // the time it takes to deliver one broadcast
         if !self.state.hack_ignore_broadcast_startup_wait_period
-            && (self.state.start_time.is_none()
-                || self.state.start_time.unwrap() + self.constants.broadcast_delivery_time > now)
+            && (self.state.start_time + self.constants.broadcast_delivery_time > now)
         {
             log::debug!("Filtering broadcast, network started too recently.");
             return true;
@@ -1616,7 +1624,7 @@ impl ZigbeeStack {
             .spinel
             .transmit_frame(&SpinelTxFrame {
                 psdu: frame.to_bytes(),
-                channel: Some(self.state.channel),
+                channel: Some(*self.state.channel.lock().unwrap()),
                 max_csma_backoffs: Some(1),
                 max_frame_retries: Some(5),
                 enable_csma_ca: Some(true),
@@ -1730,7 +1738,7 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(*self.state.ieee802154_sequence_number.lock().unwrap()),
-                dest_pan_id: Some(self.state.pan_id),
+                dest_pan_id: Some(*self.state.pan_id.lock().unwrap()),
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
                 src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
@@ -1857,7 +1865,7 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(*self.state.ieee802154_sequence_number.lock().unwrap()),
-                dest_pan_id: Some(self.state.pan_id),
+                dest_pan_id: Some(*self.state.pan_id.lock().unwrap()),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -267,21 +267,27 @@ pub struct State {
 
     // NIB
     pub sequence_number: Mutex<u8>,
+
     pub neighbor_table: Mutex<HashMap<Eui64, neighbor::TableEntry>>,
     pub route_table: Mutex<HashMap<Nwk, route::TableEntry>>,
     pub route_discovery_table: Mutex<HashMap<(Nwk, route::RequestId), route::DiscoveryEntry>>,
+    pub broadcast_transaction_table: Mutex<HashMap<(Nwk, u8), NwkBroadcastTransaction>>,
+    pub route_record_table: Mutex<HashMap<Nwk, Vec<Nwk>>>,
+
     pub capability_information: NwkCapabilityInformation,
     pub nwk_manager_addr: Nwk,
+
+    pub ieee_address: Eui64,
     pub update_id: Mutex<u8>,
+    pub pan_id: Mutex<PanId>,
     pub network_address: Nwk,
-    pub broadcast_transaction_table: Mutex<HashMap<(Nwk, u8), NwkBroadcastTransaction>>,
     pub extended_pan_id: Eui64,
-    pub route_record_table: Mutex<HashMap<Nwk, Vec<Nwk>>>,
-    pub is_concentrator: bool,
-    pub security_level: u8,
     pub security_material_primary: Mutex<NwkSecurityDescriptor>,
     pub security_material_alternate: Mutex<NwkSecurityDescriptor>,
     pub active_key_seq_number: u8,
+
+    pub is_concentrator: bool,
+    pub security_level: u8,
 
     /// Indicates whether incoming NWK frames SHALL be all checked for freshness when
     /// the memory for incoming frame counts is exceeded.
@@ -291,8 +297,6 @@ pub struct State {
     /// A flag that determines if a timestamp indication is provided on incoming and
     /// outgoing packets.
     pub time_stamp: bool,
-
-    pub pan_id: Mutex<PanId>,
 
     /// A count of Unicast transmissions made by the NNK layer on this device.
     /// Each time the NWK layer transmits a Unicast frame, by invoking the
@@ -312,8 +316,6 @@ pub struct State {
     /// This policy determines whether a NWK leave request is accepted when the Rejoin
     /// bit in the message is set to FALSE
     pub leave_request_without_rejoin_allowed: bool,
-
-    pub ieee_address: Eui64,
 
     // A strictly increasing sequence number included in all route request and route
     // reply command frames to allow other routers to determine the chronological order

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -373,7 +373,6 @@ pub struct State {
     pub channel: u8,
     pub ieee802154_sequence_number: u8,
     pub nib: Nib,
-    pub constants: Constants,
     pub pending_aps_acks: HashMap<ApsAckData, oneshot::Sender<()>>,
     pub pending_route_notifications: HashMap<Nwk, broadcast::Sender<()>>,
     pub start_time: Option<Instant>,
@@ -400,7 +399,6 @@ impl State {
             channel: 0,
             ieee802154_sequence_number: 0,
             nib: Nib::new(),
-            constants: Constants::new(),
             pending_aps_acks: HashMap::new(),
             pending_route_notifications: HashMap::new(),
             start_time: None,
@@ -431,6 +429,7 @@ pub struct ZigbeeStack {
     self_weak: Weak<ZigbeeStack>,
 
     pub state: Mutex<State>,
+    pub constants: Constants,
     pub spinel: SpinelClient,
     pub notification_tx: broadcast::Sender<ZigbeeNotification>,
     pub raw_frame_rx: Mutex<mpsc::Receiver<SpinelFramePropValueIs>>,
@@ -445,6 +444,7 @@ impl ZigbeeStack {
         let arc_stack = Arc::new_cyclic(|weak_self| ZigbeeStack {
             self_weak: weak_self.clone(),
             state: Mutex::new(State::new()),
+            constants: Constants::new(),
             spinel,
             notification_tx,
             raw_frame_rx: Mutex::new(raw_frame_rx),
@@ -828,13 +828,12 @@ impl ZigbeeStack {
     pub fn filter_broadcast(&self, nwk_frame: &NwkFrame) -> bool {
         let now = Instant::now();
         let mut state = self.state.lock().unwrap();
-        let broadcast_delivery_time = state.constants.broadcast_delivery_time;
 
         // We cannot handle broadcasts until the network has been running for at least
         // the time it takes to deliver one broadcast
         if !state.hack_ignore_broadcast_startup_wait_period
             && (state.start_time.is_none()
-                || state.start_time.unwrap() + broadcast_delivery_time > now)
+                || state.start_time.unwrap() + self.constants.broadcast_delivery_time > now)
         {
             log::debug!("Filtering broadcast, network started too recently.");
             return true;
@@ -857,7 +856,7 @@ impl ZigbeeStack {
             NwkBroadcastTransaction {
                 source_nwk: nwk_frame.nwk_header.source,
                 sequence_number: nwk_frame.nwk_header.sequence_number,
-                expiration_time: now + broadcast_delivery_time,
+                expiration_time: now + self.constants.broadcast_delivery_time,
             },
         );
 
@@ -978,7 +977,7 @@ impl ZigbeeStack {
         // TODO: this function should be replaced by real timers
         let now = Instant::now();
         let max_neighbor_age =
-            (state.constants.router_age_limit as u32) * state.constants.link_status_period;
+            (self.constants.router_age_limit as u32) * self.constants.link_status_period;
 
         for neighbor in state.nib.neighbor_table.values_mut() {
             if neighbor.outgoing_cost > 0
@@ -1304,7 +1303,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
-                    protocol_version: state.constants.protocol_version,
+                    protocol_version: self.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Suppress,
                     multicast: false,
                     security: true,
@@ -1315,7 +1314,7 @@ impl ZigbeeStack {
                 },
                 destination: next_hop_nwk,
                 source: state.nib.network_address,
-                radius: 2 * state.constants.max_depth,
+                radius: 2 * self.constants.max_depth,
                 sequence_number: state.nib.sequence_number,
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
                 source_ieee: Some(state.nib.ieee_address),
@@ -1484,8 +1483,6 @@ impl ZigbeeStack {
             route_request_cmd.route_request_identifier,
         );
 
-        let route_discovery_time = state.constants.route_discovery_time;
-
         if !is_for_self_or_child {
             self.clean_route_discovery_table(&mut state.nib.route_discovery_table);
 
@@ -1499,7 +1496,7 @@ impl ZigbeeStack {
                     sender_address: sender_nwk,
                     forward_cost: updated_path_cost,
                     residual_cost: 0,
-                    expiration_time: Instant::now() + route_discovery_time,
+                    expiration_time: Instant::now() + self.constants.route_discovery_time,
                     destination_address: route_request_cmd.destination_address,
                 });
 
@@ -1547,7 +1544,7 @@ impl ZigbeeStack {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
-                        protocol_version: state.constants.protocol_version,
+                        protocol_version: self.constants.protocol_version,
                         discover_route: NwkRouteDiscovery::Suppress,
                         multicast: false,
                         security: true,
@@ -1583,7 +1580,7 @@ impl ZigbeeStack {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
-                        protocol_version: state.constants.protocol_version,
+                        protocol_version: self.constants.protocol_version,
                         discover_route: NwkRouteDiscovery::Suppress,
                         multicast: false,
                         security: true,
@@ -1594,7 +1591,7 @@ impl ZigbeeStack {
                     },
                     destination: nwk_frame.nwk_header.source,
                     source: state.nib.network_address,
-                    radius: 2 * state.constants.max_depth,
+                    radius: 2 * self.constants.max_depth,
                     sequence_number: state.nib.sequence_number,
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: Some(state.nib.ieee_address),
@@ -1626,7 +1623,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
-                    protocol_version: state.constants.protocol_version,
+                    protocol_version: self.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Enable,
                     multicast: false,
                     security: true,
@@ -1638,7 +1635,7 @@ impl ZigbeeStack {
                 // Send our ACK back to the sender
                 destination: nwk_frame.nwk_header.source,
                 source: state.nib.network_address,
-                radius: 2 * state.constants.max_depth,
+                radius: 2 * self.constants.max_depth,
                 sequence_number: state.nib.sequence_number,
                 destination_ieee: None,
                 source_ieee: None,
@@ -1779,12 +1776,9 @@ impl ZigbeeStack {
             key_sequence_number: state.nib.active_key_seq_number,
         });
 
-        let unicast_retries = state.constants.unicast_retries;
-        let unicast_retry_delay = state.constants.unicast_retry_delay;
-
         drop(state);
 
-        for attempt in 0..=unicast_retries {
+        for attempt in 0..=self.constants.unicast_retries {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
@@ -1867,17 +1861,17 @@ impl ZigbeeStack {
                 Err(e) => {
                     log::warn!("Failed to send unicast frame: {e}");
 
-                    if attempt + 1 > unicast_retries {
+                    if attempt + 1 > self.constants.unicast_retries {
                         log::error!("Failed to send unicast frame after {} attempts", attempt);
                         return Err(e);
                     }
                     log::debug!(
                         "Retrying unicast frame send, attempt {} of {}",
                         attempt,
-                        unicast_retries
+                        self.constants.unicast_retries
                     );
 
-                    tokio::time::sleep(unicast_retry_delay).await;
+                    tokio::time::sleep(self.constants.unicast_retry_delay).await;
                 }
             }
         }
@@ -1905,12 +1899,9 @@ impl ZigbeeStack {
             key_sequence_number: state.nib.active_key_seq_number,
         });
 
-        let broadcast_retries = state.constants.max_broadcast_retries;
-        let max_broadcast_jitter = state.constants.max_broadcast_jitter;
-
         drop(state);
 
-        for attempt in 0..=broadcast_retries {
+        for attempt in 0..=self.constants.max_broadcast_retries {
             state = self.state.lock().unwrap();
 
             // The encryption frame counter always increments
@@ -1966,11 +1957,14 @@ impl ZigbeeStack {
             // "heard" relaying it. For now, we just retry a few times.
             let _ = self.send_802154_frame(ieee802154_frame).await;
 
-            let sleep_time = max_broadcast_jitter.mul_f32(rand::random::<f32>());
+            let sleep_time = self
+                .constants
+                .max_broadcast_jitter
+                .mul_f32(rand::random::<f32>());
             log::debug!(
                 "Retrying broadcast frame send, attempt {} of {} in {:?}",
                 attempt,
-                broadcast_retries,
+                self.constants.max_broadcast_retries,
                 sleep_time,
             );
 
@@ -2127,7 +2121,6 @@ impl ZigbeeStack {
 
         // We initiated discovery so insert an entry keyed by our NWK and request ID
         let network_address = state.nib.network_address;
-        let route_discovery_time = state.constants.route_discovery_time;
 
         {
             self.clean_route_discovery_table(&mut state.nib.route_discovery_table);
@@ -2142,7 +2135,7 @@ impl ZigbeeStack {
                     sender_address: Nwk(0xFFFF),
                     forward_cost: 0,
                     residual_cost: 0,
-                    expiration_time: Instant::now() + route_discovery_time,
+                    expiration_time: Instant::now() + self.constants.route_discovery_time,
                     destination_address: destination,
                 });
 
@@ -2167,7 +2160,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Command,
-                    protocol_version: state.constants.protocol_version,
+                    protocol_version: self.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Suppress,
                     multicast: false,
                     security: true,
@@ -2178,7 +2171,7 @@ impl ZigbeeStack {
                 },
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                 source: state.nib.network_address,
-                radius: 2 * state.constants.max_depth,
+                radius: 2 * self.constants.max_depth,
                 sequence_number: state.nib.sequence_number,
                 destination_ieee: None,
                 source_ieee: Some(state.nib.ieee_address),
@@ -2274,7 +2267,7 @@ impl ZigbeeStack {
             nwk_header: NwkHeader {
                 frame_control: NwkFrameControl {
                     frame_type: NwkFrameType::Data,
-                    protocol_version: state.constants.protocol_version,
+                    protocol_version: self.constants.protocol_version,
                     discover_route: NwkRouteDiscovery::Enable,
                     multicast: false,
                     security: true,
@@ -2400,7 +2393,7 @@ impl ZigbeeStack {
                 nwk_header: NwkHeader {
                     frame_control: NwkFrameControl {
                         frame_type: NwkFrameType::Command,
-                        protocol_version: state.constants.protocol_version,
+                        protocol_version: self.constants.protocol_version,
                         discover_route: NwkRouteDiscovery::Suppress,
                         multicast: false,
                         security: true,
@@ -2445,8 +2438,7 @@ impl ZigbeeStack {
 
     pub async fn periodic_link_status_broadcast_task(&self) {
         loop {
-            let link_status_period = self.state.lock().unwrap().constants.link_status_period;
-            tokio::time::sleep(link_status_period).await;
+            tokio::time::sleep(self.constants.link_status_period).await;
 
             self.send_link_status_broadcast(false).await;
         }

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -36,9 +36,6 @@ use tokio::time::{Duration, Instant};
 mod neighbor;
 mod route;
 
-// TODO: remove this once all long locks have been found
-const MAX_LOCK_DURATION: Duration = Duration::from_millis(10);
-
 const APS_ACK_TIMEOUT: Duration = Duration::from_millis(5000);
 
 // The number of the most recent samples taken into consideration SHOULD be n = 3, which
@@ -499,7 +496,7 @@ impl ZigbeeStack {
 
                             self.state
                                 .pending_aps_acks
-                                .try_lock_for(MAX_LOCK_DURATION)
+                                .try_lock()
                                 .unwrap()
                                 .remove(&ack_data)
                                 .map(|tx| {
@@ -541,7 +538,7 @@ impl ZigbeeStack {
         loop {
             let Some(spinel_frame) = self
                 .raw_frame_rx
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .expect("No thread should panic")
                 .recv()
                 .await
@@ -585,7 +582,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::PhyChan,
-                vec![{ *self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap() }],
+                vec![{ *self.state.channel.try_lock().unwrap() }],
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -623,12 +620,7 @@ impl ZigbeeStack {
 
         self.spinel
             .prop_value_set(SpinelPropertyId::Mac154Panid, {
-                self.state
-                    .pan_id
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap()
-                    .to_bytes()
-                    .to_vec()
+                self.state.pan_id.try_lock().unwrap().to_bytes().to_vec()
             })
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -688,7 +680,7 @@ impl ZigbeeStack {
 
         // Only process packets destined for our PAN ID
         {
-            let pan_id = *self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap();
+            let pan_id = *self.state.pan_id.try_lock().unwrap();
 
             match frame.dest_pan_id {
                 None => {
@@ -773,7 +765,7 @@ impl ZigbeeStack {
         match self
             .state
             .security_material_primary
-            .try_lock_for(MAX_LOCK_DURATION)
+            .try_lock()
             .unwrap()
             .incoming_frame_counter_set
             .get(&src_eui64)
@@ -799,14 +791,9 @@ impl ZigbeeStack {
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame = match nwk_frame.decrypt(
-            &self
-                .state
-                .security_material_primary
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap()
-                .key,
-        ) {
+        let decrypted_nwk_frame = match nwk_frame
+            .decrypt(&self.state.security_material_primary.try_lock().unwrap().key)
+        {
             Ok(decrypted_frame) => decrypted_frame,
             Err(err) => {
                 log::warn!("Ignoring frame, decryption failed: {err:?}");
@@ -832,7 +819,7 @@ impl ZigbeeStack {
         match self
             .state
             .address_map
-            .try_lock_for(MAX_LOCK_DURATION)
+            .try_lock()
             .unwrap()
             .insert(eui64, nwk)
         {
@@ -864,11 +851,8 @@ impl ZigbeeStack {
         );
 
         // Clean a stale entry first, if one exists.
-        let mut broadcast_transaction_table = self
-            .state
-            .broadcast_transaction_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let mut broadcast_transaction_table =
+            self.state.broadcast_transaction_table.try_lock().unwrap();
 
         if let Some(entry) = broadcast_transaction_table.get(&key) {
             if entry.expiration_time > now {
@@ -895,7 +879,7 @@ impl ZigbeeStack {
                 Some(relaying_eui64) => {
                     self.state
                         .security_material_primary
-                        .try_lock_for(MAX_LOCK_DURATION)
+                        .try_lock()
                         .unwrap()
                         .incoming_frame_counter_set
                         .insert(relaying_eui64, aux_header.frame_counter);
@@ -952,7 +936,7 @@ impl ZigbeeStack {
                     );
                     self.state
                         .route_record_table
-                        .try_lock_for(MAX_LOCK_DURATION)
+                        .try_lock()
                         .unwrap()
                         .insert(nwk_frame.nwk_header.source, route_record_cmd.relays);
                 }
@@ -972,11 +956,7 @@ impl ZigbeeStack {
 
     fn maybe_recompute_lqa(&self, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
         // Find the source node via its EUI64 address (preferred) or its NWK address
-        let mut neighbor_table = self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
 
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             neighbor_table.get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
@@ -1004,13 +984,7 @@ impl ZigbeeStack {
         let max_neighbor_age =
             (self.constants.router_age_limit as u32) * self.constants.link_status_period;
 
-        for neighbor in self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap()
-            .values_mut()
-        {
+        for neighbor in self.state.neighbor_table.try_lock().unwrap().values_mut() {
             if neighbor.outgoing_cost > 0
                 && neighbor.last_link_status_timestamp >= now + max_neighbor_age
             {
@@ -1045,7 +1019,7 @@ impl ZigbeeStack {
         let neighbors_with_nonzero_outgoing_cost = {
             self.state
                 .neighbor_table
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .unwrap()
                 .iter()
                 .filter_map(|(_, neighbor_entry)| {
@@ -1059,11 +1033,7 @@ impl ZigbeeStack {
         };
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
-        let mut neighbor_table = self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
 
         let neighbor_entry = match neighbor_table.get_mut(&source_ieee) {
             Some(entry) => entry,
@@ -1140,11 +1110,8 @@ impl ZigbeeStack {
     }
 
     fn notify_routing_change(&self, nwk: &Nwk) {
-        let pending_route_notifications = self
-            .state
-            .pending_route_notifications
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let pending_route_notifications =
+            self.state.pending_route_notifications.try_lock().unwrap();
 
         if !pending_route_notifications.contains_key(nwk) {
             return;
@@ -1170,11 +1137,7 @@ impl ZigbeeStack {
 
         let our_nwk_address = self.state.network_address;
 
-        let neighbor_table = self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let neighbor_table = self.state.neighbor_table.try_lock().unwrap();
         let neighbor = {
             match neighbor_table
                 .values()
@@ -1203,22 +1166,14 @@ impl ZigbeeStack {
 
         // TODO: clean this up, the mutability problems caused by the shared state mutex
         // make having two mutable borrows at once very difficult
-        let mut route_discovery_table = self
-            .state
-            .route_discovery_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
         let Some(discovery_entry) = route_discovery_table.get_mut(&route_discovery_table_key)
         else {
             log::debug!("Route reply for unknown route discovery, ignoring");
             return;
         };
 
-        let mut route_table = self
-            .state
-            .route_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let mut route_table = self.state.route_table.try_lock().unwrap();
         let Some(routing_entry) = route_table.get_mut(&route_reply_cmd.responder_nwk) else {
             log::debug!("Route reply with unknown responder, ignoring");
             return;
@@ -1318,13 +1273,7 @@ impl ZigbeeStack {
                 destination: next_hop_nwk,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: {
-                    *self
-                        .state
-                        .sequence_number
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                },
+                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -1361,7 +1310,7 @@ impl ZigbeeStack {
 
         self.state
             .route_discovery_table
-            .try_lock_for(MAX_LOCK_DURATION)
+            .try_lock()
             .unwrap()
             .retain(|_, entry| {
                 if entry.expiration_time <= now {
@@ -1388,11 +1337,7 @@ impl ZigbeeStack {
         );
 
         let network_address = self.state.network_address;
-        let neighbor_table = self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let neighbor_table = self.state.neighbor_table.try_lock().unwrap();
         // We need to know who sent the frame
         let Some(sender_neighbor) = neighbor_table
             .values()
@@ -1422,11 +1367,7 @@ impl ZigbeeStack {
         // table entry via the relaying device. This is free routing information and
         // should be used.
         {
-            let mut route_table = self
-                .state
-                .route_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut route_table = self.state.route_table.try_lock().unwrap();
 
             let route_table_entry = route_table
                 .entry(route_request_cmd.destination_address)
@@ -1457,11 +1398,7 @@ impl ZigbeeStack {
         // Create a routing table entry that assigns the node that last-relayed the
         // route request command to be the next-hop for the original sender
         {
-            let mut route_table = self
-                .state
-                .route_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut route_table = self.state.route_table.try_lock().unwrap();
 
             let route_table_entry = route_table
                 .entry(nwk_frame.nwk_header.source)
@@ -1505,11 +1442,7 @@ impl ZigbeeStack {
         if !is_for_self_or_child {
             self.clean_route_discovery_table();
 
-            let mut route_discovery_table = self
-                .state
-                .route_discovery_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
 
             let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
@@ -1540,7 +1473,7 @@ impl ZigbeeStack {
             {
                 self.state
                     .route_table
-                    .try_lock_for(MAX_LOCK_DURATION)
+                    .try_lock()
                     .unwrap()
                     .entry(route_request_cmd.destination_address)
                     .or_insert_with(|| route::TableEntry {
@@ -1583,11 +1516,7 @@ impl ZigbeeStack {
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
                     sequence_number: {
-                        *self
-                            .state
-                            .sequence_number
-                            .try_lock_for(MAX_LOCK_DURATION)
-                            .unwrap() // TODO: do we change this?
+                        *self.state.sequence_number.try_lock().unwrap() // TODO: do we change this?
                     },
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
@@ -1624,13 +1553,7 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.source,
                     source: self.state.network_address,
                     radius: 2 * self.constants.max_depth,
-                    sequence_number: {
-                        *self
-                            .state
-                            .sequence_number
-                            .try_lock_for(MAX_LOCK_DURATION)
-                            .unwrap()
-                    },
+                    sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
@@ -1673,13 +1596,7 @@ impl ZigbeeStack {
                 destination: nwk_frame.nwk_header.source,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: {
-                    *self
-                        .state
-                        .sequence_number
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                },
+                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1710,11 +1627,8 @@ impl ZigbeeStack {
     async fn send_802154_frame(&self, mut frame: Ieee802154Frame) -> Result<(), ZigbeeStackError> {
         // Increment the 802.15.4 sequence number
         if !frame.frame_control.sequence_number_suppression {
-            let mut ieee802154_sequence_number = self
-                .state
-                .ieee802154_sequence_number
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut ieee802154_sequence_number =
+                self.state.ieee802154_sequence_number.try_lock().unwrap();
             *ieee802154_sequence_number = ieee802154_sequence_number.wrapping_add(1);
 
             frame.sequence_number = Some(*ieee802154_sequence_number);
@@ -1732,7 +1646,7 @@ impl ZigbeeStack {
             .spinel
             .transmit_frame(&SpinelTxFrame {
                 psdu: frame.to_bytes(),
-                channel: { Some(*self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap()) },
+                channel: { Some(*self.state.channel.try_lock().unwrap()) },
                 max_csma_backoffs: Some(1),
                 max_frame_retries: Some(5),
                 enable_csma_ca: Some(true),
@@ -1799,11 +1713,7 @@ impl ZigbeeStack {
             .await?;
 
         nwk_frame.nwk_header.sequence_number = {
-            let mut sequence_number = self
-                .state
-                .sequence_number
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut sequence_number = self.state.sequence_number.try_lock().unwrap();
             *sequence_number = sequence_number.wrapping_add(1);
             *sequence_number
         };
@@ -1823,11 +1733,8 @@ impl ZigbeeStack {
         for attempt in 0..=self.constants.unicast_retries {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut security_material_primary = self
-                    .state
-                    .security_material_primary
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap();
+                let mut security_material_primary =
+                    self.state.security_material_primary.try_lock().unwrap();
                 security_material_primary.outgoing_frame_counter = security_material_primary
                     .outgoing_frame_counter
                     .wrapping_add(1);
@@ -1836,14 +1743,7 @@ impl ZigbeeStack {
             };
 
             let encrypted_nwk_frame = {
-                nwk_frame.encrypt(
-                    &self
-                        .state
-                        .security_material_primary
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                        .key,
-                )
+                nwk_frame.encrypt(&self.state.security_material_primary.try_lock().unwrap().key)
             };
 
             let ieee802154_frame = Ieee802154Frame {
@@ -1861,15 +1761,9 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: {
-                    Some(
-                        *self
-                            .state
-                            .ieee802154_sequence_number
-                            .try_lock_for(MAX_LOCK_DURATION)
-                            .unwrap(),
-                    )
+                    Some(*self.state.ieee802154_sequence_number.try_lock().unwrap())
                 },
-                dest_pan_id: { Some(*self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap()) },
+                dest_pan_id: { Some(*self.state.pan_id.try_lock().unwrap()) },
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
                 src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
@@ -1880,17 +1774,9 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            let mut neighbor_table = self
-                .state
-                .neighbor_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
 
-            let address_map = self
-                .state
-                .address_map
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let address_map = self.state.address_map.try_lock().unwrap();
 
             if let Some(relaying_ieee) = address_map.iter().find_map(|(&eui64, &nwk)| {
                 if nwk == next_hop_address {
@@ -1908,11 +1794,7 @@ impl ZigbeeStack {
 
             drop(address_map);
 
-            let mut route_table = self
-                .state
-                .route_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut route_table = self.state.route_table.try_lock().unwrap();
 
             // And the routing table counters
             if let Some(route_entry) = route_table.get_mut(&nwk_frame.nwk_header.destination) {
@@ -1922,7 +1804,7 @@ impl ZigbeeStack {
 
             // Increment counters before sending
             let tx_total = {
-                let mut tx_total = self.state.tx_total.try_lock_for(MAX_LOCK_DURATION).unwrap();
+                let mut tx_total = self.state.tx_total.try_lock().unwrap();
                 *tx_total = tx_total.wrapping_add(1);
                 *tx_total
             };
@@ -1967,11 +1849,7 @@ impl ZigbeeStack {
         mut nwk_frame: NwkFrame,
     ) -> Result<(), ZigbeeStackError> {
         nwk_frame.nwk_header.sequence_number = {
-            let mut sequence_number = self
-                .state
-                .sequence_number
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut sequence_number = self.state.sequence_number.try_lock().unwrap();
             *sequence_number = sequence_number.wrapping_add(1);
             *sequence_number
         };
@@ -1991,11 +1869,8 @@ impl ZigbeeStack {
         for attempt in 0..=self.constants.max_broadcast_retries {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut security_material_primary = self
-                    .state
-                    .security_material_primary
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap();
+                let mut security_material_primary =
+                    self.state.security_material_primary.try_lock().unwrap();
                 security_material_primary.outgoing_frame_counter = security_material_primary
                     .outgoing_frame_counter
                     .wrapping_add(1);
@@ -2004,14 +1879,7 @@ impl ZigbeeStack {
             };
 
             let encrypted_nwk_frame = {
-                nwk_frame.encrypt(
-                    &self
-                        .state
-                        .security_material_primary
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                        .key,
-                )
+                nwk_frame.encrypt(&self.state.security_material_primary.try_lock().unwrap().key)
             };
 
             let ieee802154_frame = Ieee802154Frame {
@@ -2029,15 +1897,9 @@ impl ZigbeeStack {
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: {
-                    Some(
-                        *self
-                            .state
-                            .ieee802154_sequence_number
-                            .try_lock_for(MAX_LOCK_DURATION)
-                            .unwrap(),
-                    )
+                    Some(*self.state.ieee802154_sequence_number.try_lock().unwrap())
                 },
-                dest_pan_id: Some(*self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap()),
+                dest_pan_id: Some(*self.state.pan_id.try_lock().unwrap()),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
@@ -2050,17 +1912,13 @@ impl ZigbeeStack {
             // Increment counters before sending
             {
                 let tx_total = {
-                    let mut tx_total = self.state.tx_total.try_lock_for(MAX_LOCK_DURATION).unwrap();
+                    let mut tx_total = self.state.tx_total.try_lock().unwrap();
                     *tx_total = tx_total.wrapping_add(1);
                     *tx_total
                 };
 
                 // Handle `tx_total` wrapping
-                let mut neighbor_table = self
-                    .state
-                    .neighbor_table
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap();
+                let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
 
                 if tx_total == 0x0000 {
                     for (_, neighbor) in neighbor_table.iter_mut() {
@@ -2096,7 +1954,7 @@ impl ZigbeeStack {
             || !{
                 self.state
                     .route_table
-                    .try_lock_for(MAX_LOCK_DURATION)
+                    .try_lock()
                     .unwrap()
                     .contains_key(&destination)
             }
@@ -2106,11 +1964,7 @@ impl ZigbeeStack {
         }
 
         let (route_entry_status, route_entry_next_hop_address) = {
-            let route_table = self
-                .state
-                .route_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let route_table = self.state.route_table.try_lock().unwrap();
             let entry = route_table.get(&destination).unwrap();
 
             (entry.status, entry.next_hop_address)
@@ -2137,11 +1991,8 @@ impl ZigbeeStack {
 
         // Create a pending route notification
         let mut rx = {
-            let mut pending_route_notifications = self
-                .state
-                .pending_route_notifications
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut pending_route_notifications =
+                self.state.pending_route_notifications.try_lock().unwrap();
             let tx = pending_route_notifications
                 .entry(destination)
                 .or_insert_with(|| {
@@ -2155,11 +2006,7 @@ impl ZigbeeStack {
         // Pull the current route discovery entry for the device to determine the timeout
         let discovery_timeout = {
             let now = Instant::now();
-            let route_discovery_table = self
-                .state
-                .route_discovery_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
 
             // One should exist
             let route_discovery_entry =
@@ -2192,11 +2039,7 @@ impl ZigbeeStack {
             }
             Err(err) => {
                 log::debug!("Route discovery timed out");
-                let mut route_table = self
-                    .state
-                    .route_table
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap();
+                let mut route_table = self.state.route_table.try_lock().unwrap();
                 let entry = route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
                 return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
@@ -2206,7 +2049,7 @@ impl ZigbeeStack {
         let next_hop_address = {
             self.state
                 .route_table
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .unwrap()
                 .get(&destination)
                 .unwrap()
@@ -2222,11 +2065,7 @@ impl ZigbeeStack {
 
         // Get or create a routing table entry without keeping a mutable reference
         {
-            let mut route_table = self
-                .state
-                .route_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut route_table = self.state.route_table.try_lock().unwrap();
             let route_table_entry = route_table.entry(destination).or_insert_with(|| {
                 route::TableEntry {
                     destination: destination,
@@ -2250,7 +2089,7 @@ impl ZigbeeStack {
             let mut routing_request_sequence_number = self
                 .state
                 .routing_request_sequence_number
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .unwrap();
             *routing_request_sequence_number = routing_request_sequence_number.wrapping_add(1);
             *routing_request_sequence_number
@@ -2264,11 +2103,7 @@ impl ZigbeeStack {
         self.clean_route_discovery_table();
 
         {
-            let mut route_discovery_table = self
-                .state
-                .route_discovery_table
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap();
+            let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
             let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
@@ -2290,7 +2125,7 @@ impl ZigbeeStack {
         let destination_eui64 = {
             self.state
                 .address_map
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .unwrap()
                 .iter()
                 .find_map(|(&eui64, &nwk)| {
@@ -2319,13 +2154,7 @@ impl ZigbeeStack {
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: {
-                    *self
-                        .state
-                        .sequence_number
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                },
+                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
                 destination_ieee: None,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -2431,13 +2260,7 @@ impl ZigbeeStack {
                 destination: destination,
                 source: self.state.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: {
-                    *self
-                        .state
-                        .sequence_number
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                },
+                sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2469,7 +2292,7 @@ impl ZigbeeStack {
         {
             self.state
                 .pending_aps_acks
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .unwrap()
                 .insert(ack_data, ack_tx);
         }
@@ -2503,13 +2326,7 @@ impl ZigbeeStack {
         }
 
         // Decrement the `recent_activity` field of every active routing table entry
-        for (_, route_table_entry) in self
-            .state
-            .route_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap()
-            .iter_mut()
-        {
+        for (_, route_table_entry) in self.state.route_table.try_lock().unwrap().iter_mut() {
             if route_table_entry.status == route::Status::Active {
                 route_table_entry.recent_activity =
                     route_table_entry.recent_activity.saturating_sub(1);
@@ -2519,13 +2336,7 @@ impl ZigbeeStack {
         // Decrement the inbound and outbound activity fields for neighbors
         self.maybe_age_neighbors();
 
-        for (_, neighbor_entry) in self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap()
-            .iter_mut()
-        {
+        for (_, neighbor_entry) in self.state.neighbor_table.try_lock().unwrap().iter_mut() {
             neighbor_entry.router_outbound_activity =
                 neighbor_entry.router_outbound_activity.saturating_sub(1);
             neighbor_entry.router_inbound_activity =
@@ -2535,7 +2346,7 @@ impl ZigbeeStack {
         let mut link_statuses = if !empty {
             self.state
                 .neighbor_table
-                .try_lock_for(MAX_LOCK_DURATION)
+                .try_lock()
                 .unwrap()
                 .iter()
                 .filter_map(|(_, neighbor)| {
@@ -2575,13 +2386,7 @@ impl ZigbeeStack {
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                     source: self.state.network_address,
                     radius: 1,
-                    sequence_number: {
-                        *self
-                            .state
-                            .sequence_number
-                            .try_lock_for(MAX_LOCK_DURATION)
-                            .unwrap()
-                    },
+                    sequence_number: { *self.state.sequence_number.try_lock().unwrap() },
                     destination_ieee: None,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -35,6 +35,8 @@ use tokio::time::{Duration, Instant};
 mod neighbor;
 mod route;
 
+// TODO: remove this once all long locks have been found
+const MAX_LOCK_DURATION: Duration = Duration::from_millis(10);
 const APS_ACK_TIMEOUT: Duration = Duration::from_millis(5000);
 
 // The number of the most recent samples taken into consideration SHOULD be n = 3, which
@@ -493,7 +495,7 @@ impl ZigbeeStack {
 
                             self.state
                                 .pending_aps_acks
-                                .try_lock()
+                                .try_lock_for(MAX_LOCK_DURATION)
                                 .unwrap()
                                 .remove(&ack_data)
                                 .map(|tx| {
@@ -535,7 +537,7 @@ impl ZigbeeStack {
         loop {
             let Some(spinel_frame) = self
                 .raw_frame_rx
-                .try_lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .expect("No thread should panic")
                 .recv()
                 .await
@@ -582,7 +584,7 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::PhyChan,
-                vec![*self.state.channel.try_lock().unwrap()],
+                vec![*self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap()],
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -621,7 +623,12 @@ impl ZigbeeStack {
         self.spinel
             .prop_value_set(
                 SpinelPropertyId::Mac154Panid,
-                self.state.pan_id.try_lock().unwrap().to_bytes().to_vec(),
+                self.state
+                    .pan_id
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .to_bytes()
+                    .to_vec(),
             )
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
@@ -680,7 +687,7 @@ impl ZigbeeStack {
         }
 
         // Only process packets destined for our PAN ID
-        let pan_id = *self.state.pan_id.try_lock().unwrap();
+        let pan_id = *self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap();
 
         match frame.dest_pan_id {
             None => {
@@ -764,7 +771,7 @@ impl ZigbeeStack {
         match self
             .state
             .security_material_primary
-            .try_lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .incoming_frame_counter_set
             .get(&src_eui64)
@@ -790,9 +797,14 @@ impl ZigbeeStack {
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame = match nwk_frame
-            .decrypt(&self.state.security_material_primary.try_lock().unwrap().key)
-        {
+        let decrypted_nwk_frame = match nwk_frame.decrypt(
+            &self
+                .state
+                .security_material_primary
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .key,
+        ) {
             Ok(decrypted_frame) => decrypted_frame,
             Err(err) => {
                 log::warn!("Ignoring frame, decryption failed: {err:?}");
@@ -818,7 +830,7 @@ impl ZigbeeStack {
         match self
             .state
             .address_map
-            .try_lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .insert(eui64, nwk)
         {
@@ -850,8 +862,11 @@ impl ZigbeeStack {
         );
 
         // Clean a stale entry first, if one exists.
-        let mut broadcast_transaction_table =
-            self.state.broadcast_transaction_table.try_lock().unwrap();
+        let mut broadcast_transaction_table = self
+            .state
+            .broadcast_transaction_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         if let Some(entry) = broadcast_transaction_table.get(&key) {
             if entry.expiration_time > now {
@@ -878,7 +893,7 @@ impl ZigbeeStack {
                 Some(relaying_eui64) => {
                     self.state
                         .security_material_primary
-                        .try_lock()
+                        .try_lock_for(MAX_LOCK_DURATION)
                         .unwrap()
                         .incoming_frame_counter_set
                         .insert(relaying_eui64, aux_header.frame_counter);
@@ -933,7 +948,7 @@ impl ZigbeeStack {
                     );
                     self.state
                         .route_record_table
-                        .try_lock()
+                        .try_lock_for(MAX_LOCK_DURATION)
                         .unwrap()
                         .insert(nwk_frame.nwk_header.source, route_record_cmd.relays);
                 }
@@ -953,7 +968,11 @@ impl ZigbeeStack {
 
     fn maybe_recompute_lqa(&self, nwk_frame: &NwkFrame, lqi: u8, _rssi: i8) {
         // Find the source node via its EUI64 address (preferred) or its NWK address
-        let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
+        let mut neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         match if nwk_frame.nwk_header.source_ieee.is_some() {
             neighbor_table.get_mut(&nwk_frame.nwk_header.source_ieee.unwrap())
@@ -981,7 +1000,13 @@ impl ZigbeeStack {
         let max_neighbor_age =
             (self.constants.router_age_limit as u32) * self.constants.link_status_period;
 
-        for neighbor in self.state.neighbor_table.try_lock().unwrap().values_mut() {
+        for neighbor in self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .values_mut()
+        {
             if neighbor.outgoing_cost > 0
                 && neighbor.last_link_status_timestamp >= now + max_neighbor_age
             {
@@ -1016,7 +1041,7 @@ impl ZigbeeStack {
         let neighbors_with_nonzero_outgoing_cost = self
             .state
             .neighbor_table
-            .try_lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .iter()
             .filter_map(|(_, neighbor_entry)| {
@@ -1029,7 +1054,11 @@ impl ZigbeeStack {
             .collect::<HashSet<Nwk>>();
 
         let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
-        let mut neighbor_table = self.state.neighbor_table.try_lock().unwrap();
+        let mut neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         let neighbor_entry = match neighbor_table.get_mut(&source_ieee) {
             Some(entry) => entry,
@@ -1106,8 +1135,11 @@ impl ZigbeeStack {
     }
 
     fn notify_routing_change(&self, nwk: &Nwk) {
-        let pending_route_notifications =
-            self.state.pending_route_notifications.try_lock().unwrap();
+        let pending_route_notifications = self
+            .state
+            .pending_route_notifications
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
 
         if !pending_route_notifications.contains_key(nwk) {
             return;
@@ -1133,7 +1165,11 @@ impl ZigbeeStack {
 
         let our_nwk_address = self.state.network_address;
 
-        let neighbor_table = self.state.neighbor_table.try_lock().unwrap();
+        let neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
         let neighbor = {
             match neighbor_table
                 .values()
@@ -1166,14 +1202,22 @@ impl ZigbeeStack {
         // Hold mutable references to `route_table` and `route_discovery_table` for as
         // little time as possible.
         {
-            let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
+            let mut route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let Some(discovery_entry) = route_discovery_table.get_mut(&route_discovery_table_key)
             else {
                 log::debug!("Route reply for unknown route discovery, ignoring");
                 return;
             };
 
-            let mut route_table = self.state.route_table.try_lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let Some(routing_entry) = route_table.get_mut(&route_reply_cmd.responder_nwk) else {
                 log::debug!("Route reply with unknown responder, ignoring");
                 return;
@@ -1273,7 +1317,11 @@ impl ZigbeeStack {
                 destination: next_hop_nwk,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                sequence_number: *self
+                    .state
+                    .sequence_number
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap(),
                 destination_ieee: nwk_frame.nwk_header.source_ieee,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -1310,7 +1358,7 @@ impl ZigbeeStack {
 
         self.state
             .route_discovery_table
-            .try_lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .retain(|_, entry| {
                 if entry.expiration_time <= now {
@@ -1337,7 +1385,11 @@ impl ZigbeeStack {
         );
 
         let network_address = self.state.network_address;
-        let neighbor_table = self.state.neighbor_table.try_lock().unwrap();
+        let neighbor_table = self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
         // We need to know who sent the frame
         let Some(sender_neighbor) = neighbor_table
             .values()
@@ -1367,7 +1419,11 @@ impl ZigbeeStack {
         // table entry via the relaying device. This is free routing information and
         // should be used.
         {
-            let mut route_table = self.state.route_table.try_lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             let route_table_entry = route_table
                 .entry(route_request_cmd.destination_address)
@@ -1398,7 +1454,11 @@ impl ZigbeeStack {
         // Create a routing table entry that assigns the node that last-relayed the
         // route request command to be the next-hop for the original sender
         {
-            let mut route_table = self.state.route_table.try_lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             let route_table_entry = route_table
                 .entry(nwk_frame.nwk_header.source)
@@ -1442,7 +1502,11 @@ impl ZigbeeStack {
         if !is_for_self_or_child {
             self.clean_route_discovery_table();
 
-            let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
+            let mut route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
@@ -1473,7 +1537,7 @@ impl ZigbeeStack {
             {
                 self.state
                     .route_table
-                    .try_lock()
+                    .try_lock_for(MAX_LOCK_DURATION)
                     .unwrap()
                     .entry(route_request_cmd.destination_address)
                     .or_insert_with(|| route::TableEntry {
@@ -1516,7 +1580,11 @@ impl ZigbeeStack {
                     source: nwk_frame.nwk_header.source,
                     radius: rebroadcast_radius,
                     // TODO: do we change this?
-                    sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                    sequence_number: *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap(),
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: nwk_frame.nwk_header.source_ieee,
                     multicast_control: None,
@@ -1552,7 +1620,11 @@ impl ZigbeeStack {
                     destination: nwk_frame.nwk_header.source,
                     source: self.state.network_address,
                     radius: 2 * self.constants.max_depth,
-                    sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                    sequence_number: *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap(),
                     destination_ieee: nwk_frame.nwk_header.source_ieee,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,
@@ -1595,7 +1667,11 @@ impl ZigbeeStack {
                 destination: nwk_frame.nwk_header.source,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                sequence_number: *self
+                    .state
+                    .sequence_number
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap(),
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -1626,8 +1702,11 @@ impl ZigbeeStack {
     async fn send_802154_frame(&self, mut frame: Ieee802154Frame) -> Result<(), ZigbeeStackError> {
         // Increment the 802.15.4 sequence number
         if !frame.frame_control.sequence_number_suppression {
-            let mut ieee802154_sequence_number =
-                self.state.ieee802154_sequence_number.try_lock().unwrap();
+            let mut ieee802154_sequence_number = self
+                .state
+                .ieee802154_sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *ieee802154_sequence_number = ieee802154_sequence_number.wrapping_add(1);
 
             frame.sequence_number = Some(*ieee802154_sequence_number);
@@ -1645,7 +1724,7 @@ impl ZigbeeStack {
             .spinel
             .transmit_frame(&SpinelTxFrame {
                 psdu: frame.to_bytes(),
-                channel: { Some(*self.state.channel.try_lock().unwrap()) },
+                channel: { Some(*self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap()) },
                 max_csma_backoffs: Some(1),
                 max_frame_retries: Some(5),
                 enable_csma_ca: Some(true),
@@ -1712,7 +1791,11 @@ impl ZigbeeStack {
             .await?;
 
         nwk_frame.nwk_header.sequence_number = {
-            let mut sequence_number = self.state.sequence_number.try_lock().unwrap();
+            let mut sequence_number = self
+                .state
+                .sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *sequence_number = sequence_number.wrapping_add(1);
             *sequence_number
         };
@@ -1735,7 +1818,7 @@ impl ZigbeeStack {
                 let mut outgoing_frame_counter = self
                     .state
                     .security_material_primary
-                    .try_lock()
+                    .try_lock_for(MAX_LOCK_DURATION)
                     .unwrap()
                     .outgoing_frame_counter;
                 outgoing_frame_counter = outgoing_frame_counter.wrapping_add(1);
@@ -1743,7 +1826,14 @@ impl ZigbeeStack {
             };
 
             let encrypted_nwk_frame = {
-                nwk_frame.encrypt(&self.state.security_material_primary.try_lock().unwrap().key)
+                nwk_frame.encrypt(
+                    &self
+                        .state
+                        .security_material_primary
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                        .key,
+                )
             };
 
             let ieee802154_frame = Ieee802154Frame {
@@ -1760,8 +1850,14 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: Some(*self.state.ieee802154_sequence_number.try_lock().unwrap()),
-                dest_pan_id: Some(*self.state.pan_id.try_lock().unwrap()),
+                sequence_number: Some(
+                    *self
+                        .state
+                        .ieee802154_sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap(),
+                ),
+                dest_pan_id: Some(*self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap()),
                 dest_address: Some(Ieee802154Address::Nwk(next_hop_address)),
                 src_pan_id: None,
                 src_address: Some(Ieee802154Address::Nwk(self.state.network_address)),
@@ -1772,24 +1868,24 @@ impl ZigbeeStack {
             // When forwarding packets to another node, update the counters for the neighbor
             // TODO: maybe wrap the send state into some sort of struct to avoid
             // needing to do this?
-            if let Some(relaying_ieee) =
-                self.state
-                    .address_map
-                    .try_lock()
-                    .unwrap()
-                    .iter()
-                    .find_map(|(&eui64, &nwk)| {
-                        if nwk == next_hop_address {
-                            Some(eui64)
-                        } else {
-                            None
-                        }
-                    })
+            if let Some(relaying_ieee) = self
+                .state
+                .address_map
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .iter()
+                .find_map(|(&eui64, &nwk)| {
+                    if nwk == next_hop_address {
+                        Some(eui64)
+                    } else {
+                        None
+                    }
+                })
             {
                 if let Some(neighbor_entry) = self
                     .state
                     .neighbor_table
-                    .try_lock()
+                    .try_lock_for(MAX_LOCK_DURATION)
                     .unwrap()
                     .get_mut(&relaying_ieee)
                 {
@@ -1803,7 +1899,7 @@ impl ZigbeeStack {
             if let Some(route_entry) = self
                 .state
                 .route_table
-                .try_lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap()
                 .get_mut(&nwk_frame.nwk_header.destination)
             {
@@ -1813,14 +1909,20 @@ impl ZigbeeStack {
 
             // Increment counters before sending
             let tx_total = {
-                let mut tx_total = self.state.tx_total.try_lock().unwrap();
+                let mut tx_total = self.state.tx_total.try_lock_for(MAX_LOCK_DURATION).unwrap();
                 *tx_total = tx_total.wrapping_add(1);
                 *tx_total
             };
 
             // Handle `tx_total` wrapping
             if tx_total == 0x0000 {
-                for (_, neighbor) in self.state.neighbor_table.try_lock().unwrap().iter_mut() {
+                for (_, neighbor) in self
+                    .state
+                    .neighbor_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .iter_mut()
+                {
                     neighbor.transmit_failure = 0;
                 }
             }
@@ -1855,7 +1957,11 @@ impl ZigbeeStack {
         mut nwk_frame: NwkFrame,
     ) -> Result<(), ZigbeeStackError> {
         nwk_frame.nwk_header.sequence_number = {
-            let mut sequence_number = self.state.sequence_number.try_lock().unwrap();
+            let mut sequence_number = self
+                .state
+                .sequence_number
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             *sequence_number = sequence_number.wrapping_add(1);
             *sequence_number
         };
@@ -1878,7 +1984,7 @@ impl ZigbeeStack {
                 let mut outgoing_frame_counter = self
                     .state
                     .security_material_primary
-                    .try_lock()
+                    .try_lock_for(MAX_LOCK_DURATION)
                     .unwrap()
                     .outgoing_frame_counter;
                 outgoing_frame_counter = outgoing_frame_counter.wrapping_add(1);
@@ -1886,7 +1992,14 @@ impl ZigbeeStack {
             };
 
             let encrypted_nwk_frame = {
-                nwk_frame.encrypt(&self.state.security_material_primary.try_lock().unwrap().key)
+                nwk_frame.encrypt(
+                    &self
+                        .state
+                        .security_material_primary
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap()
+                        .key,
+                )
             };
 
             let ieee802154_frame = Ieee802154Frame {
@@ -1903,8 +2016,14 @@ impl ZigbeeStack {
                     frame_version: 0,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
-                sequence_number: Some(*self.state.ieee802154_sequence_number.try_lock().unwrap()),
-                dest_pan_id: Some(*self.state.pan_id.try_lock().unwrap()),
+                sequence_number: Some(
+                    *self
+                        .state
+                        .ieee802154_sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap(),
+                ),
+                dest_pan_id: Some(*self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap()),
                 // All broadcasts are sent to the 802.15.4 broadcast address, since the
                 // distinction between Zigbee groups and broadcasts is at a higher layer
                 dest_address: Some(Ieee802154Address::Nwk(Nwk(0xFFFF))),
@@ -1916,14 +2035,20 @@ impl ZigbeeStack {
 
             // Increment counters before sending
             let tx_total = {
-                let mut tx_total = self.state.tx_total.try_lock().unwrap();
+                let mut tx_total = self.state.tx_total.try_lock_for(MAX_LOCK_DURATION).unwrap();
                 *tx_total = tx_total.wrapping_add(1);
                 *tx_total
             };
 
             // Handle `tx_total` wrapping
             if tx_total == 0x0000 {
-                for (_, neighbor) in self.state.neighbor_table.try_lock().unwrap().iter_mut() {
+                for (_, neighbor) in self
+                    .state
+                    .neighbor_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .iter_mut()
+                {
                     neighbor.transmit_failure = 0;
                 }
             }
@@ -1955,7 +2080,7 @@ impl ZigbeeStack {
             || !{
                 self.state
                     .route_table
-                    .try_lock()
+                    .try_lock_for(MAX_LOCK_DURATION)
                     .unwrap()
                     .contains_key(&destination)
             }
@@ -1965,7 +2090,11 @@ impl ZigbeeStack {
         }
 
         let (route_entry_status, route_entry_next_hop_address) = {
-            let route_table = self.state.route_table.try_lock().unwrap();
+            let route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let entry = route_table.get(&destination).unwrap();
 
             (entry.status, entry.next_hop_address)
@@ -1992,8 +2121,11 @@ impl ZigbeeStack {
 
         // Create a pending route notification
         let mut rx = {
-            let mut pending_route_notifications =
-                self.state.pending_route_notifications.try_lock().unwrap();
+            let mut pending_route_notifications = self
+                .state
+                .pending_route_notifications
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let tx = pending_route_notifications
                 .entry(destination)
                 .or_insert_with(|| {
@@ -2007,7 +2139,11 @@ impl ZigbeeStack {
         // Pull the current route discovery entry for the device to determine the timeout
         let discovery_timeout = {
             let now = Instant::now();
-            let route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
+            let route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
             // One should exist
             let route_discovery_entry =
@@ -2040,7 +2176,11 @@ impl ZigbeeStack {
             }
             Err(err) => {
                 log::debug!("Route discovery timed out");
-                let mut route_table = self.state.route_table.try_lock().unwrap();
+                let mut route_table = self
+                    .state
+                    .route_table
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap();
                 let entry = route_table.get_mut(&destination).unwrap();
                 entry.status = route::Status::DiscoveryFailed;
                 return Err(ZigbeeStackError::RouteDiscoveryTimeout(err));
@@ -2050,7 +2190,7 @@ impl ZigbeeStack {
         let next_hop_address = self
             .state
             .route_table
-            .try_lock()
+            .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
             .get(&destination)
             .unwrap()
@@ -2065,7 +2205,11 @@ impl ZigbeeStack {
 
         // Get or create a routing table entry without keeping a mutable reference
         {
-            let mut route_table = self.state.route_table.try_lock().unwrap();
+            let mut route_table = self
+                .state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let route_table_entry = route_table.entry(destination).or_insert_with(|| {
                 route::TableEntry {
                     destination: destination,
@@ -2089,7 +2233,7 @@ impl ZigbeeStack {
             let mut routing_request_sequence_number = self
                 .state
                 .routing_request_sequence_number
-                .try_lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap();
             *routing_request_sequence_number = routing_request_sequence_number.wrapping_add(1);
             *routing_request_sequence_number
@@ -2103,7 +2247,11 @@ impl ZigbeeStack {
         self.clean_route_discovery_table();
 
         {
-            let mut route_discovery_table = self.state.route_discovery_table.try_lock().unwrap();
+            let mut route_discovery_table = self
+                .state
+                .route_discovery_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
             let route_discovery_entry = route_discovery_table
                 .entry(route_discovery_table_key)
                 .or_insert_with(|| route::DiscoveryEntry {
@@ -2122,19 +2270,19 @@ impl ZigbeeStack {
         }
 
         // If we know the EUI64 corresponding to the NWK, use it
-        let destination_eui64 =
-            self.state
-                .address_map
-                .try_lock()
-                .unwrap()
-                .iter()
-                .find_map(|(&eui64, &nwk)| {
-                    if nwk == destination {
-                        Some(eui64)
-                    } else {
-                        None
-                    }
-                });
+        let destination_eui64 = self
+            .state
+            .address_map
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .iter()
+            .find_map(|(&eui64, &nwk)| {
+                if nwk == destination {
+                    Some(eui64)
+                } else {
+                    None
+                }
+            });
 
         // Construct a frame
         let route_request_frame = NwkFrame {
@@ -2153,7 +2301,11 @@ impl ZigbeeStack {
                 destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                 source: self.state.network_address,
                 radius: 2 * self.constants.max_depth,
-                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                sequence_number: *self
+                    .state
+                    .sequence_number
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap(),
                 destination_ieee: None,
                 source_ieee: Some(self.state.ieee_address),
                 multicast_control: None,
@@ -2259,7 +2411,11 @@ impl ZigbeeStack {
                 destination: destination,
                 source: self.state.network_address,
                 radius: cmp::max(radius, 1),
-                sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                sequence_number: *self
+                    .state
+                    .sequence_number
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap(),
                 destination_ieee: None,
                 source_ieee: None,
                 multicast_control: None,
@@ -2291,7 +2447,7 @@ impl ZigbeeStack {
         {
             self.state
                 .pending_aps_acks
-                .try_lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap()
                 .insert(ack_data, ack_tx);
         }
@@ -2325,7 +2481,13 @@ impl ZigbeeStack {
         }
 
         // Decrement the `recent_activity` field of every active routing table entry
-        for (_, route_table_entry) in self.state.route_table.try_lock().unwrap().iter_mut() {
+        for (_, route_table_entry) in self
+            .state
+            .route_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .iter_mut()
+        {
             if route_table_entry.status == route::Status::Active {
                 route_table_entry.recent_activity =
                     route_table_entry.recent_activity.saturating_sub(1);
@@ -2335,7 +2497,13 @@ impl ZigbeeStack {
         // Decrement the inbound and outbound activity fields for neighbors
         self.maybe_age_neighbors();
 
-        for (_, neighbor_entry) in self.state.neighbor_table.try_lock().unwrap().iter_mut() {
+        for (_, neighbor_entry) in self
+            .state
+            .neighbor_table
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .iter_mut()
+        {
             neighbor_entry.router_outbound_activity =
                 neighbor_entry.router_outbound_activity.saturating_sub(1);
             neighbor_entry.router_inbound_activity =
@@ -2345,7 +2513,7 @@ impl ZigbeeStack {
         let mut link_statuses = if !empty {
             self.state
                 .neighbor_table
-                .try_lock()
+                .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap()
                 .iter()
                 .filter_map(|(_, neighbor)| {
@@ -2385,7 +2553,11 @@ impl ZigbeeStack {
                     destination: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
                     source: self.state.network_address,
                     radius: 1,
-                    sequence_number: *self.state.sequence_number.try_lock().unwrap(),
+                    sequence_number: *self
+                        .state
+                        .sequence_number
+                        .try_lock_for(MAX_LOCK_DURATION)
+                        .unwrap(),
                     destination_ieee: None,
                     source_ieee: Some(self.state.ieee_address),
                     multicast_control: None,


### PR DESCRIPTION
The aim of this PR is to split the monolithic NIB struct up. Future PRs will combine mostly-independent structs into `Manager` objects, like `RouteManager` wrapping `route_table` and `route_discovery_table`.