### PR TITLE
Avoid parsing newer 802.15.4 beacon frames

### DIFF
--- a/crates/ziggurat-driver/src/zigbee_stack.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack.rs
@@ -1,4 +1,4 @@
-use crate::ziggurat_ieee_802154::{Ieee802154Address, Ieee802154Frame};
+use crate::ziggurat_ieee_802154::{Ieee802154Address, Ieee802154Frame, ParseError};
 
 use crate::frame_token::{self, FrameToken, TrafficClass};
 use crate::runtime::{Elapsed, RtInstant, Runtime, Spawn};
@@ -1330,6 +1330,10 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 Ok(frame) => {
                     tracing::trace!("Received 802.15.4 frame: {frame:?}");
                     return (packet, frame);
+                }
+                Err(e @ ParseError::Unsupported(_)) => {
+                    tracing::debug!("Ignoring unsupported IEEE 802.15.4 frame: {e:?}");
+                    continue;
                 }
                 Err(e) => {
                     tracing::warn!("Error parsing IEEE 802.15.4 frame: {e:?}");

--- a/crates/ziggurat-driver/src/zigbee_stack/joining.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/joining.rs
@@ -7,7 +7,7 @@ use crate::ziggurat_ieee_802154::commands::{
 use crate::ziggurat_ieee_802154::{
     Ieee802154Address, Ieee802154AddressingMode, Ieee802154AssociationStatus,
     Ieee802154CommandFrame, Ieee802154CommandPayload, Ieee802154Frame, Ieee802154FrameControl,
-    Ieee802154FrameHeader, Ieee802154FrameType,
+    Ieee802154FrameHeader, Ieee802154FrameType, Ieee802154FrameVersion,
 };
 use ziggurat_ieee_802154::FrameBytes;
 use ziggurat_ieee_802154::types::{Eui64, Key, Nwk};
@@ -384,7 +384,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Long,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Long,
                 },
                 sequence_number: Some(sequence_number),

--- a/crates/ziggurat-driver/src/zigbee_stack/mac.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/mac.rs
@@ -4,6 +4,7 @@ use crate::runtime::Runtime;
 use crate::ziggurat_ieee_802154::{
     Ieee802154Address, Ieee802154AddressingMode, Ieee802154CommandFrame, Ieee802154DataFrame,
     Ieee802154Frame, Ieee802154FrameControl, Ieee802154FrameHeader, Ieee802154FrameType,
+    Ieee802154FrameVersion,
 };
 use abstract_bits::AbstractBits;
 use alloc::vec::Vec;
@@ -99,7 +100,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::None,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(ieee802154_sequence_number),
@@ -201,7 +202,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::None,
                 },
                 sequence_number: Some(sequence_number),

--- a/crates/ziggurat-driver/src/zigbee_stack/nwk.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/nwk.rs
@@ -3,7 +3,7 @@ use crate::runtime::{Elapsed, Runtime};
 use crate::signal;
 use crate::ziggurat_ieee_802154::{
     Ieee802154Address, Ieee802154AddressingMode, Ieee802154DataFrame, Ieee802154Frame,
-    Ieee802154FrameControl, Ieee802154FrameHeader, Ieee802154FrameType,
+    Ieee802154FrameControl, Ieee802154FrameHeader, Ieee802154FrameType, Ieee802154FrameVersion,
 };
 use alloc::boxed::Box;
 use alloc::collections::BinaryHeap;
@@ -846,7 +846,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(ieee802154_sequence_number),
@@ -1763,7 +1763,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(ieee802154_sequence_number),

--- a/crates/ziggurat-ieee-802154/src/lib.rs
+++ b/crates/ziggurat-ieee-802154/src/lib.rs
@@ -46,10 +46,9 @@ pub enum Ieee802154FrameType {
     Ack = 0b010,
 }
 
-/// Frame Version field (IEEE Std 802.15.4-2020, Table 7-4). All four values are
-/// representable in the 2-bit field, so decoding never fails.
+/// Frame Version field (IEEE Std 802.15.4-2020, Table 7-4).
 #[abstract_bits(bits = 2)]
-#[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
+#[derive(Debug, Eq, PartialEq, Clone, Copy)]
 #[repr(u8)]
 pub enum Ieee802154FrameVersion {
     /// IEEE Std 802.15.4-2003

--- a/crates/ziggurat-ieee-802154/src/lib.rs
+++ b/crates/ziggurat-ieee-802154/src/lib.rs
@@ -46,6 +46,21 @@ pub enum Ieee802154FrameType {
     Ack = 0b010,
 }
 
+/// Frame Version field (IEEE Std 802.15.4-2020, Table 7-4). All four values are
+/// representable in the 2-bit field, so decoding never fails.
+#[abstract_bits(bits = 2)]
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive, Clone, Copy)]
+#[repr(u8)]
+pub enum Ieee802154FrameVersion {
+    /// IEEE Std 802.15.4-2003
+    Ieee2003 = 0b00,
+    /// IEEE Std 802.15.4-2006
+    Ieee2006 = 0b01,
+    /// IEEE Std 802.15.4-2015 and later; enables IEs, enhanced beacons/acks
+    Ieee2015 = 0b10,
+    Reserved = 0b11,
+}
+
 #[derive(Debug, Eq, PartialEq, Copy, Clone, TryFromPrimitive)]
 #[abstract_bits(bits = 8)]
 #[repr(u8)]
@@ -82,7 +97,7 @@ pub struct Ieee802154FrameControl {
     pub sequence_number_suppression: bool,
     pub information_elements_present: bool,
     pub dest_addr_mode: Ieee802154AddressingMode,
-    pub frame_version: u2,
+    pub frame_version: Ieee802154FrameVersion,
     pub src_addr_mode: Ieee802154AddressingMode,
 }
 
@@ -430,6 +445,13 @@ impl Ieee802154Frame<FrameBytes> {
         // Branch based on frame type
         match header.frame_control.frame_type {
             Ieee802154FrameType::Beacon => {
+                if !matches!(
+                    header.frame_control.frame_version,
+                    Ieee802154FrameVersion::Ieee2003 | Ieee802154FrameVersion::Ieee2006
+                ) {
+                    return Err(ParseError::Unsupported("Enhanced Beacon frame"));
+                }
+
                 if remaining.len() < 4 {
                     return Err(ParseError::UnexpectedEnd {
                         ty: "Ieee802154BeaconFrame",
@@ -611,7 +633,10 @@ mod test {
             frame_control.dest_addr_mode,
             Ieee802154AddressingMode::Short
         );
-        assert_eq!(frame_control.frame_version, 0);
+        assert_eq!(
+            frame_control.frame_version,
+            Ieee802154FrameVersion::Ieee2003
+        );
         assert_eq!(frame_control.src_addr_mode, Ieee802154AddressingMode::Short);
 
         assert_eq!(remaining, [0xFF]);
@@ -645,7 +670,10 @@ mod test {
                 data_frame.header.frame_control.dest_addr_mode,
                 Ieee802154AddressingMode::Short
             );
-            assert_eq!(data_frame.header.frame_control.frame_version, 0);
+            assert_eq!(
+                data_frame.header.frame_control.frame_version,
+                Ieee802154FrameVersion::Ieee2003
+            );
             assert_eq!(
                 data_frame.header.frame_control.src_addr_mode,
                 Ieee802154AddressingMode::Short
@@ -696,7 +724,10 @@ mod test {
         let frame = Ieee802154Frame::from_bytes(&bytes).unwrap();
 
         if let Ieee802154Frame::Ack(ack_frame) = frame {
-            assert_eq!(ack_frame.header.frame_control.frame_version, 0);
+            assert_eq!(
+                ack_frame.header.frame_control.frame_version,
+                Ieee802154FrameVersion::Ieee2003
+            );
             assert_eq!(
                 ack_frame.header.frame_control.src_addr_mode,
                 Ieee802154AddressingMode::None
@@ -736,7 +767,7 @@ mod test {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(52),
@@ -771,7 +802,7 @@ mod test {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(3),
@@ -810,7 +841,7 @@ mod test {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Short,
                 },
                 sequence_number: Some(3),
@@ -847,7 +878,7 @@ mod test {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::None,
                 },
                 sequence_number: Some(109),
@@ -883,7 +914,7 @@ mod test {
                     sequence_number_suppression: false,
                     information_elements_present: false,
                     dest_addr_mode: Ieee802154AddressingMode::Short,
-                    frame_version: 0,
+                    frame_version: Ieee802154FrameVersion::Ieee2003,
                     src_addr_mode: Ieee802154AddressingMode::Long,
                 },
                 sequence_number: Some(19),


### PR DESCRIPTION
Fixes https://github.com/zigpy/ziggurat/issues/49.