### PR TITLE
Bump abstract-bits to support signed integers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5,10 +5,10 @@ version = 4
 [[package]]
 name = "abstract-bits"
 version = "0.2.0"
-source = "git+https://github.com/yara-blue/abstract-bits.git#f82569eb658505e2b96c9baa498b376169adfe51"
+source = "git+https://github.com/puddly/abstract-bits.git?rev=1f67dd91dce8a4c3b2c760ac317780856c1d6805#1f67dd91dce8a4c3b2c760ac317780856c1d6805"
 dependencies = [
  "abstract-bits-derive",
- "arbitrary-int 1.3.0",
+ "arbitrary-int",
  "bitvec",
  "thiserror 2.0.19",
 ]
@@ -16,9 +16,9 @@ dependencies = [
 [[package]]
 name = "abstract-bits-derive"
 version = "0.2.0"
-source = "git+https://github.com/yara-blue/abstract-bits.git#f82569eb658505e2b96c9baa498b376169adfe51"
+source = "git+https://github.com/puddly/abstract-bits.git?rev=1f67dd91dce8a4c3b2c760ac317780856c1d6805#1f67dd91dce8a4c3b2c760ac317780856c1d6805"
 dependencies = [
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -118,12 +118,6 @@ name = "anyhow"
 version = "1.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330a5ed07fa54e4702c9d6c4174f74427fc0ef6e214bbd677ae50a5099946470"
-
-[[package]]
-name = "arbitrary-int"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
 
 [[package]]
 name = "arbitrary-int"
@@ -1119,25 +1113,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1844,7 +1838,7 @@ name = "ziggurat-driver"
 version = "0.1.0"
 dependencies = [
  "abstract-bits",
- "arbitrary-int 2.1.1",
+ "arbitrary-int",
  "embassy-executor",
  "embassy-sync",
  "embassy-time",
@@ -1897,7 +1891,7 @@ name = "ziggurat-protocol"
 version = "0.1.0"
 dependencies = [
  "abstract-bits",
- "arbitrary-int 2.1.1",
+ "arbitrary-int",
  "num_enum",
  "tracing",
  "ziggurat-driver",
@@ -1958,7 +1952,7 @@ version = "0.1.0"
 dependencies = [
  "abstract-bits",
  "aes",
- "arbitrary-int 2.1.1",
+ "arbitrary-int",
  "ccm",
  "educe",
  "hex",

--- a/crates/ziggurat-driver/Cargo.toml
+++ b/crates/ziggurat-driver/Cargo.toml
@@ -13,7 +13,7 @@ ziggurat-ieee-802154.workspace = true
 ziggurat-phy.workspace = true
 ziggurat-zigbee.workspace = true
 
-abstract-bits = { git = "https://github.com/yara-blue/abstract-bits.git", version = "0.2.0" }
+abstract-bits = { git = "https://github.com/puddly/abstract-bits.git", rev = "1f67dd91dce8a4c3b2c760ac317780856c1d6805", version = "0.2.0" }
 arbitrary-int = "2.1.1"
 futures = { version = "0.3", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1", default-features = false }

--- a/crates/ziggurat-driver/src/zigbee_stack/mac.rs
+++ b/crates/ziggurat-driver/src/zigbee_stack/mac.rs
@@ -8,10 +8,9 @@ use crate::ziggurat_ieee_802154::{
 };
 use abstract_bits::AbstractBits;
 use alloc::vec::Vec;
-use arbitrary_int::u24;
 use ziggurat_ieee_802154::types::{Nwk, PanId};
 use ziggurat_phy::{RadioPhy, TxFrame, TxResult};
-use ziggurat_zigbee::beacon::{RenamedU24, ZigbeeBeacon};
+use ziggurat_zigbee::beacon::ZigbeeBeacon;
 use ziggurat_zigbee::nwk::frame::{
     BROADCAST_ALL_ROUTERS_AND_COORDINATOR, EncryptedNwkFrame, NwkFrame, NwkPayload,
     NwkSecurityHeaderKeyId, NwkSecurityLevel,
@@ -127,7 +126,7 @@ impl<P: RadioPhy, R: Runtime> ZigbeeStack<P, R> {
                 device_depth: 0,
                 end_device_capacity,
                 extended_pan_id: self.state.extended_pan_id,
-                tx_offset: RenamedU24(u24::new(0xFFFFFF)),
+                tx_offset: 0xFFFFFF,
                 update_id,
             }
             .to_abstract_bytes()

--- a/crates/ziggurat-ieee-802154/Cargo.toml
+++ b/crates/ziggurat-ieee-802154/Cargo.toml
@@ -9,7 +9,7 @@ authors.workspace = true
 repository.workspace = true
 
 [dependencies]
-abstract-bits = { git = "https://github.com/yara-blue/abstract-bits.git", version = "0.2.0" }
+abstract-bits = { git = "https://github.com/puddly/abstract-bits.git", rev = "1f67dd91dce8a4c3b2c760ac317780856c1d6805", version = "0.2.0" }
 num_enum = { version = "0.7.6", default-features = false }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"] }
 thiserror = { version = "2.0.19", default-features = false }

--- a/crates/ziggurat-ncp-api/Cargo.lock
+++ b/crates/ziggurat-ncp-api/Cargo.lock
@@ -5,10 +5,10 @@ version = 4
 [[package]]
 name = "abstract-bits"
 version = "0.2.0"
-source = "git+https://github.com/yara-blue/abstract-bits.git#f82569eb658505e2b96c9baa498b376169adfe51"
+source = "git+https://github.com/puddly/abstract-bits.git?rev=1f67dd91dce8a4c3b2c760ac317780856c1d6805#1f67dd91dce8a4c3b2c760ac317780856c1d6805"
 dependencies = [
  "abstract-bits-derive",
- "arbitrary-int 1.3.0",
+ "arbitrary-int",
  "bitvec",
  "thiserror",
 ]
@@ -16,9 +16,9 @@ dependencies = [
 [[package]]
 name = "abstract-bits-derive"
 version = "0.2.0"
-source = "git+https://github.com/yara-blue/abstract-bits.git#f82569eb658505e2b96c9baa498b376169adfe51"
+source = "git+https://github.com/puddly/abstract-bits.git?rev=1f67dd91dce8a4c3b2c760ac317780856c1d6805#1f67dd91dce8a4c3b2c760ac317780856c1d6805"
 dependencies = [
- "proc-macro-error2",
+ "proc-macro-error3",
  "proc-macro2",
  "quote",
  "syn 2.0.118",
@@ -53,12 +53,6 @@ checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "arbitrary-int"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "825297538d77367557b912770ca3083f778a196054b3ee63b22673c4a3cae0a5"
 
 [[package]]
 name = "arbitrary-int"
@@ -626,25 +620,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
+name = "proc-macro-error-attr3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+checksum = "b0084e6206a967a2dad822180626b2f6b07a3b379325e8f1ec0438e33a469ba7"
 dependencies = [
  "proc-macro2",
  "quote",
 ]
 
 [[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
+name = "proc-macro-error3"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+checksum = "0cf066225f2373bc711684792b69bdeac0356019b007e721090c24d92d5d5a50"
 dependencies = [
- "proc-macro-error-attr2",
+ "proc-macro-error-attr3",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn 3.0.2",
 ]
 
 [[package]]
@@ -931,7 +925,7 @@ name = "ziggurat-driver"
 version = "0.1.0"
 dependencies = [
  "abstract-bits",
- "arbitrary-int 2.1.1",
+ "arbitrary-int",
  "embassy-executor",
  "embassy-sync",
  "embassy-time",
@@ -985,7 +979,7 @@ name = "ziggurat-protocol"
 version = "0.1.0"
 dependencies = [
  "abstract-bits",
- "arbitrary-int 2.1.1",
+ "arbitrary-int",
  "num_enum",
  "tracing",
  "ziggurat-driver",
@@ -1000,7 +994,7 @@ version = "0.1.0"
 dependencies = [
  "abstract-bits",
  "aes",
- "arbitrary-int 2.1.1",
+ "arbitrary-int",
  "ccm",
  "educe",
  "hex",

--- a/crates/ziggurat-ncp-api/Cargo.toml
+++ b/crates/ziggurat-ncp-api/Cargo.toml
@@ -11,7 +11,7 @@ ziggurat-ieee-802154 = { path = "../ziggurat-ieee-802154" }
 ziggurat-driver = { path = "../ziggurat-driver", default-features = false, features = ["embassy"] }
 ziggurat-zigbee = { path = "../ziggurat-zigbee" }
 ziggurat-protocol = { path = "../ziggurat-protocol" }
-abstract-bits = { git = "https://github.com/yara-blue/abstract-bits.git", version = "0.2.0" }
+abstract-bits = { git = "https://github.com/puddly/abstract-bits.git", rev = "1f67dd91dce8a4c3b2c760ac317780856c1d6805", version = "0.2.0" }
 num_enum = { version = "0.7.3", default-features = false }
 embassy-sync = "0.8"
 embassy-futures = "0.1"

--- a/crates/ziggurat-ncp-api/src/protocol.rs
+++ b/crates/ziggurat-ncp-api/src/protocol.rs
@@ -354,7 +354,7 @@ async fn handle_energy_scan<P: RadioPhy>(
                     request_id,
                     Event::EnergyResult(EnergyResultPayload {
                         channel,
-                        rssi: rssi as u8,
+                        rssi,
                     }),
                 )
                 .await;
@@ -422,7 +422,7 @@ async fn handle_packet_capture<P: RadioPhy>(
                     embassy_futures::select::Either::First(Some(frame)) => {
                         let event = Event::CapturedPacket(CapturedPacketPayload {
                             channel: frame.channel,
-                            rssi: frame.rssi as u8,
+                            rssi: frame.rssi,
                             lqi: frame.lqi,
                             psdu: frame.psdu,
                         });

--- a/crates/ziggurat-protocol/Cargo.toml
+++ b/crates/ziggurat-protocol/Cargo.toml
@@ -12,7 +12,7 @@ ziggurat-zigbee = { path = "../ziggurat-zigbee" }
 # Types only (ZigbeeNotification, NetworkConfig, ZigbeeStack, …); the runtime seam is
 # left to whichever workspace consumes this crate (tokio on the host, embassy on the MCU).
 ziggurat-driver = { path = "../ziggurat-driver", default-features = false }
-abstract-bits = { git = "https://github.com/yara-blue/abstract-bits.git", version = "0.2.0" }
+abstract-bits = { git = "https://github.com/puddly/abstract-bits.git", rev = "1f67dd91dce8a4c3b2c760ac317780856c1d6805", version = "0.2.0" }
 arbitrary-int = "2.1.1"
 num_enum = { version = "0.7.6", default-features = false }
 tracing = { version = "0.1", default-features = false }

--- a/crates/ziggurat-protocol/src/bridge.rs
+++ b/crates/ziggurat-protocol/src/bridge.rs
@@ -54,7 +54,7 @@ pub fn network_config(payload: &ConfigurePayload) -> NetworkConfig {
                 TclkFlavorId::ZStack => TclkFlavor::ZStack,
             },
         }),
-        tx_power: state.tx_power as i8,
+        tx_power: state.tx_power,
         source_routing: payload.source_routing,
     }
 }
@@ -97,7 +97,7 @@ pub fn network_info_payload<P: RadioPhy, R: Runtime>(
             has_tclk_seed,
             tclk_seed,
             tclk_flavor,
-            tx_power: stack.config.tx_power as u8,
+            tx_power: stack.config.tx_power,
             aps_frame_counter: aps_security.outgoing_frame_counter(),
         },
         key_count: aps_security.device_key_count() as u16,
@@ -257,7 +257,7 @@ impl From<&NetworkBeacon> for BeaconPayload {
             device_depth: beacon.device_depth,
             update_id: beacon.update_id,
             lqi: beacon.lqi,
-            rssi: beacon.rssi as u8,
+            rssi: beacon.rssi,
         }
     }
 }
@@ -296,7 +296,7 @@ pub fn send_unicast<P: RadioPhy, R: Runtime>(
             payload.asdu,
             aps_security,
             payload.flags.sleepy_destination,
-            TxPriority::from_host(payload.priority as i8),
+            TxPriority::from_host(payload.priority),
             route,
         )
         .map(|handle| (handle, confirm_kind))
@@ -318,7 +318,7 @@ pub fn send_broadcast<P: RadioPhy, R: Runtime>(
             payload.dst_ep,
             payload.radius,
             payload.asdu,
-            TxPriority::from_host(payload.priority as i8),
+            TxPriority::from_host(payload.priority),
         )
         .map(|handle| (handle, ConfirmKind::Broadcast))
         .map_err(|e| enqueue_error(&e))
@@ -338,7 +338,7 @@ pub fn send_groupcast<P: RadioPhy, R: Runtime>(
             payload.src_ep,
             payload.radius,
             payload.asdu,
-            TxPriority::from_host(payload.priority as i8),
+            TxPriority::from_host(payload.priority),
         )
         .map(|handle| (handle, ConfirmKind::Broadcast))
         .map_err(|e| enqueue_error(&e))
@@ -463,7 +463,7 @@ pub fn notification_frame(update: &ZigbeeNotification) -> Option<Vec<u8>> {
             src_ep: *src_ep,
             dst_ep: *dst_ep,
             lqi: *lqi,
-            rssi: *rssi as u8,
+            rssi: *rssi,
             data: data.clone(),
         }),
         ZigbeeNotification::DeviceJoined {

--- a/crates/ziggurat-protocol/src/wire.rs
+++ b/crates/ziggurat-protocol/src/wire.rs
@@ -287,7 +287,7 @@ pub struct NetworkState {
     pub reserved: u7,
     pub tclk_seed: Key,
     pub tclk_flavor: TclkFlavorId,
-    pub tx_power: u8, // i8 two's complement (abstract-bits has no signed types)
+    pub tx_power: i8,
     pub aps_frame_counter: u32,
 }
 
@@ -459,7 +459,7 @@ pub struct SendUnicastPayload {
     /// with stack-originated frames (ZDP, APS commands). Kept for wire stability.
     pub _aps_seq: u8,
     pub radius: u8,
-    pub priority: u8, // i8 two's complement
+    pub priority: i8,
     pub route: RouteControl,
     #[abstract_bits(
         presence_from = matches!(route, RouteControl::HintNextHop | RouteControl::ForceNextHop)
@@ -494,7 +494,7 @@ pub struct SendBroadcastPayload {
     /// Ignored, as in [`SendUnicastPayload::_aps_seq`].
     pub _aps_seq: u8,
     pub radius: u8,
-    pub priority: u8, // i8 two's complement
+    pub priority: i8,
     pub asdu_len: u16,
     #[abstract_bits(length_from = asdu_len)]
     pub asdu: Vec<u8>,
@@ -519,7 +519,7 @@ pub struct SendGroupcastPayload {
     /// Ignored, as in [`SendUnicastPayload::_aps_seq`].
     pub _aps_seq: u8,
     pub radius: u8,
-    pub priority: u8, // i8 two's complement
+    pub priority: i8,
     pub asdu_len: u16,
     #[abstract_bits(length_from = asdu_len)]
     pub asdu: Vec<u8>,
@@ -594,7 +594,7 @@ pub struct ScanRequestPayload {
 #[derive(Debug, Clone)]
 pub struct EnergyResultPayload {
     pub channel: u8,
-    pub rssi: u8, // i8 two's complement
+    pub rssi: i8,
 }
 
 #[abstract_bits]
@@ -613,14 +613,14 @@ pub struct BeaconPayload {
     pub device_depth: u8,
     pub update_id: u8,
     pub lqi: u8,
-    pub rssi: u8, // i8 two's complement
+    pub rssi: i8,
 }
 
 #[abstract_bits]
 #[derive(Debug, Clone)]
 pub struct CapturedPacketPayload {
     pub channel: u8,
-    pub rssi: u8, // i8 two's complement
+    pub rssi: i8,
     pub lqi: u8,
     pub psdu_len: u16,
     #[abstract_bits(length_from = psdu_len)]
@@ -669,7 +669,7 @@ pub struct ReceivedApsPayload {
     pub src_ep: u8,
     pub dst_ep: u8,
     pub lqi: u8,
-    pub rssi: u8, // i8 two's complement
+    pub rssi: i8,
     pub data_len: u16,
     #[abstract_bits(length_from = data_len)]
     pub data: Vec<u8>,

--- a/crates/ziggurat-server/src/main.rs
+++ b/crates/ziggurat-server/src/main.rs
@@ -785,10 +785,8 @@ impl ZigguratServer {
         for channel in payload.channels {
             match phy.energy_detect(channel, duration).await {
                 Ok(rssi) => {
-                    let event = proto::Event::EnergyResult(proto::EnergyResultPayload {
-                        channel,
-                        rssi: rssi as u8,
-                    });
+                    let event =
+                        proto::Event::EnergyResult(proto::EnergyResultPayload { channel, rssi });
                     if let Some(frame) = event.frame(request_id) {
                         let _ = outbound.send(frame).await;
                     }
@@ -873,7 +871,7 @@ impl ZigguratServer {
             while let Some(frame) = rx.recv().await {
                 let event = proto::Event::CapturedPacket(proto::CapturedPacketPayload {
                     channel: frame.channel,
-                    rssi: frame.rssi as u8,
+                    rssi: frame.rssi,
                     lqi: frame.lqi,
                     psdu: frame.psdu,
                 });

--- a/crates/ziggurat-zigbee/Cargo.toml
+++ b/crates/ziggurat-zigbee/Cargo.toml
@@ -11,7 +11,7 @@ repository.workspace = true
 [dependencies]
 ziggurat-ieee-802154.workspace = true
 
-abstract-bits = { git = "https://github.com/yara-blue/abstract-bits.git", version = "0.2.0" }
+abstract-bits = { git = "https://github.com/puddly/abstract-bits.git", rev = "1f67dd91dce8a4c3b2c760ac317780856c1d6805", version = "0.2.0" }
 aes = "0.9.1"
 arbitrary-int = "2.1.1"
 ccm = { version = "0.6.0-rc.3", default-features = false }

--- a/crates/ziggurat-zigbee/src/beacon.rs
+++ b/crates/ziggurat-zigbee/src/beacon.rs
@@ -1,38 +1,6 @@
-use abstract_bits::{
-    AbstractBits, BitReader, BitWriter, FromBytesError, ToBytesError, abstract_bits,
-};
+use abstract_bits::abstract_bits;
 use arbitrary_int::{u2, u4, u24};
 use ziggurat_ieee_802154::types::Eui64;
-
-// TODO: report this bug to abstract-bits
-#[derive(Debug, Eq, PartialEq)]
-pub struct RenamedU24(pub u24);
-
-impl AbstractBits for RenamedU24 {
-    const MIN_BITS: usize = 24;
-    const MAX_BITS: usize = 24;
-
-    fn write_abstract_bits(&self, writer: &mut BitWriter) -> Result<(), ToBytesError> {
-        // `u24::value()` widens to a `u32`, whose fourth byte must not be written
-        let [b0, b1, b2, _] = self.0.value().to_le_bytes();
-        b0.write_abstract_bits(writer)?;
-        b1.write_abstract_bits(writer)?;
-        b2.write_abstract_bits(writer)?;
-
-        Ok(())
-    }
-
-    fn read_abstract_bits(reader: &mut BitReader) -> Result<Self, FromBytesError>
-    where
-        Self: Sized,
-    {
-        Ok(Self(u24::from_le_bytes([
-            u8::read_abstract_bits(reader)?,
-            u8::read_abstract_bits(reader)?,
-            u8::read_abstract_bits(reader)?,
-        ])))
-    }
-}
 
 #[derive(Debug, Eq, PartialEq)]
 #[abstract_bits]
@@ -45,13 +13,14 @@ pub struct ZigbeeBeacon {
     pub device_depth: u4,
     pub end_device_capacity: bool,
     pub extended_pan_id: Eui64,
-    pub tx_offset: RenamedU24,
+    pub tx_offset: u24,
     pub update_id: u8,
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+    use abstract_bits::{AbstractBits, BitReader};
     use hex_literal::hex;
 
     #[test]
@@ -65,7 +34,7 @@ mod test {
             device_depth: 0,
             end_device_capacity: true,
             extended_pan_id: Eui64::from_hex("3a:9f:44:01:0b:3c:cb:93"),
-            tx_offset: RenamedU24(u24::new(0xFFFFFF)),
+            tx_offset: 0xFFFFFF,
             update_id: 0,
         };
 


### PR DESCRIPTION
Implemented in https://github.com/yara-blue/abstract-bits/pull/10, which adds support for signed integers and lets us remove a few hacks.