### PR TITLE
Enable `cargo clippy`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,10 +19,8 @@ repos:
         language: system
         pass_filenames: false
 
-#      - id: rust-clippy
-#        name: Rust clippy
-#        entry: bash -c "cd ziggurat && cargo clippy --all-targets --all-features -- -Dclippy::all"
-#        pass_filenames: false
-#        types: [file, rust]
-#        language: system
-#        files: ^ziggurat/
+      - id: rust-clippy
+        name: Rust clippy
+        entry: cargo clippy --all-targets --all-features -- -Dclippy::all
+        language: system
+        pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         pass_filenames: false
 
       - id: rust-clippy
-        name: Rust clippy
+        name: Cargo clippy
         entry: cargo clippy --all-targets --all-features -- -Dclippy::all -Dclippy::nursery
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,6 @@ repos:
 
       - id: rust-clippy
         name: Rust clippy
-        entry: cargo clippy --all-targets --all-features -- -Dclippy::all
+        entry: cargo clippy --all-targets --all-features -- -Dclippy::all -Dclippy::nursery
         language: system
         pass_filenames: false

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,12 @@ repos:
         language: system
         pass_filenames: false
 
+      - id: cargo-build
+        name: Cargo build
+        entry: cargo build
+        language: system
+        pass_filenames: false
+
 #      - id: rust-clippy
 #        name: Rust clippy
 #        entry: bash -c "cd ziggurat && cargo clippy --all-targets --all-features -- -Dclippy::all"

--- a/crates/ieee-802154/src/lib.rs
+++ b/crates/ieee-802154/src/lib.rs
@@ -291,12 +291,12 @@ mod test {
         let frame = Ieee802154Frame::from_bytes(&bytes).unwrap();
 
         assert_eq!(frame.frame_control.frame_type, Ieee802154FrameType::Data);
-        assert_eq!(frame.frame_control.security_enabled, false);
-        assert_eq!(frame.frame_control.frame_pending, false);
-        assert_eq!(frame.frame_control.ack_request, true);
-        assert_eq!(frame.frame_control.pan_id_compression, true);
-        assert_eq!(frame.frame_control.sequence_number_suppression, false);
-        assert_eq!(frame.frame_control.information_elements_present, false);
+        assert!(!frame.frame_control.security_enabled);
+        assert!(!frame.frame_control.frame_pending);
+        assert!(frame.frame_control.ack_request);
+        assert!(frame.frame_control.pan_id_compression);
+        assert!(!frame.frame_control.sequence_number_suppression);
+        assert!(!frame.frame_control.information_elements_present);
         assert_eq!(
             frame.frame_control.dest_addr_mode,
             Ieee802154AddressingMode::Short
@@ -345,12 +345,12 @@ mod test {
         let frame = Ieee802154Frame::from_bytes(&bytes).unwrap();
 
         assert_eq!(frame.frame_control.frame_type, Ieee802154FrameType::Ack);
-        assert_eq!(frame.frame_control.security_enabled, false);
-        assert_eq!(frame.frame_control.frame_pending, false);
-        assert_eq!(frame.frame_control.ack_request, false);
-        assert_eq!(frame.frame_control.pan_id_compression, false);
-        assert_eq!(frame.frame_control.sequence_number_suppression, false);
-        assert_eq!(frame.frame_control.information_elements_present, false);
+        assert!(!frame.frame_control.security_enabled);
+        assert!(!frame.frame_control.frame_pending);
+        assert!(!frame.frame_control.ack_request);
+        assert!(!frame.frame_control.pan_id_compression);
+        assert!(!frame.frame_control.sequence_number_suppression);
+        assert!(!frame.frame_control.information_elements_present);
         assert_eq!(
             frame.frame_control.dest_addr_mode,
             Ieee802154AddressingMode::None

--- a/crates/ieee-802154/src/lib.rs
+++ b/crates/ieee-802154/src/lib.rs
@@ -233,6 +233,7 @@ impl Ieee802154Frame {
         data
     }
 
+    #[allow(clippy::identity_op)]
     pub fn compute_fcs(data: &[u8]) -> u16 {
         let mut crc: u16 = 0x0000;
 
@@ -260,12 +261,12 @@ mod test {
         let remaining = &bytes[2..];
 
         assert_eq!(frame_control.frame_type, Ieee802154FrameType::Data);
-        assert_eq!(frame_control.security_enabled, false);
-        assert_eq!(frame_control.frame_pending, false);
-        assert_eq!(frame_control.ack_request, true);
-        assert_eq!(frame_control.pan_id_compression, true);
-        assert_eq!(frame_control.sequence_number_suppression, false);
-        assert_eq!(frame_control.information_elements_present, false);
+        assert!(!frame_control.security_enabled);
+        assert!(!frame_control.frame_pending);
+        assert!(frame_control.ack_request);
+        assert!(frame_control.pan_id_compression);
+        assert!(!frame_control.sequence_number_suppression);
+        assert!(!frame_control.information_elements_present);
         assert_eq!(
             frame_control.dest_addr_mode,
             Ieee802154AddressingMode::Short

--- a/crates/ieee-802154/src/lib.rs
+++ b/crates/ieee-802154/src/lib.rs
@@ -15,7 +15,7 @@ pub enum Ieee802154FrameType {
     Ack = 0b010,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[abstract_bits(bits = 8)]
 #[repr(u8)]
 pub enum Ieee802154AssociationStatus {
@@ -36,7 +36,7 @@ pub enum Ieee802154AddressingMode {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct Ieee802154FrameControl {
     pub frame_type: Ieee802154FrameType,
     pub security_enabled: bool,
@@ -51,7 +51,7 @@ pub struct Ieee802154FrameControl {
     pub src_addr_mode: Ieee802154AddressingMode,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[abstract_bits(bits = 8)]
 #[repr(u8)]
 pub enum Ieee802154CommandId {
@@ -67,7 +67,7 @@ pub enum Ieee802154CommandId {
     GtsRequest = 0x09,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Ieee802154Address {
     Nwk(Nwk),
     Eui64(Eui64),

--- a/crates/ieee-802154/src/types.rs
+++ b/crates/ieee-802154/src/types.rs
@@ -170,7 +170,7 @@ impl Key {
         }
 
         let mut key = [0; 16];
-        key.copy_from_slice(&bytes);
+        key.copy_from_slice(bytes);
 
         Ok(Self(key))
     }
@@ -195,9 +195,9 @@ impl fmt::Debug for Key {
 pub fn format_hex<T: AsRef<[u8]>>(data: T, f: &mut fmt::Formatter) -> fmt::Result {
     for (index, b) in data.as_ref().iter().enumerate() {
         if index == 0 {
-            write!(f, "{:02X}", b)?;
+            write!(f, "{b:02X}")?;
         } else {
-            write!(f, ":{:02X}", b)?;
+            write!(f, ":{b:02X}")?;
         }
     }
     Ok(())

--- a/crates/ieee-802154/src/types.rs
+++ b/crates/ieee-802154/src/types.rs
@@ -28,11 +28,11 @@ impl Nwk {
         Ok((Self(u16::from_le_bytes([bytes[0], bytes[1]])), &bytes[2..]))
     }
 
-    pub fn to_bytes(&self) -> [u8; 2] {
+    pub const fn to_bytes(&self) -> [u8; 2] {
         self.0.to_le_bytes()
     }
 
-    pub fn as_u16(&self) -> u16 {
+    pub const fn as_u16(&self) -> u16 {
         self.0
     }
 }
@@ -77,7 +77,7 @@ impl Eui64 {
         Ok((Self(eui), &bytes[8..]))
     }
 
-    pub fn to_bytes(&self) -> [u8; 8] {
+    pub const fn to_bytes(&self) -> [u8; 8] {
         self.0
     }
 }
@@ -100,7 +100,7 @@ impl fmt::Debug for Eui64 {
     }
 }
 
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 pub enum Address {
     Nwk(Nwk),
     Eui64(Eui64),
@@ -133,7 +133,7 @@ impl PanId {
         Ok((Self(u16::from_le_bytes([bytes[0], bytes[1]])), &bytes[2..]))
     }
 
-    pub fn to_bytes(&self) -> [u8; 2] {
+    pub const fn to_bytes(&self) -> [u8; 2] {
         self.0.to_le_bytes()
     }
 }
@@ -146,7 +146,7 @@ impl fmt::Debug for PanId {
     }
 }
 
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub struct Key(pub [u8; 16]);
 
 impl Key {
@@ -175,7 +175,7 @@ impl Key {
         Ok(Self(key))
     }
 
-    pub fn to_bytes(&self) -> [u8; 16] {
+    pub const fn to_bytes(&self) -> [u8; 16] {
         self.0
     }
 }

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -218,6 +218,7 @@ impl ZigguratServer {
     }
 
     /// Processes a single command from the client, mutating the server state if necessary.
+    #[allow(clippy::significant_drop_tightening)]
     async fn process_command(&self, cmd: CommandRequest) -> CommandResponse {
         match cmd.cmd.as_str() {
             "set_network_settings" => {

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -59,7 +59,7 @@ impl ZigguratServer {
     /// Listens for and handles incoming TCP connections.
     pub async fn run_tcp_server(self: Arc<Self>, listen_addr: &str) -> std::io::Result<()> {
         let listener = TcpListener::bind(listen_addr).await?;
-        log::info!("Listening for a single TCP client on {}", listen_addr);
+        log::info!("Listening for a single TCP client on {listen_addr}");
 
         loop {
             let (socket, addr) = listener.accept().await?;
@@ -68,14 +68,13 @@ impl ZigguratServer {
             let mut is_connected_guard = self.is_client_connected.lock().unwrap();
             if *is_connected_guard {
                 log::warn!(
-                    "Rejecting connection from {}: another client is already connected.",
-                    addr
+                    "Rejecting connection from {addr}: another client is already connected."
                 );
                 drop(socket);
                 continue; // The lock guard is dropped here
             }
 
-            log::info!("Accepted new TCP client from {}", addr);
+            log::info!("Accepted new TCP client from {addr}");
             *is_connected_guard = true;
             drop(is_connected_guard); // Release the lock before spawning the task
 
@@ -89,10 +88,10 @@ impl ZigguratServer {
     /// Manages the entire lifecycle of a single client connection.
     async fn handle_client(self: Arc<Self>, stream: TcpStream, addr: SocketAddr) {
         if let Err(e) = self.handle_client_loop(stream, addr).await {
-            log::warn!("Error handling client {}: {:?}", addr, e);
+            log::warn!("Error handling client {addr}: {e:?}");
         }
 
-        log::info!("Client {} disconnected.", addr);
+        log::info!("Client {addr} disconnected.");
         *self.is_client_connected.lock().unwrap() = false;
         *self.server_state.lock().unwrap() = None;
         log::info!("Zigbee stack has been reset.");
@@ -108,10 +107,7 @@ impl ZigguratServer {
         let mut reader = BufReader::new(reader);
         let mut line = String::new();
 
-        log::info!(
-            "Client {} connected. Waiting for 'set_network_settings'...",
-            addr
-        );
+        log::info!("Client {addr} connected. Waiting for 'set_network_settings'...");
         loop {
             line.clear();
             match reader.read_line(&mut line).await {
@@ -120,7 +116,7 @@ impl ZigguratServer {
                     let cmd = match serde_json::from_str::<CommandRequest>(line.trim()) {
                         Ok(cmd) => cmd,
                         Err(e) => {
-                            log::warn!("JSON parse error from {}: {}", addr, e);
+                            log::warn!("JSON parse error from {addr}: {e}");
                             let resp = json!({"tid": 0, "cmd": "error", "data": {"reason": "invalid_json", "details": e.to_string()}});
                             writer.write_all(resp.to_string().as_bytes()).await?;
                             writer.write_all(b"\n").await?;
@@ -128,7 +124,7 @@ impl ZigguratServer {
                         }
                     };
 
-                    log::debug!("Received command from {}: {:?}", addr, cmd);
+                    log::debug!("Received command from {addr}: {cmd:?}");
                     let resp = self.process_command(cmd).await;
                     let resp_str = serde_json::to_string(&resp)?;
                     writer.write_all(resp_str.as_bytes()).await?;
@@ -174,15 +170,15 @@ impl ZigguratServer {
 
                     match serde_json::from_str::<CommandRequest>(line.trim()) {
                         Ok(cmd) => {
-                            log::debug!("Received command from {}: {:?}", addr, cmd);
+                            log::debug!("Received command from {addr}: {cmd:?}");
                             let resp = self.process_command(cmd).await;
                             let resp_str = serde_json::to_string(&resp)?;
-                            log::debug!("Sending response: {}", resp_str);
+                            log::debug!("Sending response: {resp_str}");
                             writer.write_all(resp_str.as_bytes()).await?;
                             writer.write_all(b"\n").await?;
                         },
                         Err(e) => {
-                            log::warn!("JSON parse error from {}: {}", addr, e);
+                            log::warn!("JSON parse error from {addr}: {e}");
                             let resp = json!({"tid": 0, "cmd": "error", "data": {"reason": "invalid_json", "details": e.to_string()}});
                             writer.write_all(resp.to_string().as_bytes()).await?;
                             writer.write_all(b"\n").await?;
@@ -202,15 +198,15 @@ impl ZigguratServer {
                                     "lqi": lqi, "rssi": rssi, "data": hex::encode(data),
                                 }
                             });
-                            log::debug!("Sending APS frame notification: {:?}", event);
+                            log::debug!("Sending APS frame notification: {event:?}");
                             writer.write_all(event.to_string().as_bytes()).await?;
                             writer.write_all(b"\n").await?;
                         },
                         Err(tokio::sync::broadcast::error::RecvError::Lagged(count)) => {
-                            log::warn!("Client {} lagged {} messages, skipping...", addr, count);
+                            log::warn!("Client {addr} lagged {count} messages, skipping...");
                         },
                         Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                            log::warn!("Broadcast channel closed, ending client connection for {}", addr);
+                            log::warn!("Broadcast channel closed, ending client connection for {addr}");
                             break;
                         }
                     }

--- a/crates/stack/src/server.rs
+++ b/crates/stack/src/server.rs
@@ -140,9 +140,10 @@ impl ZigguratServer {
             }
         }
 
-        let state_guard = self.server_state.lock().unwrap();
-        let notification_rx = state_guard.as_ref().unwrap().notification_rx.resubscribe();
-        drop(state_guard);
+        let notification_rx = {
+            let state_guard = self.server_state.lock().unwrap();
+            state_guard.as_ref().unwrap().notification_rx.resubscribe()
+        };
 
         log::info!("Stack initialized. Now listening for commands and notifications.");
 
@@ -299,8 +300,20 @@ impl ZigguratServer {
                 }
             }
             "send_aps_command" => {
-                let state_guard = self.server_state.lock().unwrap();
-                if let Some(server_state) = &*state_guard {
+                let zigbee_stack = {
+                    let state_guard = self.server_state.lock().unwrap();
+                    if let Some(server_state) = &*state_guard {
+                        server_state.zigbee_stack.clone()
+                    } else {
+                        return CommandResponse {
+                            tid: cmd.tid,
+                            cmd: cmd.cmd,
+                            data: json!({"status": "error", "reason": "not_initialized"}),
+                        };
+                    }
+                };
+
+                {
                     // ... (parsing logic remains the same)
                     let delivery_mode = match cmd
                         .data
@@ -332,9 +345,7 @@ impl ZigguratServer {
                     let data =
                         hex::decode(cmd.data.get("data").unwrap().as_str().unwrap()).unwrap();
 
-                    // The lock is held across this await, which is now safe.
-                    let status = server_state
-                        .zigbee_stack
+                    let status = zigbee_stack
                         .send_aps_command(
                             delivery_mode,
                             destination,
@@ -353,12 +364,6 @@ impl ZigguratServer {
                         tid: cmd.tid,
                         cmd: cmd.cmd,
                         data: json!({"status": if status.is_ok() { "success" } else { "error" }, "reason": status.err().map(|e| e.to_string())}),
-                    }
-                } else {
-                    CommandResponse {
-                        tid: cmd.tid,
-                        cmd: cmd.cmd,
-                        data: json!({"status": "error", "reason": "stack_not_initialized"}),
                     }
                 }
             }

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -262,7 +262,7 @@ pub fn packed_uint21_deserialize(bytes: &[u8]) -> Result<(u32, &[u8]), SpinelFra
         }
     }
 
-    return Err(SpinelFrameParsingError::PackedU21DidNotTerminate);
+    Err(SpinelFrameParsingError::PackedU21DidNotTerminate)
 }
 
 pub fn packed_uint21_to_bytes(value: u32) -> Vec<u8> {
@@ -371,7 +371,7 @@ impl HdlcLiteFrame {
 
         if crc != expected_crc {
             return Err(HdlcLiteFrameParsingError::InvalidCrc {
-                expected_crc: expected_crc,
+                expected_crc,
                 got_crc: crc,
             });
         }
@@ -429,7 +429,7 @@ pub struct SpinelHeader {
 
 impl SpinelHeader {
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, SpinelFrameParsingError> {
-        if bytes.len() < 1 {
+        if bytes.is_empty() {
             return Err(SpinelFrameParsingError::PayloadTooShort {
                 expected: 1,
                 got: bytes.len(),
@@ -442,12 +442,12 @@ impl SpinelHeader {
         Ok(Self {
             flag: (byte & 0b11000000) >> 6,
             network_link_id: (byte & 0b00110000) >> 4,
-            transaction_id: (byte & 0b00001111) >> 0,
+            transaction_id: (byte & 0b00001111),
         })
     }
 
     pub fn to_bytes(&self) -> [u8; 1] {
-        [(self.flag << 6) | (self.network_link_id << 4) | (self.transaction_id << 0)]
+        [(self.flag << 6) | (self.network_link_id << 4) | self.transaction_id]
     }
 }
 
@@ -531,6 +531,12 @@ pub struct SpinelProtocol {
     pub property_update_receivers: HashMap<SpinelPropertyId, mpsc::Sender<SpinelFramePropValueIs>>,
 }
 
+impl Default for SpinelProtocol {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl SpinelProtocol {
     pub fn new() -> Self {
         Self {
@@ -588,7 +594,7 @@ impl SpinelProtocol {
                     | Err(HdlcLiteFrameParsingError::PayloadTooShort { .. }) => {}
                     Ok(frame) => match SpinelFrame::from_bytes(&frame.data) {
                         Err(SpinelFrameParsingError::PayloadTooShort { .. })
-                        | Err(SpinelFrameParsingError::PackedU21DidNotTerminate { .. })
+                        | Err(SpinelFrameParsingError::PackedU21DidNotTerminate)
                         | Err(SpinelFrameParsingError::NotSpinelFrame { .. }) => {}
                         Err(SpinelFrameParsingError::InvalidPropertyId { .. }) => { /* This cannot happen */
                         }
@@ -605,7 +611,7 @@ impl SpinelProtocol {
             self.buffer.drain(0..index.unwrap() + 1);
         }
 
-        return num_parsed_frames;
+        num_parsed_frames
     }
 
     pub fn parse_frames_from_bytes(&mut self, bytes: &[u8]) -> Vec<SpinelFrame> {
@@ -639,21 +645,21 @@ impl SpinelProtocol {
                                 let _ = sender.try_send(prop_value_is);
                             }
                             None => {
-                                eprintln!("No receiver for property update: {:?}", prop_value_is);
+                                eprintln!("No receiver for property update: {prop_value_is:?}");
                             }
                         }
                     }
                     Err(_) => {
-                        eprintln!("Failed to parse PropValueIs frame: {:?}", frame);
+                        eprintln!("Failed to parse PropValueIs frame: {frame:?}");
                     }
                 }
             } else {
-                eprintln!("Unhandled unsolicited frame: {:?}", frame);
+                eprintln!("Unhandled unsolicited frame: {frame:?}");
             }
         } else if let Some(sender) = self.pending_frames.remove(&tid) {
             let _ = sender.send(frame);
         } else {
-            eprintln!("Unsolicited or unmatched frame: {:?}", frame);
+            eprintln!("Unsolicited or unmatched frame: {frame:?}");
         }
     }
 

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, oneshot};
 const CRC_KERMIT: CrcAlgo<u16> = CrcAlgo::<u16>::new(0x1021, 16, 0xFFFF, 0xFFFF, true);
 const U21_MAX: u32 = 1 << 21;
 
-#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SpinelCommandId {
     Noop = 0,
@@ -37,7 +37,7 @@ pub enum SpinelCommandId {
     HboDropped = 17,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive, Hash, Eq)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive, Hash)]
 #[repr(u32)]
 pub enum SpinelPropertyId {
     // Core Properties
@@ -175,7 +175,7 @@ pub enum SpinelPropertyId {
     NestStreamMfg = 0x3BC0,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SpinelResetReason {
     Platform = 1,
@@ -183,7 +183,7 @@ pub enum SpinelResetReason {
     Bootloader = 3,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SpinelStatus {
     Ok = 0,
@@ -222,7 +222,7 @@ pub enum SpinelStatus {
     ResetWatchdog = 120,
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum SpinelMacPromiscuousMode {
     //  Normal MAC filtering is in place.
@@ -290,7 +290,7 @@ pub fn packed_uint21_to_bytes(value: u32) -> Vec<u8> {
     chunks
 }
 
-#[derive(Debug, PartialEq, Copy, Clone, TryFromPrimitive)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[repr(u8)]
 pub enum HdlcSpecial {
     Flag = 0x7E,
@@ -312,7 +312,7 @@ pub enum HdlcLiteFrameParsingError {
     PayloadTooShort { expected: usize, got: usize },
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct HdlcLiteFrame {
     pub data: Vec<u8>,
 }
@@ -420,7 +420,7 @@ impl HdlcLiteFrame {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct SpinelHeader {
     pub flag: u8,
     pub network_link_id: u8,
@@ -446,12 +446,12 @@ impl SpinelHeader {
         })
     }
 
-    pub fn to_bytes(&self) -> [u8; 1] {
+    pub const fn to_bytes(&self) -> [u8; 1] {
         [(self.flag << 6) | (self.network_link_id << 4) | self.transaction_id]
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, Eq, PartialEq, Clone)]
 pub struct SpinelFrame {
     pub header: SpinelHeader,
     pub command_id: SpinelCommandId,

--- a/crates/stack/src/spinel.rs
+++ b/crates/stack/src/spinel.rs
@@ -364,7 +364,7 @@ impl HdlcLiteFrame {
         let mut crc = 0x0000u16;
         CRC_KERMIT.init_crc(&mut crc);
         CRC_KERMIT.update_crc(&mut crc, &data[..data.len() - 2]);
-        CRC_KERMIT.finish_crc(&mut crc);
+        CRC_KERMIT.finish_crc(&crc);
         crc ^= 0xFFFF;
 
         let expected_crc = u16::from_le_bytes([data[data.len() - 2], data[data.len() - 1]]);
@@ -385,7 +385,7 @@ impl HdlcLiteFrame {
         let mut crc = 0x0000u16;
         CRC_KERMIT.init_crc(&mut crc);
         CRC_KERMIT.update_crc(&mut crc, &self.data);
-        CRC_KERMIT.finish_crc(&mut crc);
+        CRC_KERMIT.finish_crc(&crc);
         crc ^= 0xFFFF;
 
         let mut result = Vec::new();

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -15,7 +15,7 @@ use tokio::time::{Duration, timeout};
 
 const TIMEOUT: Duration = Duration::from_secs(30);
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SpinelTxFrame {
     pub psdu: Vec<u8>,
     pub channel: Option<u8>,
@@ -87,7 +87,7 @@ impl SpinelTxFrame {
     }
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SpinelRxFrame {
     pub psdu: Vec<u8>,
     pub rssi: i8,

--- a/crates/stack/src/spinel_client.rs
+++ b/crates/stack/src/spinel_client.rs
@@ -228,7 +228,7 @@ impl SpinelClient {
                         break;
                     }
                     Err(e) => {
-                        eprintln!("Error reading port: {:?}", e);
+                        eprintln!("Error reading port: {e:?}");
                         break;
                     }
                 }
@@ -248,7 +248,7 @@ impl SpinelClient {
                 .prepare_request(command_id, payload)
         };
 
-        log::debug!("Sending frame {:?}", frame);
+        log::debug!("Sending frame {frame:?}");
 
         let hdlc_frame = HdlcLiteFrame {
             data: frame.to_bytes(),
@@ -256,7 +256,7 @@ impl SpinelClient {
 
         let data = hdlc_frame.to_bytes_with_flags();
 
-        log::debug!("Writing {:02X?}", data);
+        log::debug!("Writing {data:02X?}");
         self.port.write(&data).await.map_err(SpinelError::IoError)?;
 
         match timeout(TIMEOUT, rx).await {
@@ -325,11 +325,7 @@ impl SpinelClient {
         })?;
 
         log::info!(
-            "Setting property {:?}={:02X?}, result {:?}={:02X?}",
-            property_id,
-            value,
-            rsp_property_id,
-            payload
+            "Setting property {property_id:?}={value:02X?}, result {rsp_property_id:?}={payload:02X?}"
         );
 
         Ok((rsp_property_id, payload.to_vec()))
@@ -367,7 +363,7 @@ impl SpinelClient {
             });
         }
 
-        if rsp.len() < 1 {
+        if rsp.is_empty() {
             return Err(SpinelError::InvalidResponseError {
                 reason: "Unexpected response length".to_string(),
             });

--- a/crates/stack/src/zigbee_aps.rs
+++ b/crates/stack/src/zigbee_aps.rs
@@ -198,12 +198,12 @@ pub enum ApsFrame {
 }
 
 pub fn parse_aps_frame(bytes: &[u8]) -> Result<ApsFrame, &'static str> {
-    if bytes.len() < 1 {
+    if bytes.is_empty() {
         return Err("Not enough data to parse ApsFrame");
     }
 
     let frame_type =
-        ApsFrameType::try_from((bytes[0] >> 0) & 0b11).map_err(|_| "Invalid frame type")?;
+        ApsFrameType::try_from(bytes[0] & 0b11).map_err(|_| "Invalid frame type")?;
 
     match frame_type {
         ApsFrameType::Data => Ok(ApsFrame::Data(ApsDataFrame::from_bytes(bytes)?)),

--- a/crates/stack/src/zigbee_aps.rs
+++ b/crates/stack/src/zigbee_aps.rs
@@ -20,7 +20,7 @@ pub enum ApsDeliveryMode {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApsFrameControl {
     pub frame_type: ApsFrameType,
     pub delivery_mode: ApsDeliveryMode,
@@ -31,7 +31,7 @@ pub struct ApsFrameControl {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApsAckFrameControl {
     pub frame_type: ApsFrameType,
     pub delivery_mode: ApsDeliveryMode,
@@ -41,7 +41,7 @@ pub struct ApsAckFrameControl {
     pub extended_header: bool,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApsAckFrame {
     pub frame_control: ApsAckFrameControl,
     pub destination_endpoint: Option<u8>,
@@ -52,6 +52,7 @@ pub struct ApsAckFrame {
 }
 
 impl ApsAckFrame {
+    #[allow(clippy::useless_let_if_seq)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
         if bytes.len() < 8 {
             return Err("Not enough data to parse ApsAckFrame");
@@ -118,7 +119,7 @@ impl ApsAckFrame {
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ApsDataFrame {
     pub frame_control: ApsFrameControl,
     pub group_id: Option<u16>,
@@ -131,6 +132,7 @@ pub struct ApsDataFrame {
 }
 
 impl ApsDataFrame {
+    #[allow(clippy::useless_let_if_seq)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
         if bytes.len() < 8 {
             return Err("Not enough data to parse ApsDataFrame");

--- a/crates/stack/src/zigbee_aps.rs
+++ b/crates/stack/src/zigbee_aps.rs
@@ -202,8 +202,7 @@ pub fn parse_aps_frame(bytes: &[u8]) -> Result<ApsFrame, &'static str> {
         return Err("Not enough data to parse ApsFrame");
     }
 
-    let frame_type =
-        ApsFrameType::try_from(bytes[0] & 0b11).map_err(|_| "Invalid frame type")?;
+    let frame_type = ApsFrameType::try_from(bytes[0] & 0b11).map_err(|_| "Invalid frame type")?;
 
     match frame_type {
         ApsFrameType::Data => Ok(ApsFrame::Data(ApsDataFrame::from_bytes(bytes)?)),

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -142,15 +142,15 @@ impl NwkHeader {
 
         Ok((
             Self {
-                frame_control: frame_control,
-                destination: destination,
-                source: source,
-                radius: radius,
-                sequence_number: sequence_number,
-                destination_ieee: destination_ieee,
-                source_ieee: source_ieee,
-                multicast_control: multicast_control,
-                source_route: source_route,
+                frame_control,
+                destination,
+                source,
+                radius,
+                sequence_number,
+                destination_ieee,
+                source_ieee,
+                multicast_control,
+                source_route,
             },
             remaining,
         ))
@@ -281,7 +281,7 @@ impl NwkAuxHeader {
 
 fn right_pad_to_multiple_of_16(data: &[u8]) -> Vec<Block> {
     // Pre-allocate enough blocks
-    let mut blocks = Vec::<Block>::with_capacity((data.len() + 15) / 16);
+    let mut blocks = Vec::<Block>::with_capacity(data.len().div_ceil(16));
 
     // Push all full 16-byte chunks
     for chunk in data.chunks_exact(16) {
@@ -338,7 +338,7 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
 
         let mut authed_plaintext = Vec::<Block>::new();
         authed_plaintext.extend(right_pad_to_multiple_of_16(&added_auth_data));
-        authed_plaintext.extend(right_pad_to_multiple_of_16(&plaintext));
+        authed_plaintext.extend(right_pad_to_multiple_of_16(plaintext));
 
         let mut ciphertext_buffer = Vec::<Block>::new();
         ciphertext_buffer.push(b0);
@@ -387,7 +387,7 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
         encrypted_mac_tag.copy_from_slice(&tagged_ciphertext_blocks[0][0..M]);
 
         // The actual ciphertext portion starts at the second block
-        let ciphertext_vec = Vec::<u8>::from(tagged_ciphertext_blocks[1..].concat());
+        let ciphertext_vec = tagged_ciphertext_blocks[1..].concat();
         let ciphertext = ciphertext_vec[..plaintext.len()].to_vec();
 
         (encrypted_mac_tag, ciphertext)
@@ -427,9 +427,9 @@ impl EncryptedNwkFrame {
     pub fn get_nonce(&self, aux_header: &NwkAuxHeader) -> [u8; 13] {
         let source;
 
-        if !aux_header.extended_source.is_none() {
+        if aux_header.extended_source.is_some() {
             source = aux_header.extended_source.unwrap();
-        } else if !self.nwk_header.source_ieee.is_none() {
+        } else if self.nwk_header.source_ieee.is_some() {
             source = self.nwk_header.source_ieee.unwrap();
         } else {
             // XXX: this can't happen
@@ -464,8 +464,8 @@ impl EncryptedNwkFrame {
         }
 
         Ok(Self {
-            nwk_header: nwk_header,
-            aux_header: aux_header,
+            nwk_header,
+            aux_header,
             ciphertext: remaining.to_vec(),
         })
     }
@@ -521,9 +521,9 @@ impl NwkFrame {
     pub fn get_nonce(&self, aux_header: &NwkAuxHeader) -> [u8; 13] {
         let source;
 
-        if !aux_header.extended_source.is_none() {
+        if aux_header.extended_source.is_some() {
             source = aux_header.extended_source.unwrap();
-        } else if !self.nwk_header.source_ieee.is_none() {
+        } else if self.nwk_header.source_ieee.is_some() {
             source = self.nwk_header.source_ieee.unwrap();
         } else {
             // XXX: this can't happen
@@ -551,9 +551,9 @@ impl NwkFrame {
         let nonce = self.get_nonce(&aux_header);
         let plaintext = &self.payload;
 
-        let mac_tag = crypto.compute_mac(&self.nwk_header, key, &plaintext, &aux_header, &nonce);
+        let mac_tag = crypto.compute_mac(&self.nwk_header, key, plaintext, &aux_header, &nonce);
         let (encrypted_mac_tag, ciphertext) =
-            crypto.encrypt_decrypt(key, &nonce, &mac_tag, &plaintext);
+            crypto.encrypt_decrypt(key, &nonce, &mac_tag, plaintext);
 
         let mut ciphertext_with_tag = ciphertext;
         ciphertext_with_tag.extend(encrypted_mac_tag);

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -47,7 +47,7 @@ pub enum NwkRouteDiscovery {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NwkFrameControl {
     pub frame_type: NwkFrameType,
     pub protocol_version: u4,
@@ -62,7 +62,7 @@ pub struct NwkFrameControl {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NwkSourceRoute {
     #[abstract_bits(length_of = relays)]
     relay_count: u8,
@@ -70,7 +70,7 @@ pub struct NwkSourceRoute {
     pub relays: Vec<Nwk>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NwkHeader {
     pub frame_control: NwkFrameControl,
     pub destination: Nwk,
@@ -212,7 +212,7 @@ pub enum NwkSecurityLevel {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NwkSecurityHeaderControlField {
     pub security_level: NwkSecurityLevel,
     pub key_id: NwkSecurityHeaderKeyId,
@@ -221,7 +221,7 @@ pub struct NwkSecurityHeaderControlField {
     reserved: u1,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct NwkAuxHeader {
     pub security_control: NwkSecurityHeaderControlField,
     pub frame_counter: u32,
@@ -230,6 +230,7 @@ pub struct NwkAuxHeader {
 }
 
 impl NwkAuxHeader {
+    #[allow(clippy::useless_let_if_seq)]
     pub fn deserialize(bytes: &[u8]) -> Result<(Self, &[u8]), &'static str> {
         if bytes.len() < 6 {
             return Err("Not enough data to parse NwkAuxHeader");
@@ -448,12 +449,13 @@ impl EncryptedNwkFrame {
         nonce
     }
 
-    pub fn get_crypto(&self) -> NwkCrypto<2, 4> {
+    pub const fn get_crypto(&self) -> NwkCrypto<2, 4> {
         // Only a single configuration is supported but to keep the cryptography code
         // readable, it's useful to be generic here
         NwkCrypto::<2, 4>
     }
 
+    #[allow(clippy::useless_let_if_seq)]
     pub fn from_bytes(bytes: &[u8]) -> Result<Self, &'static str> {
         let mut remaining;
         let nwk_header;
@@ -542,7 +544,7 @@ impl NwkFrame {
         nonce
     }
 
-    pub fn get_crypto(&self) -> NwkCrypto<2, 4> {
+    pub const fn get_crypto(&self) -> NwkCrypto<2, 4> {
         // Only a single configuration is supported but to keep the cryptography code
         // readable, it's useful to be generic here
         NwkCrypto::<2, 4>

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::useless_conversion)]
+
 use abstract_bits::AbstractBits;
 use abstract_bits::abstract_bits;
 use ieee_802154::types::{Eui64, Key, Nwk, format_hex};

--- a/crates/stack/src/zigbee_nwk.rs
+++ b/crates/stack/src/zigbee_nwk.rs
@@ -315,6 +315,7 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
         (ciphertext, mac_tag)
     }
 
+    #[allow(clippy::unusual_byte_groupings)]
     pub fn compute_mac(
         &self,
         nwk_header: &NwkHeader,
@@ -356,6 +357,7 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
         mac_tag
     }
 
+    #[allow(clippy::unusual_byte_groupings)]
     pub fn encrypt_decrypt(
         &self,
         key: &Key,
@@ -380,7 +382,7 @@ impl<const L: usize, const M: usize> NwkCrypto<L, M> {
             counter_block[14..16]
                 .copy_from_slice(&encoded_block_num[encoded_block_num.len() - L..]);
 
-            cipher.encrypt_block_b2b(&mut counter_block, &mut buffer_block);
+            cipher.encrypt_block_b2b(&counter_block, &mut buffer_block);
             tagged_ciphertext_blocks.push(Block::from_fn(|i| buffer_block[i] ^ plaintext_block[i]));
         }
 

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -1013,14 +1013,14 @@ impl ZigbeeStack {
 
         log::info!("Link status command frame: {link_status_cmd:#?}");
 
-        if nwk_frame.nwk_header.source_ieee.is_none() {
-            log::warn!("Link status command source EUI64 is missing");
-            return;
-        }
-
         // We collect a list of neighbors with non-zero outgoing cost up here, before
         // mutating the state
         self.maybe_age_neighbors();
+
+        let Some(source_ieee) = nwk_frame.nwk_header.source_ieee else {
+            log::warn!("Link status command source EUI64 is missing");
+            return;
+        };
 
         let neighbors_with_nonzero_outgoing_cost = self
             .state
@@ -1037,7 +1037,6 @@ impl ZigbeeStack {
             })
             .collect::<HashSet<Nwk>>();
 
-        let source_ieee = nwk_frame.nwk_header.source_ieee.unwrap();
         let mut neighbor_table = self
             .state
             .neighbor_table

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -486,52 +486,54 @@ impl ZigbeeStack {
         loop {
             let (packet, ieee802154_frame) = self.recv_frame().await;
 
-            match self.process_802154_frame(&ieee802154_frame, packet.lqi, packet.rssi) {
-                Some(nwk_frame) => {
-                    if nwk_frame.nwk_header.frame_control.frame_type != NwkFrameType::Data {
+            if let Some(nwk_frame) =
+                self.process_802154_frame(&ieee802154_frame, packet.lqi, packet.rssi)
+            {
+                if nwk_frame.nwk_header.frame_control.frame_type != NwkFrameType::Data {
+                    continue;
+                }
+
+                let aps_frame = match parse_aps_frame(&nwk_frame.payload) {
+                    Ok(ApsFrame::Data(data)) => data,
+                    Ok(ApsFrame::Ack(ack)) => {
+                        let ack_data = ApsAckData::from_aps_ack(nwk_frame.nwk_header.source, &ack);
+                        log::debug!("Received APS ack: {ack_data:?}");
+
+                        if let Some(tx) = self
+                            .state
+                            .pending_aps_acks
+                            .try_lock_for(MAX_LOCK_DURATION)
+                            .unwrap()
+                            .remove(&ack_data)
+                        {
+                            let _ = tx.send(());
+                        }
+
                         continue;
                     }
-
-                    let aps_frame = match parse_aps_frame(&nwk_frame.payload) {
-                        Ok(ApsFrame::Data(data)) => data,
-                        Ok(ApsFrame::Ack(ack)) => {
-                            let ack_data =
-                                ApsAckData::from_aps_ack(nwk_frame.nwk_header.source, &ack);
-                            log::debug!("Received APS ack: {ack_data:?}");
-
-                            if let Some(tx) = self.state
-                                .pending_aps_acks
-                                .try_lock_for(MAX_LOCK_DURATION)
-                                .unwrap()
-                                .remove(&ack_data) { let _ = tx.send(()); }
-
-                            continue;
-                        }
-                        Err(e) => {
-                            log::warn!("Error parsing APS frame: {e:?}");
-                            continue;
-                        }
-                    };
-
-                    log::debug!("Received APS data frame: {aps_frame:#?}");
-
-                    if aps_frame.frame_control.ack_request {
-                        self.handle_aps_ack_request(&aps_frame, &nwk_frame);
+                    Err(e) => {
+                        log::warn!("Error parsing APS frame: {e:?}");
+                        continue;
                     }
+                };
 
-                    let notification = ZigbeeNotification::ReceivedApsCommand {
-                        source: nwk_frame.nwk_header.source,
-                        profile_id: aps_frame.profile_id,
-                        cluster_id: aps_frame.cluster_id,
-                        src_ep: aps_frame.source_endpoint,
-                        dst_ep: aps_frame.destination_endpoint.unwrap_or(0),
-                        lqi: packet.lqi,
-                        rssi: packet.rssi,
-                        data: aps_frame.asdu,
-                    };
-                    let _ = self.notification_tx.send(notification);
+                log::debug!("Received APS data frame: {aps_frame:#?}");
+
+                if aps_frame.frame_control.ack_request {
+                    self.handle_aps_ack_request(&aps_frame, &nwk_frame);
                 }
-                None => {}
+
+                let notification = ZigbeeNotification::ReceivedApsCommand {
+                    source: nwk_frame.nwk_header.source,
+                    profile_id: aps_frame.profile_id,
+                    cluster_id: aps_frame.cluster_id,
+                    src_ep: aps_frame.source_endpoint,
+                    dst_ep: aps_frame.destination_endpoint.unwrap_or(0),
+                    lqi: packet.lqi,
+                    rssi: packet.rssi,
+                    data: aps_frame.asdu,
+                };
+                let _ = self.notification_tx.send(notification);
             }
         }
     }
@@ -698,9 +700,7 @@ impl ZigbeeStack {
                 return None;
             }
             Some(dest_pan_id) if dest_pan_id != pan_id => {
-                log::debug!(
-                    "Ignoring frame, PAN ID does not match {dest_pan_id:?} != {pan_id:?}"
-                );
+                log::debug!("Ignoring frame, PAN ID does not match {dest_pan_id:?} != {pan_id:?}");
                 return None;
             }
             Some(_) => (),
@@ -870,9 +870,10 @@ impl ZigbeeStack {
             .unwrap();
 
         if let Some(entry) = broadcast_transaction_table.get(&key)
-            && entry.expiration_time > now {
-                return true;
-            }
+            && entry.expiration_time > now
+        {
+            return true;
+        }
 
         broadcast_transaction_table.insert(
             key,
@@ -888,20 +889,20 @@ impl ZigbeeStack {
 
     pub fn handle_decrypted_frame(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk, lqi: u8, rssi: i8) {
         // Update the frame counter for the relaying device
-        if let Some(aux_header) = &nwk_frame.aux_header {
-            if let Some(relaying_eui64) = aux_header.extended_source {
-                self.state
-                    .security_material_primary
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap()
-                    .incoming_frame_counter_set
-                    .insert(relaying_eui64, aux_header.frame_counter);
+        if let Some(aux_header) = &nwk_frame.aux_header
+            && let Some(relaying_eui64) = aux_header.extended_source
+        {
+            self.state
+                .security_material_primary
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .incoming_frame_counter_set
+                .insert(relaying_eui64, aux_header.frame_counter);
 
-                log::debug!(
-                    "Incremented frame counter for {relaying_eui64:?} to {}",
-                    aux_header.frame_counter
-                );
-            }
+            log::debug!(
+                "Incremented frame counter for {relaying_eui64:?} to {}",
+                aux_header.frame_counter
+            );
         }
 
         // Update the address cache
@@ -939,9 +940,7 @@ impl ZigbeeStack {
                     // TODO: Error handling for decoding?
                     let route_record_cmd =
                         NwkRouteRecordCommand::deserialize(&nwk_frame.payload).unwrap();
-                    log::info!(
-                        "Route record command frame received: {route_record_cmd:#?}"
-                    );
+                    log::info!("Route record command frame received: {route_record_cmd:#?}");
                     self.state
                         .route_record_table
                         .try_lock_for(MAX_LOCK_DURATION)
@@ -977,8 +976,7 @@ impl ZigbeeStack {
                 .values_mut()
                 .find(|e| e.network_address == nwk_frame.nwk_header.source)
         } {
-            None => {
-            }
+            None => {}
             Some(entry) => {
                 entry.lqas.push_back(lqi);
 
@@ -1374,9 +1372,7 @@ impl ZigbeeStack {
             }
         };
 
-        log::info!(
-            "Route request command frame (sender {sender_nwk:#?}): {route_request_cmd:#?}"
-        );
+        log::info!("Route request command frame (sender {sender_nwk:#?}): {route_request_cmd:#?}");
 
         let network_address = self.state.network_address;
         let neighbor_table = self
@@ -1881,11 +1877,11 @@ impl ZigbeeStack {
                     .try_lock_for(MAX_LOCK_DURATION)
                     .unwrap()
                     .get_mut(&relaying_ieee)
-                {
-                    // Update the neighbor table counters
-                    neighbor_entry.router_outbound_activity =
-                        neighbor_entry.router_outbound_activity.saturating_add(1);
-                }
+            {
+                // Update the neighbor table counters
+                neighbor_entry.router_outbound_activity =
+                    neighbor_entry.router_outbound_activity.saturating_add(1);
+            }
 
             // And the routing table counters
             if let Some(route_entry) = self

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -1813,16 +1813,14 @@ impl ZigbeeStack {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = self.next_nwk_frame_counter();
 
-            let encrypted_nwk_frame = {
-                nwk_frame.encrypt(
-                    &self
-                        .state
-                        .security_material_primary
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                        .key,
-                )
-            };
+            let encrypted_nwk_frame = nwk_frame.encrypt(
+                &self
+                    .state
+                    .security_material_primary
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .key,
+            );
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {
@@ -1968,16 +1966,14 @@ impl ZigbeeStack {
             // The encryption frame counter always increments
             nwk_frame.aux_header.as_mut().unwrap().frame_counter = self.next_nwk_frame_counter();
 
-            let encrypted_nwk_frame = {
-                nwk_frame.encrypt(
-                    &self
-                        .state
-                        .security_material_primary
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                        .key,
-                )
-            };
+            let encrypted_nwk_frame = nwk_frame.encrypt(
+                &self
+                    .state
+                    .security_material_primary
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .key,
+            );
 
             let ieee802154_frame = Ieee802154Frame {
                 frame_control: Ieee802154FrameControl {

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -45,7 +45,7 @@ const APS_ACK_TIMEOUT: Duration = Duration::from_millis(5000);
 const LINK_QUALITY_SAMPLES: usize = 3;
 
 /// Compute the link cost (1-7) based on the LQI (0-255).
-fn lqi_to_link_cost(lqi: u8) -> u8 {
+const fn lqi_to_link_cost(lqi: u8) -> u8 {
     match lqi {
         0..=16 => 7,
         17..=32 => 6,
@@ -190,7 +190,7 @@ impl Default for Constants {
 }
 
 impl Constants {
-    pub fn new() -> Self {
+    pub const fn new() -> Self {
         Self {
             passive_ack_timeout: Duration::from_millis(500),
             max_broadcast_retries: 2,
@@ -233,8 +233,8 @@ pub struct ApsAckData {
 }
 
 impl ApsAckData {
-    pub fn from_aps_ack(src: Nwk, ack: &ApsAckFrame) -> Self {
-        ApsAckData {
+    pub const fn from_aps_ack(src: Nwk, ack: &ApsAckFrame) -> Self {
+        Self {
             src,
             destination_endpoint: ack.destination_endpoint,
             cluster_id: ack.cluster_id,
@@ -351,7 +351,7 @@ impl State {
         key_seq_number: u8,
         outgoing_frame_counter: u32,
     ) -> Self {
-        State {
+        Self {
             channel: Mutex::new(channel),
             ieee802154_sequence_number: Mutex::new(0),
             pending_aps_acks: Mutex::new(HashMap::new()),
@@ -460,7 +460,7 @@ impl ZigbeeStack {
         let (raw_frame_tx, raw_frame_rx) = mpsc::channel::<SpinelFramePropValueIs>(32);
         spinel.set_property_update_receiver(SpinelPropertyId::StreamRaw, raw_frame_tx);
 
-        let arc_stack = Arc::new_cyclic(|weak_self| ZigbeeStack {
+        let arc_stack = Arc::new_cyclic(|weak_self| Self {
             self_weak: weak_self.clone(),
             state: State::new(
                 channel,
@@ -482,6 +482,9 @@ impl ZigbeeStack {
         (arc_stack, notification_rx)
     }
 
+    // This function intentionally holds locks across await points to maintain
+    // exclusive access to shared state during frame processing.
+    #[allow(clippy::future_not_send)]
     pub async fn run(&self) {
         self.start_network().await.expect("Failed to start network");
 
@@ -501,13 +504,13 @@ impl ZigbeeStack {
                         let ack_data = ApsAckData::from_aps_ack(nwk_frame.nwk_header.source, &ack);
                         log::debug!("Received APS ack: {ack_data:?}");
 
-                        if let Some(tx) = self
+                        let tx = self
                             .state
                             .pending_aps_acks
                             .try_lock_for(MAX_LOCK_DURATION)
                             .unwrap()
-                            .remove(&ack_data)
-                        {
+                            .remove(&ack_data);
+                        if let Some(tx) = tx {
                             let _ = tx.send(());
                         }
 
@@ -542,7 +545,11 @@ impl ZigbeeStack {
 
     // We intentionally hold the receiver lock for the entire duration of this function
     // to ensure exclusive access to the raw frame receiver.
-    #[allow(clippy::await_holding_lock)]
+    #[allow(
+        clippy::await_holding_lock,
+        clippy::significant_drop_tightening,
+        clippy::future_not_send
+    )]
     async fn recv_frame(&self) -> (SpinelRxFrame, Ieee802154Frame) {
         let mut receiver = self
             .raw_frame_rx
@@ -662,6 +669,9 @@ impl ZigbeeStack {
         Ok(())
     }
 
+    // This function handles complex 802.15.4 frame processing with multiple
+    // validation steps and protocol handling paths.
+    #[allow(clippy::cognitive_complexity)]
     pub fn process_802154_frame(
         &self,
         frame: &Ieee802154Frame,
@@ -789,14 +799,13 @@ impl ZigbeeStack {
         );
 
         // Finally, attempt decryption
-        let decrypted_nwk_frame = match nwk_frame.decrypt(
-            &self
-                .state
-                .security_material_primary
-                .try_lock_for(MAX_LOCK_DURATION)
-                .unwrap()
-                .key,
-        ) {
+        let key = &self
+            .state
+            .security_material_primary
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap()
+            .key;
+        let decrypted_nwk_frame = match nwk_frame.decrypt(key) {
             Ok(decrypted_frame) => decrypted_frame,
             Err(err) => {
                 log::warn!("Ignoring frame, decryption failed: {err:?}");
@@ -819,13 +828,13 @@ impl ZigbeeStack {
     }
 
     pub fn update_nwk_eui64_mapping(&self, nwk: Nwk, eui64: Eui64) {
-        match self
+        let old_nwk = self
             .state
             .address_map
             .try_lock_for(MAX_LOCK_DURATION)
             .unwrap()
-            .insert(eui64, nwk)
-        {
+            .insert(eui64, nwk);
+        match old_nwk {
             None => {
                 log::debug!("Added new address mapping: {eui64:?} -> {nwk:?}")
             }
@@ -1002,6 +1011,7 @@ impl ZigbeeStack {
         }
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     fn handle_link_status(&self, nwk_frame: &NwkFrame, lqi: u8) {
         let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
@@ -1043,46 +1053,42 @@ impl ZigbeeStack {
             .try_lock_for(MAX_LOCK_DURATION)
             .unwrap();
 
-        let neighbor_entry = match neighbor_table.get_mut(&source_ieee) {
-            Some(entry) => entry,
-            None => {
-                // Create one
-                log::info!("Creating new neighbor entry for {source_ieee:?}");
+        let neighbor_entry = neighbor_table.entry(source_ieee).or_insert_with(|| {
+            // Create one
+            log::info!("Creating new neighbor entry for {source_ieee:?}");
 
-                let mut entry = neighbor::TableEntry {
-                    extended_address: source_ieee,
-                    network_address: nwk_frame.nwk_header.source,
-                    device_type: NwkDeviceType::Router,
-                    rx_on_when_idle: true,
-                    end_device_configuration: 0x0000,
-                    timeout_at: Instant::now() + Duration::from_secs(0xFFFFFFFF),
-                    device_timeout_at: Instant::now() + Duration::from_secs(0xFFFFFFFF),
-                    relationship: neighbor::Relationship::Sibling,
-                    transmit_failure: 0,
-                    lqas: VecDeque::new(),
-                    outgoing_cost: 0,
-                    last_link_status_timestamp: Instant::now(),
-                    incoming_beacon_timestamp: 0,
-                    beacon_transmission_time_offset: 0,
-                    keepalive_received: true,
-                    mac_unicast_bytes_transmitted: 0,
-                    mac_unicast_bytes_received: 0,
-                    router_added_timestamp: Instant::now(),
-                    router_connectivity: 0,
-                    router_neighbor_set_diversity: 0,
-                    router_outbound_activity: 0,
-                    router_inbound_activity: 0,
-                    security_timer: 0,
-                };
+            let mut entry = neighbor::TableEntry {
+                extended_address: source_ieee,
+                network_address: nwk_frame.nwk_header.source,
+                device_type: NwkDeviceType::Router,
+                rx_on_when_idle: true,
+                end_device_configuration: 0x0000,
+                timeout_at: Instant::now() + Duration::from_secs(0xFFFFFFFF),
+                device_timeout_at: Instant::now() + Duration::from_secs(0xFFFFFFFF),
+                relationship: neighbor::Relationship::Sibling,
+                transmit_failure: 0,
+                lqas: VecDeque::new(),
+                outgoing_cost: 0,
+                last_link_status_timestamp: Instant::now(),
+                incoming_beacon_timestamp: 0,
+                beacon_transmission_time_offset: 0,
+                keepalive_received: true,
+                mac_unicast_bytes_transmitted: 0,
+                mac_unicast_bytes_received: 0,
+                router_added_timestamp: Instant::now(),
+                router_connectivity: 0,
+                router_neighbor_set_diversity: 0,
+                router_outbound_activity: 0,
+                router_inbound_activity: 0,
+                security_timer: 0,
+            };
 
-                // Update the neighbor's LQI deque here, since we did not do so earlier
-                // when receiving the packet (since the entry was missing)
-                entry.lqas.push_back(lqi);
+            // Update the neighbor's LQI deque here, since we did not do so earlier
+            // when receiving the packet (since the entry was missing)
+            entry.lqas.push_back(lqi);
 
-                neighbor_table.insert(source_ieee, entry);
-                neighbor_table.get_mut(&source_ieee).unwrap()
-            }
-        };
+            entry
+        });
 
         neighbor_entry.last_link_status_timestamp = Instant::now();
 
@@ -1122,20 +1128,23 @@ impl ZigbeeStack {
     }
 
     fn notify_routing_change(&self, nwk: &Nwk) {
-        let pending_route_notifications = self
-            .state
-            .pending_route_notifications
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
+        let tx = {
+            let pending_route_notifications = self
+                .state
+                .pending_route_notifications
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
 
-        if !pending_route_notifications.contains_key(nwk) {
-            return;
-        }
+            if !pending_route_notifications.contains_key(nwk) {
+                return;
+            }
 
-        let tx = pending_route_notifications.get(nwk).unwrap();
+            pending_route_notifications.get(nwk).unwrap().clone()
+        };
         let _ = tx.send(());
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     fn handle_route_reply(&self, nwk_frame: &NwkFrame) {
         let route_reply_cmd = match NwkRouteReplyCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
@@ -1357,6 +1366,7 @@ impl ZigbeeStack {
             });
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     fn handle_route_request(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk) {
         let route_request_cmd = match NwkRouteRequestCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
@@ -1369,32 +1379,39 @@ impl ZigbeeStack {
         log::info!("Route request command frame (sender {sender_nwk:#?}): {route_request_cmd:#?}");
 
         let network_address = self.state.network_address;
-        let neighbor_table = self
-            .state
-            .neighbor_table
-            .try_lock_for(MAX_LOCK_DURATION)
-            .unwrap();
-        // We need to know who sent the frame
-        let Some(sender_neighbor) = neighbor_table
-            .values()
-            .find(|&entry| entry.network_address == sender_nwk)
-        else {
-            // Can we do anything here? Broadcast an unsolicited link status?
-            log::warn!("Route request relayer not found in neighbor table");
-            return;
-        };
 
-        if sender_neighbor.outgoing_cost == 0 {
-            log::warn!("Path cost to neighbor is 0, not sending route reply");
-            return;
-        }
+        // Extract needed values from neighbor table and drop the lock early
+        let (outgoing_cost, incoming_cost) = {
+            let neighbor_table = self
+                .state
+                .neighbor_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap();
+
+            // We need to know who sent the frame
+            let Some(sender_neighbor) = neighbor_table
+                .values()
+                .find(|&entry| entry.network_address == sender_nwk)
+            else {
+                // Can we do anything here? Broadcast an unsolicited link status?
+                log::warn!("Route request relayer not found in neighbor table");
+                return;
+            };
+
+            if sender_neighbor.outgoing_cost == 0 {
+                log::warn!("Path cost to neighbor is 0, not sending route reply");
+                return;
+            }
+
+            (
+                sender_neighbor.outgoing_cost,
+                sender_neighbor.incoming_link_cost(),
+            )
+        };
 
         // The maximum of the incoming and outgoing costs is used for computations to
         // deprioritize asymmetric routes
-        let contributing_path_cost = cmp::max(
-            sender_neighbor.outgoing_cost,
-            sender_neighbor.incoming_link_cost(),
-        );
+        let contributing_path_cost = cmp::max(outgoing_cost, incoming_cost);
         let updated_path_cost = route_request_cmd
             .path_cost
             .saturating_add(contributing_path_cost);
@@ -1409,8 +1426,14 @@ impl ZigbeeStack {
                 .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap();
 
-            let route_table_entry = route_table
+            route_table
                 .entry(route_request_cmd.destination_address)
+                .and_modify(|entry| {
+                    if entry.status != route::Status::Active {
+                        entry.status = route::Status::Active;
+                        entry.next_hop_address = sender_nwk;
+                    }
+                })
                 .or_insert_with(|| {
                     route::TableEntry {
                         destination: route_request_cmd.destination_address,
@@ -1426,14 +1449,9 @@ impl ZigbeeStack {
                         recent_activity: 0,
                     }
                 });
-
-            if route_table_entry.status != route::Status::Active {
-                route_table_entry.status = route::Status::Active;
-                route_table_entry.next_hop_address = sender_nwk;
-            }
-
-            self.notify_routing_change(&route_request_cmd.destination_address);
         }
+
+        self.notify_routing_change(&route_request_cmd.destination_address);
 
         // Create a routing table entry that assigns the node that last-relayed the
         // route request command to be the next-hop for the original sender
@@ -1444,8 +1462,14 @@ impl ZigbeeStack {
                 .try_lock_for(MAX_LOCK_DURATION)
                 .unwrap();
 
-            let route_table_entry = route_table
+            route_table
                 .entry(nwk_frame.nwk_header.source)
+                .and_modify(|entry| {
+                    if entry.status != route::Status::Active {
+                        entry.status = route::Status::Active;
+                        entry.next_hop_address = sender_nwk;
+                    }
+                })
                 .or_insert_with(|| route::TableEntry {
                     destination: nwk_frame.nwk_header.source,
                     status: route::Status::Active,
@@ -1459,14 +1483,9 @@ impl ZigbeeStack {
                     total_usage_count: 0,
                     recent_activity: 0,
                 });
-
-            if route_table_entry.status != route::Status::Active {
-                route_table_entry.status = route::Status::Active;
-                route_table_entry.next_hop_address = sender_nwk;
-            }
-
-            self.notify_routing_change(&nwk_frame.nwk_header.source);
         }
+
+        self.notify_routing_change(&nwk_frame.nwk_header.source);
 
         // TODO: what do we do if one of these values doesn't match? This would be
         // an error, some device on the network is storing invalid information about
@@ -1486,6 +1505,7 @@ impl ZigbeeStack {
         if !is_for_self_or_child {
             self.clean_route_discovery_table();
 
+            // Check if we should ignore this route request due to higher cost
             let mut route_discovery_table = self
                 .state
                 .route_discovery_table
@@ -1509,35 +1529,29 @@ impl ZigbeeStack {
             );
 
             if route_discovery_entry.forward_cost < updated_path_cost {
-                log::debug!(
-                    "Ignoring route request with higher cost ({} > {})",
-                    updated_path_cost,
-                    route_discovery_entry.forward_cost
-                );
+                log::debug!("Ignoring route request with higher cost");
                 return;
             }
 
             // Create an entry in the routing table as well
-            {
-                self.state
-                    .route_table
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap()
-                    .entry(route_request_cmd.destination_address)
-                    .or_insert_with(|| route::TableEntry {
-                        destination: route_request_cmd.destination_address,
-                        status: route::Status::DiscoveryUnderway,
-                        no_route_cache: false,
-                        many_to_one: false,
-                        route_record_required: false,
-                        expired: false,
-                        sequence_number_valid: false,
-                        next_hop_address: Nwk(0xFFFF),
-                        sequence_number: 0,
-                        total_usage_count: 0,
-                        recent_activity: 0,
-                    });
-            }
+            self.state
+                .route_table
+                .try_lock_for(MAX_LOCK_DURATION)
+                .unwrap()
+                .entry(route_request_cmd.destination_address)
+                .or_insert_with(|| route::TableEntry {
+                    destination: route_request_cmd.destination_address,
+                    status: route::Status::DiscoveryUnderway,
+                    no_route_cache: false,
+                    many_to_one: false,
+                    route_record_required: false,
+                    expired: false,
+                    sequence_number_valid: false,
+                    next_hop_address: Nwk(0xFFFF),
+                    sequence_number: 0,
+                    total_usage_count: 0,
+                    recent_activity: 0,
+                });
 
             // If we get here, we have a reason to relay
             let rebroadcast_radius = nwk_frame.nwk_header.radius.saturating_sub(1);
@@ -2048,6 +2062,7 @@ impl ZigbeeStack {
         Ok(())
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     pub async fn discover_route(&self, destination: Nwk) -> Result<Nwk, ZigbeeStackError> {
         if self.state.hack_force_route_discovery
             || !{
@@ -2172,6 +2187,7 @@ impl ZigbeeStack {
         Ok(next_hop_address)
     }
 
+    #[allow(clippy::significant_drop_tightening)]
     pub async fn send_route_discovery(&self, destination: Nwk) {
         // Discover next hop route
         log::debug!("Sending route discovery for NWK {destination:?}");

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -920,7 +920,7 @@ impl ZigbeeStack {
                 Ok(NwkCommandId::LinkStatus) => {
                     // TODO: Error handling for decoding?
                     log::info!("Link status command frame received");
-                    self.handle_link_status(nwk_frame);
+                    self.handle_link_status(nwk_frame, lqi);
                 }
                 Ok(NwkCommandId::RouteReply) => {
                     // TODO: Error handling for decoding?
@@ -1002,7 +1002,7 @@ impl ZigbeeStack {
         }
     }
 
-    fn handle_link_status(&self, nwk_frame: &NwkFrame) {
+    fn handle_link_status(&self, nwk_frame: &NwkFrame, lqi: u8) {
         let link_status_cmd = match NwkLinkStatusCommand::deserialize(&nwk_frame.payload) {
             Ok(cmd) => cmd,
             Err(e) => {
@@ -1049,7 +1049,7 @@ impl ZigbeeStack {
                 // Create one
                 log::info!("Creating new neighbor entry for {source_ieee:?}");
 
-                let entry = neighbor::TableEntry {
+                let mut entry = neighbor::TableEntry {
                     extended_address: source_ieee,
                     network_address: nwk_frame.nwk_header.source,
                     device_type: NwkDeviceType::Router,
@@ -1074,6 +1074,10 @@ impl ZigbeeStack {
                     router_inbound_activity: 0,
                     security_timer: 0,
                 };
+
+                // Update the neighbor's LQI deque here, since we did not do so earlier
+                // when receiving the packet (since the entry was missing)
+                entry.lqas.push_back(lqi);
 
                 neighbor_table.insert(source_ieee, entry);
                 neighbor_table.get_mut(&source_ieee).unwrap()

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -183,6 +183,12 @@ pub struct Constants {
     pub end_device_timeout_default: u8,
 }
 
+impl Default for Constants {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Constants {
     pub fn new() -> Self {
         Self {
@@ -371,17 +377,17 @@ impl State {
             },
             nwk_manager_addr: Nwk(0x0000),
             update_id: Mutex::new(update_id),
-            network_address: network_address,
+            network_address,
             broadcast_transaction_table: Mutex::new(HashMap::new()),
-            extended_pan_id: extended_pan_id,
+            extended_pan_id,
             route_record_table: Mutex::new(HashMap::new()),
             is_concentrator: true,
             security_level: 5,
             security_material_primary: Mutex::new(NwkSecurityDescriptor {
-                key_seq_number: key_seq_number,
-                outgoing_frame_counter: outgoing_frame_counter,
+                key_seq_number,
+                outgoing_frame_counter,
                 incoming_frame_counter_set: HashMap::new(),
-                key: key,
+                key,
                 network_key_type: NetworkKeyType::Standard,
             }),
             security_material_alternate: Mutex::new(NwkSecurityDescriptor {
@@ -400,7 +406,7 @@ impl State {
             leave_request_allowed: false,
             parent_information: 0,
             leave_request_without_rejoin_allowed: false,
-            ieee_address: ieee_address,
+            ieee_address,
             // TODO: The 16-bit routing sequence number is expected to be
             // strictly-increasing, it should be persisted to disk
             // nwk_routing_sequence_number: 0x0000,
@@ -491,26 +497,23 @@ impl ZigbeeStack {
                         Ok(ApsFrame::Ack(ack)) => {
                             let ack_data =
                                 ApsAckData::from_aps_ack(nwk_frame.nwk_header.source, &ack);
-                            log::debug!("Received APS ack: {:?}", ack_data);
+                            log::debug!("Received APS ack: {ack_data:?}");
 
-                            self.state
+                            if let Some(tx) = self.state
                                 .pending_aps_acks
                                 .try_lock_for(MAX_LOCK_DURATION)
                                 .unwrap()
-                                .remove(&ack_data)
-                                .map(|tx| {
-                                    let _ = tx.send(());
-                                });
+                                .remove(&ack_data) { let _ = tx.send(()); }
 
                             continue;
                         }
                         Err(e) => {
-                            log::warn!("Error parsing APS frame: {:?}", e);
+                            log::warn!("Error parsing APS frame: {e:?}");
                             continue;
                         }
                     };
 
-                    log::debug!("Received APS data frame: {:#?}", aps_frame);
+                    log::debug!("Received APS data frame: {aps_frame:#?}");
 
                     if aps_frame.frame_control.ack_request {
                         self.handle_aps_ack_request(&aps_frame, &nwk_frame);
@@ -549,7 +552,7 @@ impl ZigbeeStack {
             let packet = match SpinelRxFrame::from_bytes(&spinel_frame.value) {
                 Ok(p) => p,
                 Err(e) => {
-                    log::warn!("Error parsing spinel frame: {:?}", e);
+                    log::warn!("Error parsing spinel frame: {e:?}");
                     continue;
                 }
             };
@@ -563,11 +566,11 @@ impl ZigbeeStack {
 
             match Ieee802154Frame::from_bytes_without_fcs(frame_data) {
                 Ok(frame) => {
-                    log::debug!("Received 802.15.4 frame: {:?}", frame);
+                    log::debug!("Received 802.15.4 frame: {frame:?}");
                     return (packet, frame);
                 }
                 Err(e) => {
-                    log::warn!("Error parsing IEEE 802.15.4 frame: {:?}", e);
+                    log::warn!("Error parsing IEEE 802.15.4 frame: {e:?}");
                     continue;
                 }
             };
@@ -696,9 +699,7 @@ impl ZigbeeStack {
             }
             Some(dest_pan_id) if dest_pan_id != pan_id => {
                 log::debug!(
-                    "Ignoring frame, PAN ID does not match {:?} != {:?}",
-                    dest_pan_id,
-                    pan_id
+                    "Ignoring frame, PAN ID does not match {dest_pan_id:?} != {pan_id:?}"
                 );
                 return None;
             }
@@ -823,7 +824,7 @@ impl ZigbeeStack {
 
         self.handle_decrypted_frame(&decrypted_nwk_frame, source_nwk, lqi, rssi);
 
-        return Some(decrypted_nwk_frame);
+        Some(decrypted_nwk_frame)
     }
 
     pub fn update_nwk_eui64_mapping(&self, nwk: Nwk, eui64: Eui64) {
@@ -868,11 +869,10 @@ impl ZigbeeStack {
             .try_lock_for(MAX_LOCK_DURATION)
             .unwrap();
 
-        if let Some(entry) = broadcast_transaction_table.get(&key) {
-            if entry.expiration_time > now {
+        if let Some(entry) = broadcast_transaction_table.get(&key)
+            && entry.expiration_time > now {
                 return true;
             }
-        }
 
         broadcast_transaction_table.insert(
             key,
@@ -883,27 +883,24 @@ impl ZigbeeStack {
             },
         );
 
-        return false;
+        false
     }
 
     pub fn handle_decrypted_frame(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk, lqi: u8, rssi: i8) {
         // Update the frame counter for the relaying device
         if let Some(aux_header) = &nwk_frame.aux_header {
-            match aux_header.extended_source {
-                Some(relaying_eui64) => {
-                    self.state
-                        .security_material_primary
-                        .try_lock_for(MAX_LOCK_DURATION)
-                        .unwrap()
-                        .incoming_frame_counter_set
-                        .insert(relaying_eui64, aux_header.frame_counter);
+            if let Some(relaying_eui64) = aux_header.extended_source {
+                self.state
+                    .security_material_primary
+                    .try_lock_for(MAX_LOCK_DURATION)
+                    .unwrap()
+                    .incoming_frame_counter_set
+                    .insert(relaying_eui64, aux_header.frame_counter);
 
-                    log::debug!(
-                        "Incremented frame counter for {relaying_eui64:?} to {}",
-                        aux_header.frame_counter
-                    );
-                }
-                None => {}
+                log::debug!(
+                    "Incremented frame counter for {relaying_eui64:?} to {}",
+                    aux_header.frame_counter
+                );
             }
         }
 
@@ -919,7 +916,7 @@ impl ZigbeeStack {
         // Ignore frames that aren't destined for us
         if nwk_frame.nwk_header.destination.as_u16()
             >= BROADCAST_ALL_ROUTERS_AND_COORDINATOR.as_u16()
-            && self.filter_broadcast(&nwk_frame)
+            && self.filter_broadcast(nwk_frame)
         {
             log::debug!("Filtering broadcast, stopping further processing");
             return;
@@ -943,8 +940,7 @@ impl ZigbeeStack {
                     let route_record_cmd =
                         NwkRouteRecordCommand::deserialize(&nwk_frame.payload).unwrap();
                     log::info!(
-                        "Route record command frame received: {:#?}",
-                        route_record_cmd
+                        "Route record command frame received: {route_record_cmd:#?}"
                     );
                     self.state
                         .route_record_table
@@ -982,7 +978,6 @@ impl ZigbeeStack {
                 .find(|e| e.network_address == nwk_frame.nwk_header.source)
         } {
             None => {
-                return;
             }
             Some(entry) => {
                 entry.lqas.push_back(lqi);
@@ -1158,7 +1153,7 @@ impl ZigbeeStack {
             }
         };
 
-        log::info!("Route reply command frame: {:#?}", route_reply_cmd);
+        log::info!("Route reply command frame: {route_reply_cmd:#?}");
 
         // Both `responder_eui64` and `originator_eui64` SHALL be set according to the
         // R23 spec but real devices do not do this
@@ -1380,8 +1375,7 @@ impl ZigbeeStack {
         };
 
         log::info!(
-            "Route request command frame (sender {sender_nwk:#?}): {:#?}",
-            route_request_cmd
+            "Route request command frame (sender {sender_nwk:#?}): {route_request_cmd:#?}"
         );
 
         let network_address = self.state.network_address;
@@ -1712,7 +1706,7 @@ impl ZigbeeStack {
             frame.sequence_number = Some(*ieee802154_sequence_number);
         }
 
-        log::info!("Sending 802.15.4 frame: {:#?}", frame);
+        log::info!("Sending 802.15.4 frame: {frame:#?}");
         log::info!("Sending 802.15.4 frame bytes: {:02X?}", frame.to_bytes());
 
         if self.state.hack_disable_tx {
@@ -1741,7 +1735,7 @@ impl ZigbeeStack {
             .expect("Failed to transmit frame");
 
         if status == SpinelStatus::Ok {
-            return Ok(());
+            Ok(())
         } else if status == SpinelStatus::NoAck {
             let next_hop = match frame.dest_address.unwrap() {
                 Ieee802154Address::Nwk(nwk) => Some(nwk),
@@ -1749,7 +1743,7 @@ impl ZigbeeStack {
             }
             .expect("Next 802.15.4. hop must have NWK addressing");
 
-            return Err(ZigbeeStackError::NwkNoAck { next_hop: next_hop });
+            return Err(ZigbeeStackError::NwkNoAck { next_hop });
         } else if status == SpinelStatus::CcaFailure {
             return Err(ZigbeeStackError::CcaFailure);
         } else {
@@ -1881,8 +1875,7 @@ impl ZigbeeStack {
                         None
                     }
                 })
-            {
-                if let Some(neighbor_entry) = self
+                && let Some(neighbor_entry) = self
                     .state
                     .neighbor_table
                     .try_lock_for(MAX_LOCK_DURATION)
@@ -1893,7 +1886,6 @@ impl ZigbeeStack {
                     neighbor_entry.router_outbound_activity =
                         neighbor_entry.router_outbound_activity.saturating_add(1);
                 }
-            }
 
             // And the routing table counters
             if let Some(route_entry) = self
@@ -1935,7 +1927,7 @@ impl ZigbeeStack {
                     log::warn!("Failed to send unicast frame: {e}");
 
                     if attempt + 1 > self.constants.unicast_retries {
-                        log::error!("Failed to send unicast frame after {} attempts", attempt);
+                        log::error!("Failed to send unicast frame after {attempt} attempts");
                         return Err(e);
                     }
                     log::debug!(
@@ -2212,7 +2204,7 @@ impl ZigbeeStack {
                 .unwrap();
             let route_table_entry = route_table.entry(destination).or_insert_with(|| {
                 route::TableEntry {
-                    destination: destination,
+                    destination,
                     status: route::Status::Inactive,
                     no_route_cache: false,
                     many_to_one: false,
@@ -2314,10 +2306,10 @@ impl ZigbeeStack {
             aux_header: None, // will be replaced
             payload: NwkRouteRequestCommand {
                 many_to_one: NwkRouteRequestManyToOne::NotManyToOne,
-                route_request_identifier: route_request_identifier,
+                route_request_identifier,
                 destination_address: destination,
                 path_cost: 0, // The path cost starts at 0, since we originate it
-                destination_eui64: destination_eui64,
+                destination_eui64,
             }
             .serialize()
             .unwrap(),
@@ -2351,8 +2343,8 @@ impl ZigbeeStack {
                 },
                 group_id: None,
                 destination_endpoint: Some(dst_ep),
-                cluster_id: cluster_id,
-                profile_id: profile_id,
+                cluster_id,
+                profile_id,
                 source_endpoint: src_ep,
                 counter: aps_seq,
                 asdu: data.to_vec(),
@@ -2368,8 +2360,8 @@ impl ZigbeeStack {
                 },
                 group_id: None,
                 destination_endpoint: Some(dst_ep),
-                cluster_id: cluster_id,
-                profile_id: profile_id,
+                cluster_id,
+                profile_id,
                 source_endpoint: src_ep,
                 counter: aps_seq,
                 asdu: data.to_vec(),
@@ -2385,15 +2377,15 @@ impl ZigbeeStack {
                 },
                 group_id: Some(destination.as_u16()),
                 destination_endpoint: None,
-                cluster_id: cluster_id,
-                profile_id: profile_id,
+                cluster_id,
+                profile_id,
                 source_endpoint: src_ep,
                 counter: aps_seq,
                 asdu: data.to_vec(),
             },
         };
 
-        log::debug!("Prepared APS frame: {:#?}", aps_frame);
+        log::debug!("Prepared APS frame: {aps_frame:#?}");
 
         let nwk_frame = NwkFrame {
             nwk_header: NwkHeader {
@@ -2408,7 +2400,7 @@ impl ZigbeeStack {
                     extended_source: false,
                     end_device_initiator: false,
                 },
-                destination: destination,
+                destination,
                 source: self.state.network_address,
                 radius: cmp::max(radius, 1),
                 sequence_number: *self
@@ -2425,7 +2417,7 @@ impl ZigbeeStack {
             payload: aps_frame.to_bytes(),
         };
 
-        log::debug!("Prepared NWK frame: {:#?}", nwk_frame);
+        log::debug!("Prepared NWK frame: {nwk_frame:#?}");
 
         if !aps_ack {
             self.background_send_nwk_frame(nwk_frame);
@@ -2443,7 +2435,7 @@ impl ZigbeeStack {
 
         let (ack_tx, ack_rx) = oneshot::channel();
 
-        log::debug!("APS ACK requested, waiting for {:?}", ack_data);
+        log::debug!("APS ACK requested, waiting for {ack_data:?}");
         {
             self.state
                 .pending_aps_acks
@@ -2460,7 +2452,7 @@ impl ZigbeeStack {
                 log::info!("APS ACK received");
             }
             Ok(Err(e)) => {
-                log::warn!("APS ACK channel hung up: {:?}", e);
+                log::warn!("APS ACK channel hung up: {e:?}");
                 return Err(ZigbeeStackError::ApsAckTimeout);
             }
             Err(_) => {

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -339,6 +339,7 @@ pub struct State {
 }
 
 impl State {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         channel: u8,
         update_id: u8,
@@ -442,6 +443,7 @@ pub struct ZigbeeStack {
 }
 
 impl ZigbeeStack {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         spinel: SpinelClient,
         channel: u8,
@@ -757,17 +759,13 @@ impl ZigbeeStack {
         }
 
         // Validate the security header frame counter for the relaying EUI64
-        let src_eui64;
-
-        match aux_header.extended_source {
+        let src_eui64 = match aux_header.extended_source {
             None => {
                 log::debug!("Ignoring frame, extended source is missing");
                 return None;
             }
-            Some(eui64) => {
-                src_eui64 = eui64;
-            }
-        }
+            Some(eui64) => eui64,
+        };
 
         match self
             .state
@@ -2314,6 +2312,7 @@ impl ZigbeeStack {
         self.background_send_nwk_frame(route_request_frame);
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn send_aps_command(
         &self,
         delivery_mode: ApsDeliveryMode,

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -540,15 +540,17 @@ impl ZigbeeStack {
         }
     }
 
+    // We intentionally hold the receiver lock for the entire duration of this function
+    // to ensure exclusive access to the raw frame receiver.
+    #[allow(clippy::await_holding_lock)]
     async fn recv_frame(&self) -> (SpinelRxFrame, Ieee802154Frame) {
+        let mut receiver = self
+            .raw_frame_rx
+            .try_lock_for(MAX_LOCK_DURATION)
+            .expect("No thread should panic");
+
         loop {
-            let Some(spinel_frame) = self
-                .raw_frame_rx
-                .try_lock_for(MAX_LOCK_DURATION)
-                .expect("No thread should panic")
-                .recv()
-                .await
-            else {
+            let Some(spinel_frame) = receiver.recv().await else {
                 log::warn!("Frame sender hung up");
                 continue;
             };
@@ -588,11 +590,9 @@ impl ZigbeeStack {
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
+        let channel = *self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap();
         self.spinel
-            .prop_value_set(
-                SpinelPropertyId::PhyChan,
-                vec![*self.state.channel.try_lock_for(MAX_LOCK_DURATION).unwrap()],
-            )
+            .prop_value_set(SpinelPropertyId::PhyChan, vec![channel])
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
@@ -627,16 +627,9 @@ impl ZigbeeStack {
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
+        let pan_id = *self.state.pan_id.try_lock_for(MAX_LOCK_DURATION).unwrap();
         self.spinel
-            .prop_value_set(
-                SpinelPropertyId::Mac154Panid,
-                self.state
-                    .pan_id
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap()
-                    .to_bytes()
-                    .to_vec(),
-            )
+            .prop_value_set(SpinelPropertyId::Mac154Panid, pan_id.to_bytes().to_vec())
             .await
             .map_err(ZigbeeStackError::SpinelError)?;
 
@@ -1476,7 +1469,7 @@ impl ZigbeeStack {
         // an error, some device on the network is storing invalid information about
         // either us or a child.
         let is_for_self_or_child = route_request_cmd.destination_address == network_address
-            || route_request_cmd.destination_eui64 == route_request_cmd.destination_eui64
+            || route_request_cmd.destination_eui64 == Some(self.state.ieee_address)
             /* || destination_is_child */;
 
         // Check for a route discovery table entry. If one already exists and the

--- a/crates/stack/src/zigbee_stack.rs
+++ b/crates/stack/src/zigbee_stack.rs
@@ -1765,6 +1765,19 @@ impl ZigbeeStack {
         }
     }
 
+    pub fn next_nwk_frame_counter(&self) -> u32 {
+        let mut security_material_primary = self
+            .state
+            .security_material_primary
+            .try_lock_for(MAX_LOCK_DURATION)
+            .unwrap();
+        security_material_primary.outgoing_frame_counter = security_material_primary
+            .outgoing_frame_counter
+            .wrapping_add(1);
+
+        security_material_primary.outgoing_frame_counter
+    }
+
     pub async fn send_unicast_nwk_frame(
         &self,
         mut nwk_frame: NwkFrame,
@@ -1798,16 +1811,7 @@ impl ZigbeeStack {
 
         for attempt in 0..=self.constants.unicast_retries {
             // The encryption frame counter always increments
-            nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut outgoing_frame_counter = self
-                    .state
-                    .security_material_primary
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap()
-                    .outgoing_frame_counter;
-                outgoing_frame_counter = outgoing_frame_counter.wrapping_add(1);
-                outgoing_frame_counter
-            };
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter = self.next_nwk_frame_counter();
 
             let encrypted_nwk_frame = {
                 nwk_frame.encrypt(
@@ -1962,16 +1966,7 @@ impl ZigbeeStack {
 
         for attempt in 0..=self.constants.max_broadcast_retries {
             // The encryption frame counter always increments
-            nwk_frame.aux_header.as_mut().unwrap().frame_counter = {
-                let mut outgoing_frame_counter = self
-                    .state
-                    .security_material_primary
-                    .try_lock_for(MAX_LOCK_DURATION)
-                    .unwrap()
-                    .outgoing_frame_counter;
-                outgoing_frame_counter = outgoing_frame_counter.wrapping_add(1);
-                outgoing_frame_counter
-            };
+            nwk_frame.aux_header.as_mut().unwrap().frame_counter = self.next_nwk_frame_counter();
 
             let encrypted_nwk_frame = {
                 nwk_frame.encrypt(

--- a/crates/stack/src/zigbee_stack/neighbor.rs
+++ b/crates/stack/src/zigbee_stack/neighbor.rs
@@ -77,7 +77,7 @@ impl TableEntry {
 
         // Calculate median
         if num_samples % 2 == 1 {
-            return Some(sorted_lqas[num_samples / 2]);
+            Some(sorted_lqas[num_samples / 2])
         } else {
             // Average of the two middle elements for even number of samples
             let mid1 = sorted_lqas[num_samples / 2 - 1];

--- a/crates/stack/src/zigbee_stack/neighbor.rs
+++ b/crates/stack/src/zigbee_stack/neighbor.rs
@@ -82,12 +82,12 @@ impl TableEntry {
             // Average of the two middle elements for even number of samples
             let mid1 = sorted_lqas[num_samples / 2 - 1];
             let mid2 = sorted_lqas[num_samples / 2];
-            return Some(((mid1 as u16 + mid2 as u16) / 2) as u8);
-        };
+            Some(((mid1 as u16 + mid2 as u16) / 2) as u8)
+        }
     }
 
     pub fn incoming_link_cost(&self) -> u8 {
-        self.lqa().map_or(0, |lqa| lqi_to_link_cost(lqa))
+        self.lqa().map_or(0, lqi_to_link_cost)
     }
 }
 

--- a/crates/stack/src/zigbee_stack/neighbor.rs
+++ b/crates/stack/src/zigbee_stack/neighbor.rs
@@ -14,19 +14,19 @@ pub struct TableEntry {
     pub end_device_configuration: u16,
 
     /// The current time remaining, in seconds, for the end device
-    pub timeout_at: Instant,
     /// max: 15728640 seconds, ~182 days
+    pub timeout_at: Instant,
 
     /// This field indicates the timeout, in seconds, for the end device child
-    pub device_timeout_at: Instant,
     /// max: 129600 seconds, 36 hours
+    pub device_timeout_at: Instant,
     pub relationship: Relationship,
 
     /// A value indicating if previous transmissions to the device were successful or
     /// not. Higher values indicate more failures.
     pub transmit_failure: u8,
-    pub lqas: VecDeque<u8>,
     /// TODO: replace with a fixed-size ring buffer
+    pub lqas: VecDeque<u8>,
 
     /// The outgoing cost field contains the cost of the link as measured by the
     /// neighbor. The value is obtained from the most recent link status command frame

--- a/crates/stack/src/zigbee_stack/route.rs
+++ b/crates/stack/src/zigbee_stack/route.rs
@@ -4,7 +4,7 @@ use ieee_802154::types::Nwk;
 
 pub type RequestId = u8;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Status {
     Active = 0,
     DiscoveryUnderway = 1,

--- a/crates/zigbee-parts/src/commands.rs
+++ b/crates/zigbee-parts/src/commands.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::useless_conversion)]
+
 use crate::{Command, Request, Response};
 use abstract_bits::abstract_bits;
 use ieee_802154::types::{Eui64, Nwk, PanId};

--- a/crates/zigbee-parts/src/commands.rs
+++ b/crates/zigbee-parts/src/commands.rs
@@ -40,7 +40,7 @@ pub enum NwkRouteRequestManyToOne {
 
 /// Zigbee spec: 3.4.1 Route Request Command
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkRouteRequestCommand {
     reserved: u3,
     pub many_to_one: NwkRouteRequestManyToOne,
@@ -63,7 +63,7 @@ impl Command for NwkRouteRequestCommand {
 
 /// Zigbee spec 3.4.2 Route Reply Command
 #[abstract_bits::abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkRouteReplyCommand {
     reserved: u4,
     #[abstract_bits(presence_of = originator_eui64)]
@@ -155,7 +155,7 @@ pub enum NwkNetworkStatus {
 }
 
 #[abstract_bits::abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkNetworkStatusCommand {
     pub status_code: NwkNetworkStatus,
     pub network_address: Nwk,
@@ -167,7 +167,7 @@ impl Command for NwkNetworkStatusCommand {
 
 /// Zigbee spec 3.4.5: Route Record Command
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkRouteRecordCommand {
     #[abstract_bits(length_of = relays)]
     reserved: u8,
@@ -196,7 +196,7 @@ pub enum NwkRejoinCapabilityInformationPowerSource {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkRejoinCapabilityInformation {
     /// This field will always have a value of 0 in implementations of this
     /// specification.
@@ -226,7 +226,7 @@ pub struct NwkRejoinCapabilityInformation {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkRejoinRequestCommand {
     pub capability_information: NwkRejoinCapabilityInformation,
 }
@@ -240,7 +240,7 @@ impl Command for NwkRejoinRequestCommand {
 }
 
 /// Zigbee spec: 3.4.7 Rejoin Response Command
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, Eq, PartialEq, Copy, Clone)]
 #[abstract_bits(bits = 8)]
 #[repr(u8)]
 pub enum Nwk802154AssociationStatus {
@@ -254,7 +254,7 @@ pub enum Nwk802154AssociationStatus {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkRejoinResponseCommand {
     pub network_address: Nwk,
     pub rejoin_status: Nwk802154AssociationStatus,
@@ -270,7 +270,7 @@ impl Command for NwkRejoinResponseCommand {
 
 /// Zigbee spec compressed: 3.4.8.3
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkLinkStatusCommand {
     #[abstract_bits(length_of = link_statuses)]
     reserved: u5,
@@ -286,7 +286,7 @@ impl Command for NwkLinkStatusCommand {
 
 /// Zigbee spec 3.4.8
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkLinkStatus {
     pub address: Nwk,
     pub incoming_cost: u3,
@@ -297,7 +297,7 @@ pub struct NwkLinkStatus {
 
 /// Zigbee spec: 3.4.4 Leave Command
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkLeaveCommand {
     reserved: u5,
     pub rejoin: bool,
@@ -340,7 +340,7 @@ pub enum NwkReportCommandIdentifier {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkNetworkReportCommand {
     #[abstract_bits(length_of = pan_ids)]
     report_information_count: u5,
@@ -365,7 +365,7 @@ pub enum NwkUpdateCommandIdentifier {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkNetworkUpdateCommand {
     /// For a PAN Identifier Update, this value SHALL be 1.
     update_information_count: u5,
@@ -384,7 +384,7 @@ impl Command for NwkNetworkUpdateCommand {
 
 /// Zigbee spec 3.4.11 End Device Timeout Request Command
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkEndDeviceTimeoutRequestCommand {
     pub request_timeout_enum: EndDeviceTimeout,
     reserved: u8, // reserved for future use
@@ -408,7 +408,7 @@ pub enum NwkEndDeviceTimeoutResponseStatus {
 
 /// Zigbee spec: 3.4.12 End Device Timeout Response Command
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkEndDeviceTimeoutResponseCommand {
     pub status: NwkEndDeviceTimeoutResponseStatus,
     pub mac_data_poll_keepalive_supported: bool,
@@ -436,7 +436,7 @@ pub enum NwkLinkPowerDeltaType {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkPowerListEntry {
     pub device_address: Nwk,
     /// Delta power calculated as the difference between the optimal power level and the
@@ -446,7 +446,7 @@ pub struct NwkPowerListEntry {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkLinkPowerDeltaCommand {
     pub command_type: NwkLinkPowerDeltaType,
     reserved: u6,
@@ -469,7 +469,7 @@ pub enum NwkCommissioningType {
 }
 
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkNetworkCommissioningRequestCommand {
     pub commissioning_type: NwkCommissioningType,
     pub capability_information: NwkRejoinCapabilityInformation,
@@ -485,7 +485,7 @@ impl Command for NwkNetworkCommissioningRequestCommand {
 
 /// Zigbee spec 3.4.15: Network Commissioning Response Command
 #[abstract_bits]
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Eq, PartialEq)]
 pub struct NwkNetworkCommissioningResponseCommand {
     /// The network address assigned to the joining device.
     pub network_address: Nwk,


### PR DESCRIPTION
`cargo build` and `cargo clippy` are now part of the pre-commit commands. I've fixed all of the presented warnings, four of which were bugs.