### PR TITLE
Increase the broadcast budget

### DIFF
--- a/crates/ziggurat-zigbee/src/constants.rs
+++ b/crates/ziggurat-zigbee/src/constants.rs
@@ -377,17 +377,11 @@ tunables! {
 
     /// Broadcast admission budget: a token bucket shared across traffic classes,
     /// mirroring the frame budget above but bounding broadcast *rate*.
-    ///
-    /// This is the burst capacity: a discrete host action (a button press, a scene)
-    /// draws from it and goes out immediately, however low the sustained rate is, so
-    /// responsiveness comes from the burst, not from the rate below.
-    broadcast_budget_tokens: u8 = 15,
+    broadcast_budget_tokens: u8 = 40,
 
     /// Time to regenerate one broadcast token; the reciprocal is the sustained
-    /// admission rate (~0.55/s here). Held just under a stock SiLabs router's ~0.6/s
-    /// relay budget so the surrounding mesh always keeps headroom to carry our
-    /// broadcasts.
-    broadcast_token_refill: Duration = Duration::from_millis(1800),
+    /// admission rate (~1.48/s here).
+    broadcast_token_refill: Duration = Duration::from_millis(675),
 
     /// Broadcast tokens only stack-critical broadcasts (route discovery, key updates,
     /// leaves, ZDO management) may draw; a host flood can never consume them.


### PR DESCRIPTION
Follow up to https://github.com/zigpy/ziggurat/pull/54 (and https://github.com/zigpy/ziggurat/issues/43).

I ran a quick packet capture test on my home network while spamming broadcasts (setting Ziggurat's limit to 255) and noticed something odd: none of my home routers behaved the way the SiLabs SDK claims they should and none of the routers ever really stopped relaying packets during a sustained burst of almost 64 broadcasts in 20 seconds.

Many manufacturers using SiLabs chips thankfully do not enable firmware encryption so we can statically analyze what they use as the firmware config. The results are a little surprising (the IKEA ones were checked by hand, the rest were checked with a script that speeds up the analysis):

| Vendor | Images | Table size(s) |
|---|---|---|
| NodOn | 35 | 15 (3), 35 (32) |
| IKEA | 31 | 15 (6), 46 (4), 50 (14), 56 (7) |
| Innr | 15 | 40 |
| Bosch | 5 | 15 |
| SalusControls | 5 | 15 |
| Niko | 4 | 40 (3), 50 (1) |
| Datek | 3 | 15 |
| Gledopto | 2 | 40 |
| Heiman | 2 | 15 |
| LEDVANCE | 2 | 50 |
| Aeotec | 1 | 15 |
| EcoDim | 1 | 50 |
| Inovelli | 1 | 15 |

All new generation IKEA devices override the broadcast table size to 50! Inner and Gledopto use 40, LEDVANCE uses 50. Hue images are encrypted but they behaved identically to IKEA so I would assume they use at least 40-50 as well.

For a network consisting of popular router devices (IKEA, Hue, Innr, etc.), every router on the network has a broadcast table size of 40-50 and theoretically can relay broadcasts at a rate of 2/second. I think we can adjust the Ziggurat rate limiting accordingly.