### PR TITLE
Make `Tunables` fields atomic to allow runtime configuration

### DIFF
--- a/crates/ziggurat-driver/src/zigbee_stack.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack.rs
@@ -41,7 +41,7 @@ mod zdp;
 pub use ziggurat_zigbee::aps::security as aps_security;
 pub use ziggurat_zigbee::aps::security::{ApsSecurity, TclkSeed};
 pub use ziggurat_zigbee::constants::{
-    MAX_DEPTH, PROTOCOL_VERSION, STACK_PROFILE, Tunables, WELL_KNOWN_LINK_KEY,
+    MAX_DEPTH, PROTOCOL_VERSION, STACK_PROFILE, TunableError, Tunables, WELL_KNOWN_LINK_KEY,
 };
 pub use ziggurat_zigbee::indirect::{IndirectQueue, SrcMatchTable, Transaction};
 pub use ziggurat_zigbee::nwk::NwkDeviceType;
@@ -668,27 +668,16 @@ pub struct State {
 }
 
 impl State {
-    pub fn new(config: &NetworkConfig, tunables: &Tunables) -> Self {
+    pub fn new(config: &NetworkConfig) -> Self {
         Self {
             core: Mutex::new(ZigbeeCore {
                 nib: Nib {
                     sequence_number: 0,
                     update_id: config.update_id,
                     tx_total: 0,
-                    neighbors: Neighbors::new(
-                        config.network_address,
-                        u32::from(tunables.router_age_limit) * tunables.link_status_period,
-                    ),
-                    routing: Routing::new(
-                        config.network_address,
-                        tunables.route_discovery_time,
-                        tunables.mtorr_route_error_threshold,
-                        tunables.mtorr_delivery_failure_threshold,
-                    ),
-                    broadcasts: Broadcasts::new(
-                        tunables.broadcast_delivery_time,
-                        tunables.broadcast_passive_ack_quorum,
-                    ),
+                    neighbors: Neighbors::default(),
+                    routing: Routing::default(),
+                    broadcasts: Broadcasts::default(),
                     nwk_security: NwkSecurity::new(
                         config.network_key.clone(),
                         config.network_key_seq_number,
@@ -709,7 +698,7 @@ impl State {
                     channel: config.channel,
                     ieee802154_sequence_number: 0,
                     pan_id: config.pan_id,
-                    indirect_queue: IndirectQueue::new(tunables.transaction_persistence_time),
+                    indirect_queue: IndirectQueue::default(),
                 },
                 permitting_joins_until: None,
                 trust_center_joins_until: None,
@@ -999,7 +988,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         Arc::new_cyclic(|weak_self| Self {
             self_weak: weak_self.clone(),
             start_time: R::now(),
-            state: State::new(&config, &tunables),
+            state: State::new(&config),
             config,
             tunables,
             radio,
@@ -1033,6 +1022,20 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         })
     }
 
+    /// Set a tunable by its Rust field name from a raw wire value. Takes effect on
+    /// the next read: in-flight waits (a sleeping retry, a stamped deadline) finish
+    /// under the value they started with.
+    pub fn set_tunable(&self, name: &str, raw: u64) -> Result<(), TunableError> {
+        // These size the global frame-token pool once, in `configure_frame_budget`.
+        if matches!(
+            name,
+            "frame_budget_bytes" | "critical_reserve_frames" | "forwarding_reserve_frames"
+        ) {
+            return Err(TunableError::StartupOnly);
+        }
+        self.tunables.set(name, raw)
+    }
+
     /// Size the frame-token budget from the platform's heap arena and the tunables.
     ///
     /// A token is priced at a parked frame's worst case: the queue entry plus its boxed
@@ -1054,7 +1057,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             return;
         }
 
-        let budget_bytes = match tunables.frame_budget_bytes {
+        let budget_bytes = match tunables.frame_budget_bytes() {
             0 => arena.saturating_sub(NON_FRAME_HEAP_CEILING),
             bytes => bytes,
         };
@@ -1063,14 +1066,14 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // A budget too small to hold the reserves means the platform's queue caps and
         // this ceiling need rethinking, not silent operation with a starved stack.
         assert!(
-            total > tunables.critical_reserve_frames + tunables.forwarding_reserve_frames,
+            total > tunables.critical_reserve_frames() + tunables.forwarding_reserve_frames(),
             "frame budget of {total} tokens cannot hold the configured reserves"
         );
 
         frame_token::set_budget(
             total,
-            tunables.critical_reserve_frames,
-            tunables.forwarding_reserve_frames,
+            tunables.critical_reserve_frames(),
+            tunables.forwarding_reserve_frames(),
         );
     }
 
@@ -1574,7 +1577,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                         channel: None,
                         csma_ca: true,
                         max_frame_retries: 0,
-                        max_csma_backoffs: self.tunables.mac_max_csma_backoffs,
+                        max_csma_backoffs: self.tunables.mac_max_csma_backoffs(),
                         security_processed: true,
                     })
                     .await;

--- a/crates/ziggurat-driver/src/zigbee_stack/aps.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/aps.rs
@@ -101,7 +101,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     /// are swept on each call.
     pub(super) fn is_duplicate_aps_frame(&self, source: Nwk, counter: u8) -> bool {
         let now = self.core_now();
-        let timeout = self.tunables.aps_duplicate_rejection_timeout;
+        let timeout = self.tunables.aps_duplicate_rejection_timeout();
 
         let mut table = self.state.aps_duplicates.lock();
         table.retain(|_, seen| now.saturating_duration_since(*seen) < timeout);
@@ -297,9 +297,9 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     /// sees (and acks) the frame after polling.
     fn aps_ack_timeout(&self, destination: Nwk) -> Duration {
         if self.sleepy_child_eui64(destination).is_some() {
-            self.tunables.aps_ack_timeout_indirect
+            self.tunables.aps_ack_timeout_indirect()
         } else {
-            self.tunables.aps_ack_timeout
+            self.tunables.aps_ack_timeout()
         }
     }
 

--- a/crates/ziggurat-driver/src/zigbee_stack/indirect.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/indirect.rs
@@ -21,10 +21,13 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     /// `poll_address`. Its `outcome` is resolved when the device extracts the frame, or
     /// with an error on expiry or eviction.
     pub(super) fn enqueue_indirect_frame(&self, frame: IndirectFrame, outcome: TxOutcome) {
-        self.core()
-            .mac
-            .indirect_queue
-            .push(frame.poll_address, frame, outcome, self.core_now());
+        self.core().mac.indirect_queue.push(
+            frame.poll_address,
+            frame,
+            outcome,
+            self.core_now(),
+            self.tunables.transaction_persistence_time(),
+        );
 
         self.src_match_sync.notify_one();
         self.maintenance_wake.notify_one();

--- a/crates/ziggurat-driver/src/zigbee_stack/joining.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/joining.rs
@@ -67,7 +67,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
 
             (
                 core.nib.neighbors.contains(source_eui64),
-                core.nib.neighbors.child_count() >= usize::from(self.tunables.max_children),
+                core.nib.neighbors.child_count() >= usize::from(self.tunables.max_children()),
             )
         };
 
@@ -102,7 +102,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // Spec 3.6.10.5: end device children start with the default keepalive
         // timeout; router children are not aged
         let device_timeout = if device_type == NwkDeviceType::EndDevice {
-            self.tunables.end_device_timeout_default.duration()
+            self.tunables.end_device_timeout_default().duration()
         } else {
             Duration::from_secs(0xFFFFFFFF)
         };
@@ -200,7 +200,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             let mut conflicts = self.state.address_conflicts.lock();
 
             let now = self.core_now();
-            let window = self.tunables.broadcast_delivery_time;
+            let window = self.tunables.broadcast_delivery_time();
 
             // Detection re-triggers on every frame from the conflicted devices, so a
             // conflict is handled once per delivery window
@@ -859,7 +859,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // Spec Table 4-7: Update-Device must be APS-encrypted when we share a unique link
         // key with the relaying router. Drop an unencrypted one from such a router unless
         // policy explicitly allows it.
-        if !aps_encrypted && !self.tunables.allow_unencrypted_router_device_update {
+        if !aps_encrypted && !self.tunables.allow_unencrypted_router_device_update() {
             let router_ieee = nwk_frame
                 .nwk_header
                 .source_ieee
@@ -1018,7 +1018,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     /// exposed under the well-known key); the `allow_unsecured_rejoins` policy overrides
     /// this for migration scenarios.
     fn may_rejoin_unsecured(&self, eui64: Eui64) -> bool {
-        self.tunables.allow_unsecured_rejoins
+        self.tunables.allow_unsecured_rejoins()
             || self.core().aib.aps_security.has_unique_link_key(eui64)
     }
 
@@ -1045,7 +1045,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
 
             (
                 core.nib.neighbors.contains(source_ieee),
-                core.nib.neighbors.child_count() >= usize::from(self.tunables.max_children),
+                core.nib.neighbors.child_count() >= usize::from(self.tunables.max_children()),
             )
         };
 
@@ -1086,7 +1086,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // Spec 3.6.10.5: end device children start with the default keepalive
         // timeout; router children are not aged
         let device_timeout = if device_type == NwkDeviceType::EndDevice {
-            self.tunables.end_device_timeout_default.duration()
+            self.tunables.end_device_timeout_default().duration()
         } else {
             Duration::from_secs(0xFFFFFFFF)
         };

--- a/crates/ziggurat-driver/src/zigbee_stack/joining.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/joining.rs
@@ -60,20 +60,27 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
 
         let permitting_joins = self.permitting_joins();
 
-        // Spec 3.6.1.6.1.3: known devices may always re-attach; new children are
-        // admitted only while capacity remains
+        let device_type = match request.device_type {
+            AssociationRequestDeviceType::FullFunctionDevice => NwkDeviceType::Router,
+            AssociationRequestDeviceType::ReducedFunctionDevice => NwkDeviceType::EndDevice,
+        };
+
+        // Spec 3.6.1.6.1.3: known devices may always re-attach; new end device
+        // children are admitted only while parent capacity remains. Routers are never
+        // capped: they use us as the network entry point, not as a parent.
         let (already_known, at_capacity) = {
             let core = self.core();
 
             (
                 core.nib.neighbors.contains(source_eui64),
-                core.nib.neighbors.child_count() >= usize::from(self.tunables.max_children()),
+                core.nib.neighbors.end_device_child_count()
+                    >= usize::from(self.tunables.max_children()),
             )
         };
 
         let denial_status = if !permitting_joins {
             Some(Ieee802154AssociationStatus::PanAccessDenied)
-        } else if !already_known && at_capacity {
+        } else if device_type == NwkDeviceType::EndDevice && !already_known && at_capacity {
             Some(Ieee802154AssociationStatus::PanAtCapacity)
         } else {
             None
@@ -93,11 +100,6 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // Joiners retry association requests if they miss our response, so the address
         // and table entries must be stable across retries
         self.update_nwk_eui64_mapping(short_address, source_eui64);
-
-        let device_type = match request.device_type {
-            AssociationRequestDeviceType::FullFunctionDevice => NwkDeviceType::Router,
-            AssociationRequestDeviceType::ReducedFunctionDevice => NwkDeviceType::EndDevice,
-        };
 
         // Spec 3.6.10.5: end device children start with the default keepalive
         // timeout; router children are not aged
@@ -1038,18 +1040,25 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         let requested_nwk = nwk_frame.nwk_header.source;
         let capability = &rejoin_request.capability_information;
 
-        // Spec 3.6.1.6.1.3: known devices may always re-attach; new children are
-        // admitted only while capacity remains
+        let device_type = match capability.device_type {
+            NwkRejoinCapabilityInformationDeviceType::Router => NwkDeviceType::Router,
+            NwkRejoinCapabilityInformationDeviceType::EndDevice => NwkDeviceType::EndDevice,
+        };
+
+        // Spec 3.6.1.6.1.3: known devices may always re-attach; new end device
+        // children are admitted only while parent capacity remains. Routers are never
+        // capped: they use us as the network entry point, not as a parent.
         let (already_known, at_capacity) = {
             let core = self.core();
 
             (
                 core.nib.neighbors.contains(source_ieee),
-                core.nib.neighbors.child_count() >= usize::from(self.tunables.max_children()),
+                core.nib.neighbors.end_device_child_count()
+                    >= usize::from(self.tunables.max_children()),
             )
         };
 
-        if !already_known && at_capacity {
+        if device_type == NwkDeviceType::EndDevice && !already_known && at_capacity {
             tracing::info!("Denying rejoin request from {source_ieee:?}, no child capacity left");
             self.send_rejoin_response(
                 requested_nwk,
@@ -1077,11 +1086,6 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         tracing::info!("Device {source_ieee:?} is rejoining as {assigned_nwk:?}");
 
         self.update_nwk_eui64_mapping(assigned_nwk, source_ieee);
-
-        let device_type = match capability.device_type {
-            NwkRejoinCapabilityInformationDeviceType::Router => NwkDeviceType::Router,
-            NwkRejoinCapabilityInformationDeviceType::EndDevice => NwkDeviceType::EndDevice,
-        };
 
         // Spec 3.6.10.5: end device children start with the default keepalive
         // timeout; router children are not aged

--- a/crates/ziggurat-driver/src/zigbee_stack/mac.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/mac.rs
@@ -74,7 +74,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         tracing::trace!("Sending 802.15.4 beacon frame (permitting joins: {permitting_joins})");
 
         let end_device_capacity =
-            { self.core().nib.neighbors.child_count() } < usize::from(self.tunables.max_children);
+            { self.core().nib.neighbors.child_count() } < usize::from(self.tunables.max_children());
 
         let (ieee802154_sequence_number, pan_id, update_id) = {
             let core = self.core();
@@ -420,8 +420,8 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 psdu: final_frame.to_bytes_without_fcs(),
                 channel: Some(channel),
                 csma_ca: true,
-                max_frame_retries: self.tunables.mac_max_frame_retries,
-                max_csma_backoffs: self.tunables.mac_max_csma_backoffs,
+                max_frame_retries: self.tunables.mac_max_frame_retries(),
+                max_csma_backoffs: self.tunables.mac_max_csma_backoffs(),
                 security_processed: true,
             })
             .await?;

--- a/crates/ziggurat-driver/src/zigbee_stack/mac.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/mac.rs
@@ -73,8 +73,10 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         let permitting_joins = self.permitting_joins();
         tracing::trace!("Sending 802.15.4 beacon frame (permitting joins: {permitting_joins})");
 
-        let end_device_capacity =
-            { self.core().nib.neighbors.child_count() } < usize::from(self.tunables.max_children());
+        // `max_children` caps end device children only; routers always join through
+        // us without consuming parent capacity, so router capacity is unconditional.
+        let end_device_capacity = { self.core().nib.neighbors.end_device_child_count() }
+            < usize::from(self.tunables.max_children());
 
         let (ieee802154_sequence_number, pan_id, update_id) = {
             let core = self.core();

--- a/crates/ziggurat-driver/src/zigbee_stack/neighbor.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/neighbor.rs
@@ -46,8 +46,12 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     }
 
     pub(super) fn maybe_age_neighbors(&self) {
+        // Link costs reset after `router_age_limit` missed link status periods
+        let max_age =
+            u32::from(self.tunables.router_age_limit()) * self.tunables.link_status_period();
+
         // TODO: this function should be replaced by real timers
-        let stale_neighbors = self.core().nib.neighbors.age(self.core_now());
+        let stale_neighbors = self.core().nib.neighbors.age(self.core_now(), max_age);
 
         for neighbor_nwk in stale_neighbors {
             self.invalidate_routes_via(neighbor_nwk);
@@ -70,6 +74,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         };
 
         let lost_link = self.core().nib.neighbors.on_link_status(
+            self.state.network_address,
             source_ieee,
             nwk_frame.nwk_header.source,
             lqi,
@@ -167,7 +172,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
 
     pub async fn periodic_link_status_broadcast_task(&self) {
         loop {
-            R::sleep(self.tunables.link_status_period).await;
+            R::sleep(self.tunables.link_status_period()).await;
 
             self.send_link_status_broadcast(false).await;
         }

--- a/crates/ziggurat-driver/src/zigbee_stack/nwk.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/nwk.rs
@@ -71,7 +71,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // We cannot handle broadcasts until the network has been running for at least
         // the time it takes to deliver one broadcast (core time starts at zero).
         if !self.state.hack_ignore_broadcast_startup_wait_period
-            && (CoreInstant::from_micros(0) + self.tunables.broadcast_delivery_time > now)
+            && (CoreInstant::from_micros(0) + self.tunables.broadcast_delivery_time() > now)
         {
             tracing::debug!("Filtering broadcast, network started too recently.");
             return true;
@@ -88,6 +88,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             sender_nwk,
             audience,
             now,
+            self.tunables.broadcast_delivery_time(),
         );
         drop(core);
 
@@ -160,7 +161,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
 
             let next_attempt = match schedule {
                 BroadcastSchedule::PassiveAck => {
-                    now + self.tunables.passive_ack_timeout + self.broadcast_jitter()
+                    now + self.tunables.passive_ack_timeout() + self.broadcast_jitter()
                 }
                 BroadcastSchedule::FixedInterval { interval } => now + interval,
             };
@@ -301,7 +302,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 class: TrafficClass::Critical,
             },
             BroadcastSchedule::FixedInterval {
-                interval: self.tunables.rreq_retry_interval,
+                interval: self.tunables.rreq_retry_interval(),
             },
             initial_delay,
             attempts,
@@ -312,7 +313,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     /// A random retransmission jitter in `[0, max_broadcast_jitter)` (spec 3.6.6).
     pub(super) fn broadcast_jitter(&self) -> Duration {
         self.tunables
-            .max_broadcast_jitter
+            .max_broadcast_jitter()
             .mul_f32(crate::rng::random_f32())
     }
 
@@ -322,9 +323,12 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         let core = self.core();
         let live_relayers = core.nib.neighbors.expected_broadcast_relayers();
 
-        core.nib
-            .broadcasts
-            .passively_acked(key.0, key.1, &live_relayers)
+        core.nib.broadcasts.passively_acked(
+            key.0,
+            key.1,
+            &live_relayers,
+            self.tunables.broadcast_passive_ack_quorum(),
+        )
     }
 
     pub fn handle_decrypted_frame(&self, nwk_frame: &NwkFrame, sender_nwk: Nwk, lqi: u8, rssi: i8) {
@@ -385,7 +389,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             // reach this point: the send path pre-fills the transaction table. The
             // frame is discarded instead of relayed (3.6.1.10).
             if nwk_frame.nwk_header.source == self.state.network_address {
-                if CoreInstant::from_micros(0) + self.tunables.broadcast_delivery_time
+                if CoreInstant::from_micros(0) + self.tunables.broadcast_delivery_time()
                     < self.core_now()
                 {
                     self.handle_address_conflict(
@@ -740,7 +744,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         self.core()
             .nib
             .routing
-            .route_to(destination, self.tunables.max_source_route)
+            .route_to(destination, self.tunables.max_source_route())
     }
 
     /// Originate a unicast and await its delivery result. The completion resolves once
@@ -897,7 +901,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 nwk_frame,
                 next_hop,
                 security,
-                attempts_remaining: self.tunables.unicast_retries,
+                attempts_remaining: self.tunables.unicast_retries(),
             },
             priority,
             outcome,
@@ -937,7 +941,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 .entry(destination)
                 .or_insert_with(|| PendingRoute {
                     frames: Vec::new(),
-                    attempts_remaining: self.tunables.pending_route_discovery_attempts,
+                    attempts_remaining: self.tunables.pending_route_discovery_attempts(),
                 })
                 .frames
                 .push(PendingFrame {
@@ -1332,7 +1336,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         outcome: TxOutcome,
         token: FrameToken,
     ) {
-        let delay = self.tunables.unicast_retry_delay;
+        let delay = self.tunables.unicast_retry_delay();
 
         // The frame has a random jitter of up to one retry delay period
         let jitter = delay.mul_f32(crate::rng::random_f32());
@@ -1526,9 +1530,13 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             let mut core = self.core();
             let audience = core.nib.neighbors.expected_broadcast_relayers();
 
-            core.nib
-                .broadcasts
-                .record_transmission(key.0, key.1, audience, self.core_now());
+            core.nib.broadcasts.record_transmission(
+                key.0,
+                key.1,
+                audience,
+                self.core_now(),
+                self.tunables.broadcast_delivery_time(),
+            );
         }
 
         // Transmit the first copy immediately; the reactor makes any retransmissions,
@@ -1547,8 +1555,8 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             security,
             policy,
             BroadcastSchedule::PassiveAck,
-            self.tunables.passive_ack_timeout + self.broadcast_jitter(),
-            self.tunables.max_broadcast_retries,
+            self.tunables.passive_ack_timeout() + self.broadcast_jitter(),
+            self.tunables.max_broadcast_retries(),
             request_id,
         );
     }
@@ -1666,7 +1674,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 NwkCommand::RouteRecord(route_record) => {
                     // Spec 3.6.4.5.5: with no room left for our address the route record
                     // is discarded rather than overflowing the frame.
-                    if route_record.relays.len() >= usize::from(self.tunables.max_source_route) {
+                    if route_record.relays.len() >= usize::from(self.tunables.max_source_route()) {
                         tracing::warn!("Dropping transiting route record: relay list is full");
                         return;
                     }
@@ -1847,7 +1855,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             },
             BroadcastSchedule::PassiveAck,
             self.broadcast_jitter(),
-            self.tunables.max_broadcast_retries + 1,
+            self.tunables.max_broadcast_retries() + 1,
             None,
         );
     }

--- a/crates/ziggurat-driver/src/zigbee_stack/route.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/route.rs
@@ -45,6 +45,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         let updated_path_cost = route_reply_cmd.path_cost;
 
         let disposition = self.core().nib.routing.accept_route_reply(
+            self.state.network_address,
             route_reply_cmd.originator_nwk,
             route_reply_cmd.route_request_identifier,
             route_reply_cmd.responder_nwk,
@@ -150,6 +151,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             updated_path_cost,
             route_request_cmd.many_to_one,
             self.core_now(),
+            self.tunables.route_discovery_time(),
         );
 
         if !accepted {
@@ -236,15 +238,20 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             .with_radius(rebroadcast_radius)
             .with_sequence_number(nwk_frame.nwk_header.sequence_number);
 
-        // Spec 3.6.4.5.1.4: relayed route requests are jittered and retried
-        let jitter = (self.tunables.min_rreq_jitter
-            + (self.tunables.max_rreq_jitter - self.tunables.min_rreq_jitter)
+        // Spec 3.6.4.5.1.4: relayed route requests are jittered and retried. The jitter
+        // bounds are loaded once and subtracted saturating: a runtime tunable change can
+        // transiently leave min above max.
+        let min_jitter = self.tunables.min_rreq_jitter();
+        let max_jitter = self.tunables.max_rreq_jitter();
+        let jitter = (min_jitter
+            + max_jitter
+                .saturating_sub(min_jitter)
                 .mul_f32(crate::rng::random_f32()))
             * 2;
 
         self.broadcast_route_request(
             relayed_route_request_cmd,
-            self.tunables.rreq_retries + 1,
+            self.tunables.rreq_retries() + 1,
             jitter,
         );
     }
@@ -254,11 +261,11 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     /// per-device route discoveries, and respond with route record commands that we
     /// store for future source routing.
     pub async fn send_many_to_one_route_request(&self) {
-        let route_request_identifier = self
-            .core()
-            .nib
-            .routing
-            .begin_many_to_one_advertisement(self.core_now());
+        let route_request_identifier = self.core().nib.routing.begin_many_to_one_advertisement(
+            self.state.network_address,
+            self.core_now(),
+            self.tunables.route_discovery_time(),
+        );
 
         tracing::debug!("Sending many-to-one route request {route_request_identifier}");
 
@@ -273,7 +280,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                     destination_eui64: None,
                 }),
             )
-            .with_radius(self.tunables.concentrator_radius)
+            .with_radius(self.tunables.concentrator_radius())
             // Sent via `transmit_*`, which does not assign sequence numbers
             .with_sequence_number(self.next_nwk_sequence_number());
 
@@ -297,7 +304,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // Receivers drop route requests from senders with a zero outgoing cost, so
         // the first advertisement waits until link status exchanges establish a
         // neighbor link, bounded by a fixed ceiling in case the network is silent
-        let startup_deadline = self.core_now() + 2 * self.tunables.link_status_period;
+        let startup_deadline = self.core_now() + 2 * self.tunables.link_status_period();
 
         loop {
             if self.core().nib.neighbors.any_live_router_link() {
@@ -318,8 +325,8 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
 
             self.core().nib.routing.reset_mtorr_triggers();
 
-            let min_deadline = self.core_now() + self.tunables.mtorr_min_interval;
-            let max_deadline = self.core_now() + self.tunables.mtorr_max_interval;
+            let min_deadline = self.core_now() + self.tunables.mtorr_min_interval();
+            let max_deadline = self.core_now() + self.tunables.mtorr_max_interval();
 
             // Advertise every max interval, sooner when accumulated route errors or
             // delivery failures signal that routes toward us have gone bad, but never
@@ -342,7 +349,11 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             return;
         }
 
-        let kick = self.core().nib.routing.note_route_error();
+        let kick = self
+            .core()
+            .nib
+            .routing
+            .note_route_error(self.tunables.mtorr_route_error_threshold());
 
         if kick {
             self.mtorr_kick.notify_one();
@@ -356,7 +367,11 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
             return;
         }
 
-        let kick = self.core().nib.routing.note_delivery_failure();
+        let kick = self
+            .core()
+            .nib
+            .routing
+            .note_delivery_failure(self.tunables.mtorr_delivery_failure_threshold());
 
         if kick {
             self.mtorr_kick.notify_one();
@@ -442,11 +457,12 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
     pub(super) fn send_route_discovery(&self, destination: Nwk) {
         tracing::debug!("Sending route discovery for NWK {destination:?}");
 
-        let route_request_identifier = self
-            .core()
-            .nib
-            .routing
-            .begin_discovery(destination, self.core_now());
+        let route_request_identifier = self.core().nib.routing.begin_discovery(
+            self.state.network_address,
+            destination,
+            self.core_now(),
+            self.tunables.route_discovery_time(),
+        );
 
         // If we know the EUI64 corresponding to the NWK, use it
         let destination_eui64 = self.core().nib.address_map.eui64_for(destination);
@@ -470,7 +486,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         // times, separated by the retry interval
         self.broadcast_route_request(
             route_request_frame,
-            self.tunables.initial_rreq_retries + 1,
+            self.tunables.initial_rreq_retries() + 1,
             Duration::ZERO,
         );
     }

--- a/crates/ziggurat-driver/src/zigbee_stack/zdp.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/zdp.rs
@@ -328,10 +328,10 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
         loop {
             let jitter = self
                 .tunables
-                .parent_annce_jitter_max
+                .parent_annce_jitter_max()
                 .mul_f32(crate::rng::random_f32());
             let slept_at = self.core_now();
-            R::sleep(self.tunables.parent_annce_base_timer + jitter).await;
+            R::sleep(self.tunables.parent_annce_base_timer() + jitter).await;
 
             // Spec 2.4.3.1.12.2: an announcement from another router restarts the
             // countdown

--- a/crates/ziggurat-ncp-api/src/protocol.rs
+++ b/crates/ziggurat-ncp-api/src/protocol.rs
@@ -144,6 +144,10 @@ async fn dispatch<P: RadioPhy>(
         Request::PacketCaptureChannel(payload) => {
             handle_packet_capture_channel(app, payload).await
         }
+        Request::SetTunable(payload) => {
+            proto::set_tunable(&**configured(app)?, &payload)?;
+            Ok(Response::Empty)
+        }
     }
 }
 

--- a/crates/ziggurat-ncp-api/src/protocol.rs
+++ b/crates/ziggurat-ncp-api/src/protocol.rs
@@ -216,7 +216,7 @@ async fn handle_configure<P: RadioPhy>(
     }
     app.started = false;
 
-    let stack = ZigbeeStack::new(app.phy.clone(), config, Tunables::new(), app.spawner);
+    let stack = ZigbeeStack::new(app.phy.clone(), config, Tunables::default(), app.spawner);
     stack
         .state
         .core

--- a/crates/ziggurat-protocol/src/bridge.rs
+++ b/crates/ziggurat-protocol/src/bridge.rs
@@ -272,6 +272,20 @@ pub fn send_aps<P: RadioPhy, R: Runtime>(
         .map_err(|e| Error::new(Status::TransmitFailed, &e.to_string()))
 }
 
+/// Apply a `set_tunable` to the stack: the name is matched against the Rust field
+/// names of `Tunables`, the raw value decoded per the field's type.
+pub fn set_tunable<P: RadioPhy, R: Runtime>(
+    stack: &ZigbeeStack<P, R>,
+    payload: &SetTunablePayload,
+) -> Result<(), Error> {
+    let name = core::str::from_utf8(&payload.name)
+        .map_err(|_| Error::new(Status::InvalidRequest, "tunable name is not UTF-8"))?;
+
+    stack
+        .set_tunable(name, payload.value)
+        .map_err(|e| Error::new(Status::InvalidRequest, &alloc::format!("{name}: {e}")))
+}
+
 /// Encode one unsolicited notification. `send_confirm`/`aps_ack_confirm` carry
 /// their originating request id in the envelope.
 pub fn notification_frame(update: &ZigbeeNotification) -> Option<Vec<u8>> {

--- a/crates/ziggurat-protocol/src/wire.rs
+++ b/crates/ziggurat-protocol/src/wire.rs
@@ -49,6 +49,7 @@ pub enum CommandId {
     NetworkScan = 0x26,
     PacketCapture = 0x27,
     PacketCaptureChannel = 0x28,
+    SetTunable = 0x29,
     // More notifications.
     ReceivedAps = 0x30,
     SendConfirm = 0x31,
@@ -369,6 +370,19 @@ pub struct ProvisionalKeyPayload {
     pub key: Key,
 }
 
+/// Sets one driver tunable by its Rust field name (see the `tunables!` block in
+/// `ziggurat-zigbee`). The value is type-punned into a `u64`: integers as-is,
+/// bools as 0/1, durations in microseconds, enums as their discriminant; the
+/// stack rejects out-of-range values and unknown names.
+#[abstract_bits]
+#[derive(Debug, Clone)]
+pub struct SetTunablePayload {
+    pub name_len: u8,
+    #[abstract_bits(length_from = name_len)]
+    pub name: Vec<u8>,
+    pub value: u64,
+}
+
 #[abstract_bits]
 #[derive(Debug, Clone)]
 pub struct ScanRequestPayload {
@@ -556,6 +570,7 @@ pub enum Request {
     NetworkScan(ScanRequestPayload),
     PacketCapture(ChannelPayload),
     PacketCaptureChannel(ChannelPayload),
+    SetTunable(SetTunablePayload),
 }
 
 impl Request {
@@ -589,6 +604,7 @@ impl Request {
             CommandId::PacketCaptureChannel => {
                 Self::PacketCaptureChannel(require(payload, "channel")?)
             }
+            CommandId::SetTunable => Self::SetTunable(require(payload, "set_tunable")?),
             // Everything else (the device -> host notification opcodes) is not a request.
             _ => return Err(Error::new(Status::UnknownCommand, "not a request")),
         })

--- a/crates/ziggurat-server/src/main.rs
+++ b/crates/ziggurat-server/src/main.rs
@@ -523,6 +523,10 @@ impl ZigguratServer {
                     .await
             }
             R::PacketCaptureChannel(payload) => self.handle_packet_capture_channel(payload).await,
+            R::SetTunable(payload) => {
+                proto::set_tunable(&*self.configured()?, &payload)?;
+                Ok(proto::Response::Empty)
+            }
         }
     }
 

--- a/crates/ziggurat-server/src/main.rs
+++ b/crates/ziggurat-server/src/main.rs
@@ -583,7 +583,7 @@ impl ZigguratServer {
         let stack = ZigbeeStack::new(
             phy,
             proto::network_config(&payload),
-            Tunables::new(),
+            Tunables::default(),
             TokioSpawner::default(),
         );
         stack

--- a/crates/ziggurat-zigbee/src/constants.rs
+++ b/crates/ziggurat-zigbee/src/constants.rs
@@ -1,4 +1,10 @@
+use core::fmt;
+use core::marker::PhantomData;
+use core::sync::atomic::Ordering::Relaxed;
+use core::sync::atomic::{AtomicBool, AtomicU8, AtomicU32, AtomicUsize};
 use core::time::Duration;
+
+use num_enum::TryFromPrimitive;
 
 use ziggurat_ieee_802154::types::Key;
 
@@ -17,166 +23,354 @@ pub const MAX_DEPTH: u8 = 15;
 /// The well-known global link key most joins encrypt the network key with.
 pub const WELL_KNOWN_LINK_KEY: Key = Key::from_string(b"ZigBeeAlliance09");
 
-/// Protocol parameters and policy knobs, initialized to spec-derived defaults.
-/// Unlike the module-level constants above, every field here is tweakable.
-#[derive(Debug)]
-pub struct Tunables {
-    pub concentrator_radius: u8,
-    pub transaction_persistence_time: Duration,
-    pub max_source_route: u8,
-    pub max_children: u8,
+/// A tunable set that failed: the driver maps these onto a protocol error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TunableError {
+    UnknownName,
+    InvalidValue,
+    /// The value feeds startup-only sizing (the frame budget) and cannot change on a
+    /// live stack.
+    StartupOnly,
+}
+
+impl fmt::Display for TunableError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::UnknownName => "unknown tunable",
+            Self::InvalidValue => "value out of range",
+            Self::StartupOnly => "tunable only applies at configure time",
+        })
+    }
+}
+
+/// A `Duration` stored as atomic microseconds, so tunables need no lock.
+///
+/// The `u32` backing (the widest atomic on every target, including the 32-bit MCUs)
+/// caps it at ~71.6 minutes; every protocol timer is seconds-scale.
+pub struct AtomicDuration(AtomicU32);
+
+impl AtomicDuration {
+    pub const fn new(duration: Duration) -> Self {
+        Self(AtomicU32::new(duration.as_micros() as u32))
+    }
+
+    pub fn load(&self) -> Duration {
+        Duration::from_micros(self.0.load(Relaxed).into())
+    }
+
+    pub fn store(&self, duration: Duration) {
+        self.0.store(duration.as_micros() as u32, Relaxed);
+    }
+}
+
+impl fmt::Debug for AtomicDuration {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.load(), f)
+    }
+}
+
+/// An enum stored as its `u8` discriminant in an atomic.
+pub struct AtomicEnum<T>(AtomicU8, PhantomData<T>);
+
+impl<T: Copy + Into<u8> + TryFromPrimitive<Primitive = u8>> AtomicEnum<T> {
+    pub fn new(value: T) -> Self {
+        Self(AtomicU8::new(value.into()), PhantomData)
+    }
+
+    pub fn load(&self) -> T {
+        // Only `store` writes here, so the discriminant is always valid.
+        T::try_from_primitive(self.0.load(Relaxed)).unwrap_or_else(|_| unreachable!())
+    }
+
+    pub fn store(&self, value: T) {
+        self.0.store(value.into(), Relaxed);
+    }
+}
+
+impl<T: Copy + Into<u8> + TryFromPrimitive<Primitive = u8> + fmt::Debug> fmt::Debug
+    for AtomicEnum<T>
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(&self.load(), f)
+    }
+}
+
+/// A [`Tunables`] field type.
+///
+/// Defines how the type is stored atomically and how it decodes from the wire's
+/// `u64` value (bools are 0/1, durations are microseconds, enums are their
+/// discriminant). `decode` rejects anything out of range.
+pub trait TunableValue: Sized {
+    type Atomic;
+
+    fn new_atomic(value: Self) -> Self::Atomic;
+    fn load(atomic: &Self::Atomic) -> Self;
+    fn store(value: Self, atomic: &Self::Atomic);
+    fn decode(raw: u64) -> Option<Self>;
+}
+
+impl TunableValue for u8 {
+    type Atomic = AtomicU8;
+
+    fn new_atomic(value: Self) -> Self::Atomic {
+        AtomicU8::new(value)
+    }
+
+    fn load(atomic: &Self::Atomic) -> Self {
+        atomic.load(Relaxed)
+    }
+
+    fn store(value: Self, atomic: &Self::Atomic) {
+        atomic.store(value, Relaxed);
+    }
+
+    fn decode(raw: u64) -> Option<Self> {
+        Self::try_from(raw).ok()
+    }
+}
+
+impl TunableValue for usize {
+    type Atomic = AtomicUsize;
+
+    fn new_atomic(value: Self) -> Self::Atomic {
+        AtomicUsize::new(value)
+    }
+
+    fn load(atomic: &Self::Atomic) -> Self {
+        atomic.load(Relaxed)
+    }
+
+    fn store(value: Self, atomic: &Self::Atomic) {
+        atomic.store(value, Relaxed);
+    }
+
+    fn decode(raw: u64) -> Option<Self> {
+        Self::try_from(raw).ok()
+    }
+}
+
+impl TunableValue for bool {
+    type Atomic = AtomicBool;
+
+    fn new_atomic(value: Self) -> Self::Atomic {
+        AtomicBool::new(value)
+    }
+
+    fn load(atomic: &Self::Atomic) -> Self {
+        atomic.load(Relaxed)
+    }
+
+    fn store(value: Self, atomic: &Self::Atomic) {
+        atomic.store(value, Relaxed);
+    }
+
+    fn decode(raw: u64) -> Option<Self> {
+        match raw {
+            0 => Some(false),
+            1 => Some(true),
+            _ => None,
+        }
+    }
+}
+
+impl TunableValue for Duration {
+    type Atomic = AtomicDuration;
+
+    fn new_atomic(value: Self) -> Self::Atomic {
+        AtomicDuration::new(value)
+    }
+
+    fn load(atomic: &Self::Atomic) -> Self {
+        atomic.load()
+    }
+
+    fn store(value: Self, atomic: &Self::Atomic) {
+        atomic.store(value);
+    }
+
+    fn decode(raw: u64) -> Option<Self> {
+        // Bound the microseconds to the `AtomicDuration` backing width.
+        u32::try_from(raw)
+            .ok()
+            .map(|micros| Self::from_micros(micros.into()))
+    }
+}
+
+impl TunableValue for EndDeviceTimeout {
+    type Atomic = AtomicEnum<Self>;
+
+    fn new_atomic(value: Self) -> Self::Atomic {
+        AtomicEnum::new(value)
+    }
+
+    fn load(atomic: &Self::Atomic) -> Self {
+        atomic.load()
+    }
+
+    fn store(value: Self, atomic: &Self::Atomic) {
+        atomic.store(value);
+    }
+
+    fn decode(raw: u64) -> Option<Self> {
+        Self::try_from_primitive(u8::try_from(raw).ok()?).ok()
+    }
+}
+
+/// Defines [`Tunables`] once: the struct, its defaults, the typed getters, and the
+/// by-field-name `set` used by the `SetTunable` protocol command all come from this
+/// single field list.
+macro_rules! tunables {
+    ($($(#[$attr:meta])* $name:ident: $ty:ty = $default:expr,)*) => {
+        /// Protocol parameters and policy knobs, initialized to spec-derived defaults.
+        ///
+        /// Unlike the module-level constants above, every field here is tweakable at
+        /// runtime: values are stored atomically and read at each use, so a `set`
+        /// takes effect on the next read (in-flight waits and stamped deadlines
+        /// finish under the value they started with).
+        #[derive(Debug)]
+        pub struct Tunables {
+            $($name: <$ty as TunableValue>::Atomic,)*
+        }
+
+        impl Default for Tunables {
+            fn default() -> Self {
+                Self {
+                    $($name: <$ty as TunableValue>::new_atomic($default),)*
+                }
+            }
+        }
+
+        impl Tunables {
+            $(
+                $(#[$attr])*
+                pub fn $name(&self) -> $ty {
+                    <$ty as TunableValue>::load(&self.$name)
+                }
+            )*
+
+            /// Set a tunable from its Rust field name and a raw wire value.
+            pub fn set(&self, name: &str, raw: u64) -> Result<(), TunableError> {
+                match name {
+                    $(stringify!($name) => {
+                        let value = <$ty as TunableValue>::decode(raw)
+                            .ok_or(TunableError::InvalidValue)?;
+                        <$ty as TunableValue>::store(value, &self.$name);
+                    })*
+                    _ => return Err(TunableError::UnknownName),
+                }
+                Ok(())
+            }
+        }
+    };
+}
+
+tunables! {
+    concentrator_radius: u8 = 10,
+    transaction_persistence_time: Duration = Duration::from_millis(7680),
+    max_source_route: u8 = 12,
+    max_children: u8 = 32,
 
     /// Trust center policy: allow an unsecured (trust center) rejoin from a device that
     /// has not established a unique link key. Off by default — such a rejoin re-delivers
     /// the network key encrypted with the well-known key, exposing it to anyone who
     /// knows that key (spec 4.7.3.6).
-    pub allow_unsecured_rejoins: bool,
+    allow_unsecured_rejoins: bool = false,
 
     /// Trust center policy: accept an Update-Device command that is not APS-encrypted
     /// from a router with which we share a unique trust center link key. Off by default
     /// (spec Table 4-7 requires APS encryption in that case).
-    pub allow_unencrypted_router_device_update: bool,
+    allow_unencrypted_router_device_update: bool = false,
 
-    pub passive_ack_timeout: Duration,
+    passive_ack_timeout: Duration = Duration::from_millis(500),
 
     /// The maximum number of retries allowed after a broadcast transmission failure.
-    pub max_broadcast_retries: u8,
+    max_broadcast_retries: u8 = 2,
 
     /// A broadcast with at least this many expected relayers is considered passively
     /// acknowledged once this many of them have been heard, instead of all of them.
     // TODO: replace the fixed quorum with probabilistic modeling of propagation,
     // e.g. per-neighbor estimates of how reliably we hear their rebroadcasts
-    pub broadcast_passive_ack_quorum: usize,
+    broadcast_passive_ack_quorum: usize = 8,
 
     /// The minimum time between two consecutive many-to-one route requests, even when
     /// error thresholds are crossed.
-    pub mtorr_min_interval: Duration,
+    mtorr_min_interval: Duration = Duration::from_secs(10),
 
     /// The maximum time between two consecutive many-to-one route requests; the
     /// baseline advertisement period.
-    pub mtorr_max_interval: Duration,
+    mtorr_max_interval: Duration = Duration::from_secs(60),
 
     /// The number of received route-failure network status commands that triggers an
     /// early many-to-one route request.
-    pub mtorr_route_error_threshold: u8,
+    mtorr_route_error_threshold: u8 = 3,
 
     /// The number of locally failed unicast deliveries that triggers an early
     /// many-to-one route request.
-    pub mtorr_delivery_failure_threshold: u8,
+    mtorr_delivery_failure_threshold: u8 = 1,
 
     /// The time between link status command frames.
-    pub link_status_period: Duration,
+    link_status_period: Duration = Duration::from_secs(15),
 
     /// The number of missed link status command frames before resetting the link costs
     /// to zero.
-    pub router_age_limit: u8,
+    router_age_limit: u8 = 3,
 
-    pub route_discovery_time: Duration,
-    pub max_broadcast_jitter: Duration,
-    pub initial_rreq_retries: u8,
-    pub rreq_retries: u8,
-    pub rreq_retry_interval: Duration,
-    pub min_rreq_jitter: Duration,
-    pub max_rreq_jitter: Duration,
-    pub unicast_retries: u8,
-    pub unicast_retry_delay: Duration,
-    pub broadcast_delivery_time: Duration,
+    route_discovery_time: Duration = Duration::from_millis(10000),
+    max_broadcast_jitter: Duration = Duration::from_millis(64),
+    initial_rreq_retries: u8 = 3,
+    rreq_retries: u8 = 2,
+    rreq_retry_interval: Duration = Duration::from_millis(254),
+    min_rreq_jitter: Duration = Duration::from_millis(2),
+    max_rreq_jitter: Duration = Duration::from_millis(128),
+    unicast_retries: u8 = 3,
+    unicast_retry_delay: Duration = Duration::from_millis(50),
+    broadcast_delivery_time: Duration = Duration::from_millis(9000),
 
     /// How many route discoveries a frame parked awaiting a route will trigger before it
     /// is discarded. `1` (the default) means a single discovery: if it fails, every frame
     /// waiting on that destination inherits the failure. Higher values keep the parked
     /// frames waiting while discovery is retried, the whole bucket riding along together.
-    pub pending_route_discovery_attempts: u8,
+    pending_route_discovery_attempts: u8 = 1,
 
     /// The default timeout for any end device child that does not negotiate a
     /// different value via the End Device Timeout Request command (spec 3.6.10.2).
-    pub end_device_timeout_default: EndDeviceTimeout,
+    end_device_timeout_default: EndDeviceTimeout = EndDeviceTimeout::Minutes256,
 
     /// `apsParentAnnounceBaseTimer`: the base delay before each broadcast parent
     /// announcement.
-    pub parent_annce_base_timer: Duration,
+    parent_annce_base_timer: Duration = Duration::from_secs(10),
 
     /// `apsParentAnnounceJitterMax`: the maximum random addition to
     /// [`Self::parent_annce_base_timer`].
-    pub parent_annce_jitter_max: Duration,
+    parent_annce_jitter_max: Duration = Duration::from_secs(10),
 
     /// Spec 2.2.8.4.2: how long an (originator, APS counter) pair is remembered for
     /// duplicate rejection. Must cover the sender's full APS retransmission window.
-    pub aps_duplicate_rejection_timeout: Duration,
+    aps_duplicate_rejection_timeout: Duration = Duration::from_secs(9),
 
-    pub aps_ack_timeout: Duration,
+    aps_ack_timeout: Duration = Duration::from_millis(5000),
 
     /// APS acks from a sleepy child arrive only after it polls for the frame, so the
     /// wait must cover a full indirect transaction lifetime (7.68s) plus the ack's trip
     /// back.
-    pub aps_ack_timeout_indirect: Duration,
+    aps_ack_timeout_indirect: Duration = Duration::from_millis(10000),
 
     /// `macMaxCSMABackoffs`: how many times the radio backs off on a busy channel before
     /// declaring a transmit failed.
-    pub mac_max_csma_backoffs: u8,
+    mac_max_csma_backoffs: u8 = 2,
 
     /// `macMaxFrameRetries`: how many times the radio retransmits a unicast that goes
     /// unacknowledged before declaring it failed.
-    pub mac_max_frame_retries: u8,
+    mac_max_frame_retries: u8 = 5,
 
     /// Bytes of heap the driver may hold in parked frames. 0 derives it from the
     /// platform's heap arena minus a worst-case ceiling for everything else.
-    pub frame_budget_bytes: usize,
+    frame_budget_bytes: usize = 0,
 
     /// Frame tokens only stack-critical traffic may use.
-    pub critical_reserve_frames: usize,
+    critical_reserve_frames: usize = 32,
 
     /// Frame tokens reserved for transit traffic, so a host flood cannot stop the
     /// device from routing.
-    pub forwarding_reserve_frames: usize,
-}
-
-impl Default for Tunables {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl Tunables {
-    pub const fn new() -> Self {
-        Self {
-            passive_ack_timeout: Duration::from_millis(500),
-            max_broadcast_retries: 2,
-            broadcast_passive_ack_quorum: 8,
-            max_children: 32,
-            allow_unsecured_rejoins: false,
-            allow_unencrypted_router_device_update: false,
-            max_source_route: 12,
-            transaction_persistence_time: Duration::from_millis(7680),
-            concentrator_radius: 10,
-            mtorr_min_interval: Duration::from_secs(10),
-            mtorr_max_interval: Duration::from_secs(60),
-            mtorr_route_error_threshold: 3,
-            mtorr_delivery_failure_threshold: 1,
-            link_status_period: Duration::from_secs(15),
-            router_age_limit: 3,
-            route_discovery_time: Duration::from_millis(10000),
-            max_broadcast_jitter: Duration::from_millis(64),
-            initial_rreq_retries: 3,
-            rreq_retries: 2,
-            rreq_retry_interval: Duration::from_millis(254),
-            min_rreq_jitter: Duration::from_millis(2),
-            max_rreq_jitter: Duration::from_millis(128),
-            unicast_retries: 3,
-            unicast_retry_delay: Duration::from_millis(50),
-            broadcast_delivery_time: Duration::from_millis(9000),
-            pending_route_discovery_attempts: 1,
-            end_device_timeout_default: EndDeviceTimeout::Minutes256,
-            parent_annce_base_timer: Duration::from_secs(10),
-            parent_annce_jitter_max: Duration::from_secs(10),
-            aps_duplicate_rejection_timeout: Duration::from_secs(9),
-            aps_ack_timeout: Duration::from_millis(5000),
-            aps_ack_timeout_indirect: Duration::from_millis(10000),
-            mac_max_csma_backoffs: 2,
-            mac_max_frame_retries: 5,
-            frame_budget_bytes: 0,
-            critical_reserve_frames: 32,
-            forwarding_reserve_frames: 16,
-        }
-    }
+    forwarding_reserve_frames: usize = 16,
 }

--- a/crates/ziggurat-zigbee/src/indirect.rs
+++ b/crates/ziggurat-zigbee/src/indirect.rs
@@ -74,26 +74,35 @@ impl SrcMatchTable {
 /// address.
 #[derive(Debug)]
 pub struct IndirectQueue<F, C> {
-    /// How long a transaction awaits a poll before expiring
-    persistence_time: Duration,
     queue: FlatMap<Ieee802154Address, VecDeque<Transaction<F, C>>>,
 }
 
-impl<F, C> IndirectQueue<F, C> {
-    pub const fn new(persistence_time: Duration) -> Self {
+// Not derived: a derive would demand `F: Default, C: Default` for a field that
+// needs neither.
+impl<F, C> Default for IndirectQueue<F, C> {
+    fn default() -> Self {
         Self {
-            persistence_time,
             queue: FlatMap::new(),
         }
     }
+}
 
-    pub fn push(&mut self, destination: Ieee802154Address, frame: F, completion: C, now: Instant) {
+impl<F, C> IndirectQueue<F, C> {
+    /// Queue a frame to await a poll; it expires after `persistence_time` without one.
+    pub fn push(
+        &mut self,
+        destination: Ieee802154Address,
+        frame: F,
+        completion: C,
+        now: Instant,
+        persistence_time: Duration,
+    ) {
         self.queue
             .entry(destination)
             .or_default()
             .push_back(Transaction {
                 frame,
-                expires_at: now + self.persistence_time,
+                expires_at: now + persistence_time,
                 completion,
             });
     }

--- a/crates/ziggurat-zigbee/src/nwk/broadcasts.rs
+++ b/crates/ziggurat-zigbee/src/nwk/broadcasts.rs
@@ -23,25 +23,12 @@ struct Transaction {
 
 /// The NWK broadcast transaction table: deduplication of received broadcasts and
 /// passive acknowledgment accounting (spec 3.6.6).
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Broadcasts {
-    /// How long a transaction stays in the table (`nwkNetworkBroadcastDeliveryTime`)
-    delivery_time: Duration,
-    /// A broadcast with at least this many expected relayers is considered passively
-    /// acknowledged once this many of them have been heard, instead of all of them
-    quorum: usize,
     table: FlatMap<(Nwk, u8), Transaction>,
 }
 
 impl Broadcasts {
-    pub const fn new(delivery_time: Duration, quorum: usize) -> Self {
-        Self {
-            delivery_time,
-            quorum,
-            table: FlatMap::new(),
-        }
-    }
-
     /// Digest a received broadcast. Returns true for a known transaction, which also
     /// records the sender's passive acknowledgment: the frame is a duplicate and must
     /// be filtered. An unknown broadcast creates a transaction expecting passive acks
@@ -53,6 +40,7 @@ impl Broadcasts {
         sender: Nwk,
         audience: Vec<Nwk>,
         now: Instant,
+        delivery_time: Duration,
     ) -> bool {
         self.table.retain(|_, entry| entry.expiration_time > now);
 
@@ -66,7 +54,7 @@ impl Broadcasts {
         self.table.insert(
             (source, sequence_number),
             Transaction {
-                expiration_time: now + self.delivery_time,
+                expiration_time: now + delivery_time,
                 expected_relayers: audience,
                 // Whoever delivered the frame to us has already broadcast it
                 heard_from: FlatSet::from([sender]),
@@ -84,11 +72,12 @@ impl Broadcasts {
         sequence_number: u8,
         audience: Vec<Nwk>,
         now: Instant,
+        delivery_time: Duration,
     ) {
         self.table.insert(
             (source, sequence_number),
             Transaction {
-                expiration_time: now + self.delivery_time,
+                expiration_time: now + delivery_time,
                 expected_relayers: audience,
                 heard_from: FlatSet::new(),
             },
@@ -101,7 +90,13 @@ impl Broadcasts {
     /// unreasonable to wait for all ~40 nearby routers, so _enough_ of them suffice.
     /// An absent (expired) transaction means the delivery window has already closed,
     /// which counts as acknowledged.
-    pub fn passively_acked(&self, source: Nwk, sequence_number: u8, live_relayers: &[Nwk]) -> bool {
+    pub fn passively_acked(
+        &self,
+        source: Nwk,
+        sequence_number: u8,
+        live_relayers: &[Nwk],
+        quorum: usize,
+    ) -> bool {
         self.table
             .get(&(source, sequence_number))
             .is_none_or(|transaction| {
@@ -117,7 +112,7 @@ impl Broadcasts {
                     .filter(|nwk| transaction.heard_from.contains(nwk))
                     .count();
 
-                heard >= audience.len().min(self.quorum)
+                heard >= audience.len().min(quorum)
             })
     }
 }

--- a/crates/ziggurat-zigbee/src/nwk/commands.rs
+++ b/crates/ziggurat-zigbee/src/nwk/commands.rs
@@ -264,7 +264,9 @@ pub struct NwkLeaveCommand {
 }
 
 #[abstract_bits(bits = 8)]
-#[derive(Debug, Eq, PartialEq, Clone, Copy)]
+#[derive(
+    Debug, Eq, PartialEq, Clone, Copy, num_enum::TryFromPrimitive, num_enum::IntoPrimitive,
+)]
 #[repr(u8)]
 pub enum EndDeviceTimeout {
     Seconds10 = 0,

--- a/crates/ziggurat-zigbee/src/nwk/neighbors.rs
+++ b/crates/ziggurat-zigbee/src/nwk/neighbors.rs
@@ -168,11 +168,8 @@ pub struct NeighborLink {
 }
 
 /// The neighbor table: link quality accounting, link status digestion, and aging.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Neighbors {
-    network_address: Nwk,
-    /// Neighbors silent for this long get their link costs reset
-    max_age: Duration,
     table: FlatMap<Eui64, TableEntry>,
     /// LQI samples for senders that have no neighbor entry yet, capped at
     /// [`PENDING_LQA_CAP`] entries.
@@ -180,15 +177,6 @@ pub struct Neighbors {
 }
 
 impl Neighbors {
-    pub const fn new(network_address: Nwk, max_age: Duration) -> Self {
-        Self {
-            network_address,
-            max_age,
-            table: FlatMap::new(),
-            pending_lqas: FlatMap::new(),
-        }
-    }
-
     /// Record an LQI sample for the device that transmitted a frame to us. LQA is a
     /// property of the radio link to the MAC transmitter; the frame's NWK originator
     /// may be several hops away.
@@ -529,17 +517,16 @@ impl Neighbors {
             .collect()
     }
 
-    /// Reset link costs of neighbors that have stopped sending link status frames,
-    /// returning their addresses so routes through them can be invalidated.
+    /// Reset link costs of neighbors that have been silent for `max_age` (stopped
+    /// sending link status frames), returning their addresses so routes through them
+    /// can be invalidated.
     #[must_use = "routes through the returned aged-out neighbors must be invalidated; \
         dropping them leaves stale routes"]
-    pub fn age(&mut self, now: Instant) -> Vec<Nwk> {
+    pub fn age(&mut self, now: Instant, max_age: Duration) -> Vec<Nwk> {
         let mut stale_neighbors = Vec::new();
 
         for neighbor in self.table.values_mut() {
-            if neighbor.outgoing_cost > 0
-                && neighbor.last_link_status_timestamp + self.max_age <= now
-            {
+            if neighbor.outgoing_cost > 0 && neighbor.last_link_status_timestamp + max_age <= now {
                 neighbor.lqas.clear();
                 neighbor.outgoing_cost = 0;
                 stale_neighbors.push(neighbor.network_address);
@@ -619,6 +606,7 @@ impl Neighbors {
     /// routes through it must be invalidated (spec 3.6.4.4.2).
     pub fn on_link_status(
         &mut self,
+        own_address: Nwk,
         source_ieee: Eui64,
         source_nwk: Nwk,
         lqi: u8,
@@ -705,7 +693,7 @@ impl Neighbors {
                 }
             }
 
-            if link_status.address == self.network_address {
+            if link_status.address == own_address {
                 neighbor_entry.outgoing_cost = link_status.incoming_cost;
             }
         }

--- a/crates/ziggurat-zigbee/src/nwk/neighbors.rs
+++ b/crates/ziggurat-zigbee/src/nwk/neighbors.rs
@@ -267,9 +267,13 @@ impl Neighbors {
         self.table.contains_key(&eui64)
     }
 
-    /// The number of children, for join admission and beacon capacity decisions.
-    pub fn child_count(&self) -> usize {
-        self.table.values().filter(|entry| entry.is_child()).count()
+    /// The number of end device children, for join admission and beacon capacity
+    /// decisions.
+    pub fn end_device_child_count(&self) -> usize {
+        self.table
+            .values()
+            .filter(|entry| entry.is_child() && entry.device_type == NwkDeviceType::EndDevice)
+            .count()
     }
 
     /// Spec 3.6.10.4: a MAC data poll from a known device refreshes its keepalive

--- a/crates/ziggurat-zigbee/src/nwk/routing.rs
+++ b/crates/ziggurat-zigbee/src/nwk/routing.rs
@@ -151,18 +151,13 @@ pub enum RouteReplyDisposition {
 
 /// The NWK routing layer: route table, route discovery table, and route record table,
 /// with the decision logic for route request/reply processing.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct Routing {
-    network_address: Nwk,
-    route_discovery_time: Duration,
-
     /// Route-repair signals counted since the last many-to-one route request
     /// (route-failure network statuses and locally failed unicast deliveries);
     /// crossing a threshold warrants advertising the concentrator early
     mtorr_route_errors: u8,
     mtorr_delivery_failures: u8,
-    mtorr_route_error_threshold: u8,
-    mtorr_delivery_failure_threshold: u8,
 
     route_table: FlatMap<Nwk, TableEntry>,
     discovery_table: FlatMap<(Nwk, RouteRequestId), DiscoveryEntry>,
@@ -176,38 +171,18 @@ pub struct Routing {
 }
 
 impl Routing {
-    pub const fn new(
-        network_address: Nwk,
-        route_discovery_time: Duration,
-        mtorr_route_error_threshold: u8,
-        mtorr_delivery_failure_threshold: u8,
-    ) -> Self {
-        Self {
-            network_address,
-            route_discovery_time,
-            mtorr_route_errors: 0,
-            mtorr_delivery_failures: 0,
-            mtorr_route_error_threshold,
-            mtorr_delivery_failure_threshold,
-            route_table: FlatMap::new(),
-            discovery_table: FlatMap::new(),
-            route_record_table: FlatMap::new(),
-            request_sequence_number: 0,
-        }
-    }
-
     /// Count a received route-failure network status toward an early many-to-one
-    /// route request. Returns whether the accumulated signals warrant one.
-    pub const fn note_route_error(&mut self) -> bool {
+    /// route request. Returns whether the accumulated signals reach `threshold`.
+    pub const fn note_route_error(&mut self, threshold: u8) -> bool {
         self.mtorr_route_errors = self.mtorr_route_errors.saturating_add(1);
-        self.mtorr_route_errors >= self.mtorr_route_error_threshold
+        self.mtorr_route_errors >= threshold
     }
 
     /// Count a locally failed unicast delivery toward an early many-to-one route
-    /// request. Returns whether the accumulated signals warrant one.
-    pub const fn note_delivery_failure(&mut self) -> bool {
+    /// request. Returns whether the accumulated signals reach `threshold`.
+    pub const fn note_delivery_failure(&mut self, threshold: u8) -> bool {
         self.mtorr_delivery_failures = self.mtorr_delivery_failures.saturating_add(1);
-        self.mtorr_delivery_failures >= self.mtorr_delivery_failure_threshold
+        self.mtorr_delivery_failures >= threshold
     }
 
     /// A many-to-one route request went out: the accumulated route-repair signals
@@ -334,7 +309,13 @@ impl Routing {
     /// Prepare table state for a route discovery we originate: the routing entry enters
     /// `DiscoveryUnderway` and a discovery entry keyed by our own address is created.
     /// Returns the request identifier to put in the route request command.
-    pub fn begin_discovery(&mut self, destination: Nwk, now: Instant) -> RouteRequestId {
+    pub fn begin_discovery(
+        &mut self,
+        own_address: Nwk,
+        destination: Nwk,
+        now: Instant,
+        route_discovery_time: Duration,
+    ) -> RouteRequestId {
         // Expire stale discoveries before establishing the new one. A just-expired
         // discovery toward this same destination would otherwise tear down the
         // `DiscoveryUnderway` route entry created below.
@@ -349,17 +330,17 @@ impl Routing {
         self.request_sequence_number = self.request_sequence_number.wrapping_add(1);
         let request_id = self.request_sequence_number;
 
-        let key = (self.network_address, request_id);
+        let key = (own_address, request_id);
         let discovery_entry = self
             .discovery_table
             .entry(key)
             .or_insert_with(|| DiscoveryEntry {
                 route_request_id: request_id,
-                source_address: self.network_address,
+                source_address: own_address,
                 sender_address: UNKNOWN_NEXT_HOP,
                 forward_cost: 0,
                 residual_cost: u8::MAX,
-                expiration_time: now + self.route_discovery_time,
+                expiration_time: now + route_discovery_time,
                 destination_address: destination,
             });
 
@@ -370,7 +351,12 @@ impl Routing {
 
     /// Register the discovery entry backing a many-to-one route advertisement, which
     /// is addressed to a broadcast address and never answered with a reply.
-    pub fn begin_many_to_one_advertisement(&mut self, now: Instant) -> RouteRequestId {
+    pub fn begin_many_to_one_advertisement(
+        &mut self,
+        own_address: Nwk,
+        now: Instant,
+        route_discovery_time: Duration,
+    ) -> RouteRequestId {
         self.request_sequence_number = self.request_sequence_number.wrapping_add(1);
         let request_id = self.request_sequence_number;
 
@@ -379,14 +365,14 @@ impl Routing {
         // The discovery entry exists purely for loop detection: relayed copies of our
         // own request will compare against the zero forward cost and be dropped
         self.discovery_table.insert(
-            (self.network_address, request_id),
+            (own_address, request_id),
             DiscoveryEntry {
                 route_request_id: request_id,
-                source_address: self.network_address,
+                source_address: own_address,
                 sender_address: UNKNOWN_NEXT_HOP,
                 forward_cost: 0,
                 residual_cost: u8::MAX,
-                expiration_time: now + self.route_discovery_time,
+                expiration_time: now + route_discovery_time,
                 destination_address: BROADCAST_ALL_ROUTERS_AND_COORDINATOR,
             },
         );
@@ -421,6 +407,7 @@ impl Routing {
         updated_path_cost: u8,
         many_to_one: NwkRouteRequestManyToOne,
         now: Instant,
+        route_discovery_time: Duration,
     ) -> bool {
         self.expire_discoveries(now);
 
@@ -443,7 +430,7 @@ impl Routing {
                         sender_address: sender,
                         forward_cost: updated_path_cost,
                         residual_cost: u8::MAX,
-                        expiration_time: now + self.route_discovery_time,
+                        expiration_time: now + route_discovery_time,
                         destination_address: destination,
                     },
                 );
@@ -490,6 +477,7 @@ impl Routing {
     /// `updated_path_cost` is the advertised cost plus the sender's outgoing link cost.
     pub fn accept_route_reply(
         &mut self,
+        own_address: Nwk,
         originator: Nwk,
         request_id: RouteRequestId,
         responder: Nwk,
@@ -507,7 +495,7 @@ impl Routing {
         };
 
         // If we are the originator, handling is simplified
-        if originator == self.network_address {
+        if originator == own_address {
             if routing_entry.status == Status::Active
                 && updated_path_cost >= discovery_entry.residual_cost
             {


### PR DESCRIPTION
This allows setting `max_children = 0` from zigpy in addition to allowing *every* other constant in the stack to be changed at runtime (not just startup!).

A new `SetTunable("name_of_constant", value_as_u64)` command is used by the radio library to do this. There is no corresponding `ReadTunable` command because the defaults are defined by the spec.